### PR TITLE
Contain legacy profile data cleanup paths

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import logging
 import math
 import os
+import re
 import shutil
 import stat
 import tempfile
@@ -44,10 +45,38 @@ _OWNER_EXPORT_CONSENT_ERROR = (
     "can contain private or deleted account data."
 )
 _UNEXPECTED_UPLOAD_ERROR = "An unexpected processing error occurred."
+_PROFILE_DIRECTORY_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}")
 
 
 class _OwnerExportPublicationConsentRequired(PermissionError):
     """Expected upload validation failure with a fixed, public-safe message."""
+
+
+def _remove_scraped_profile_directory(username: str) -> None:
+    """Remove one legacy scrape directory without deriving a path from input.
+
+    Profile data now lives in PostgreSQL, but older installations may still
+    have a per-profile directory below ``SCRAPED_DATA_DIR``. Enumerating that
+    fixed root keeps the deletion target filesystem-derived, while the strict
+    component check and symlink rejection prevent traversal outside it.
+    """
+
+    if not _PROFILE_DIRECTORY_COMPONENT.fullmatch(username):
+        raise HTTPException(status_code=400, detail="Invalid username/path")
+
+    try:
+        entries = os.scandir(SCRAPED_DATA_DIR)
+    except FileNotFoundError:
+        return
+
+    with entries:
+        for entry in entries:
+            if entry.name != username:
+                continue
+            if entry.is_symlink() or not entry.is_dir(follow_symlinks=False):
+                raise HTTPException(status_code=400, detail="Invalid profile data path")
+            shutil.rmtree(entry.path)
+            return
 
 # Pydantic models for request/response
 class ProfileCreate(BaseModel):
@@ -540,13 +569,8 @@ async def delete_profile(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
     
-    # Clean up data directory
-    data_path = os.path.normpath(os.path.join(SCRAPED_DATA_DIR, username))
-    # Ensure the final path is within SCRAPED_DATA_DIR
-    if not data_path.startswith(os.path.abspath(SCRAPED_DATA_DIR) + os.sep):
-        raise HTTPException(status_code=400, detail="Invalid username/path")
-    if os.path.exists(data_path):
-        shutil.rmtree(data_path)
+    # Clean up any legacy on-disk scrape owned by this canonical profile.
+    _remove_scraped_profile_directory(profile.username)
     
     # Delete from database (cascades to ratings, reviews, etc.)
     profile_repo.delete_profile(profile.id)
@@ -656,12 +680,10 @@ async def clear_profile_data(
     if not profile:
         raise HTTPException(status_code=404, detail="Profile not found")
 
+    # Validate and remove any legacy on-disk scrape before committing the
+    # database clear, so a rejected path cannot leave a partial operation.
+    _remove_scraped_profile_directory(profile.username)
     profile_repo.clear_profile_data(profile.id)
-    
-    # Clean up data directory
-    data_path = os.path.join(SCRAPED_DATA_DIR, username)
-    if os.path.exists(data_path):
-        shutil.rmtree(data_path)
 
     _refresh_dashboard_snapshot_cache(db)
     

--- a/backend/tests/test_scraped_directory_cleanup.py
+++ b/backend/tests/test_scraped_directory_cleanup.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from backend.main import _remove_scraped_profile_directory, clear_profile_data
+
+
+def test_removes_only_the_matching_immediate_profile_directory(tmp_path: Path):
+    scrape_root = tmp_path / "scraped"
+    target = scrape_root / "target_profile"
+    survivor = scrape_root / "survivor"
+    target.mkdir(parents=True)
+    survivor.mkdir()
+    (target / "ratings.csv").write_text("target", encoding="utf-8")
+    (survivor / "ratings.csv").write_text("survivor", encoding="utf-8")
+
+    with patch("backend.main.SCRAPED_DATA_DIR", str(scrape_root)):
+        _remove_scraped_profile_directory("target_profile")
+
+    assert not target.exists()
+    assert (survivor / "ratings.csv").read_text(encoding="utf-8") == "survivor"
+
+
+@pytest.mark.parametrize(
+    "username",
+    ["", ".", "..", "../outside", "/tmp/outside", "nested/profile", "nested\\profile"],
+)
+def test_rejects_non_component_profile_names(tmp_path: Path, username: str):
+    scrape_root = tmp_path / "scraped"
+    scrape_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep", encoding="utf-8")
+
+    with (
+        patch("backend.main.SCRAPED_DATA_DIR", str(scrape_root)),
+        pytest.raises(HTTPException) as raised,
+    ):
+        _remove_scraped_profile_directory(username)
+
+    assert raised.value.status_code == 400
+    assert (outside / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_rejects_matching_symlink_without_following_it(tmp_path: Path):
+    scrape_root = tmp_path / "scraped"
+    scrape_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep.txt").write_text("keep", encoding="utf-8")
+    link = scrape_root / "target"
+    link.symlink_to(outside, target_is_directory=True)
+
+    with (
+        patch("backend.main.SCRAPED_DATA_DIR", str(scrape_root)),
+        pytest.raises(HTTPException) as raised,
+    ):
+        _remove_scraped_profile_directory("target")
+
+    assert raised.value.status_code == 400
+    assert link.is_symlink()
+    assert (outside / "keep.txt").read_text(encoding="utf-8") == "keep"
+
+
+def test_missing_legacy_scrape_root_is_a_no_op(tmp_path: Path):
+    with patch("backend.main.SCRAPED_DATA_DIR", str(tmp_path / "missing")):
+        _remove_scraped_profile_directory("target")
+
+
+def test_clear_endpoint_rejects_unsafe_profile_before_database_clear(tmp_path: Path):
+    scrape_root = tmp_path / "scraped"
+    scrape_root.mkdir()
+    repository = MagicMock()
+    repository.get_profile_by_username.return_value = SimpleNamespace(
+        id=17,
+        username="../outside",
+    )
+
+    with (
+        patch("backend.main.SCRAPED_DATA_DIR", str(scrape_root)),
+        patch("backend.main.ProfileRepository", return_value=repository),
+        pytest.raises(HTTPException) as raised,
+    ):
+        asyncio.run(
+            clear_profile_data(
+                "../outside",
+                db=MagicMock(),
+                _user=MagicMock(),
+            )
+        )
+
+    assert raised.value.status_code == 400
+    repository.clear_profile_data.assert_not_called()


### PR DESCRIPTION
## Summary
- stop deriving recursive-delete targets from request or stored usernames
- enumerate only the fixed legacy scrape root and reject unsafe components/symlinks
- validate filesystem cleanup before committing profile-data deletion
- reuse the same cleanup boundary for both profile delete routes

Closes CodeQL alerts #13 and #14.

## Verification
- `.venv/bin/pytest -q backend/tests` — 138 passed, 1 skipped, 17 subtests passed
- `.venv/bin/python -m py_compile backend/main.py backend/tests/test_scraped_directory_cleanup.py`
- `git diff --check`