### PR TITLE
Fix dashboard overflow across responsive widths

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -240,7 +240,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       </motion.nav>
 
       {/* Main Content */}
-      <main className="flex-1 flex flex-col min-h-screen lg:min-h-auto">
+      <main className="flex min-w-0 flex-1 flex-col min-h-screen lg:min-h-auto">
         {/* Top Header */}
         <motion.header 
           className={`${isInsightWorkspace ? 'hidden' : 'hidden lg:block'} border-b border-white/10 bg-black/10 px-6 py-4 backdrop-blur-md`}

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -119,7 +119,7 @@ const Dashboard: React.FC = () => {
     >
       {/* Header with Actions */}
       <motion.div 
-        className="flex items-center justify-between"
+        className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.2 }}
@@ -134,7 +134,7 @@ const Dashboard: React.FC = () => {
         </div>
         
         <motion.div 
-          className="flex space-x-4"
+          className="flex flex-wrap gap-4"
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.3 }}


### PR DESCRIPTION
## Summary
- allow the main dashboard flex column to shrink beside the desktop sidebar
- stack and wrap dashboard actions on narrow screens

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- rendered dashboard QA at 320px, 390px, 1024px, and 1280px with 13 profiles loaded; document width equals viewport width