### PR TITLE
Fix TMDB matches across release-year differences

### DIFF
--- a/backend/services/tmdb_client.py
+++ b/backend/services/tmdb_client.py
@@ -274,8 +274,22 @@ class TMDBClient:
         release_year: Optional[int] = None,
         language: str = DEFAULT_LANGUAGE,
     ) -> Optional[Dict[str, Any]]:
-        return select_best_movie_match(
+        match = select_best_movie_match(
             self.search_movies(title, release_year=release_year, language=language),
+            title=title,
+            release_year=release_year,
+        )
+        if match is not None or release_year is None:
+            return match
+
+        # Letterboxd commonly uses a festival or first-premiere year while
+        # TMDB's `primary_release_year` reflects a later theatrical release.
+        # The matcher already permits an exact title within one year, but an
+        # exact-year API filter prevents it from ever seeing that candidate.
+        # Retry without the server-side year filter only after the narrow
+        # search fails, then apply the same conservative title/year matcher.
+        return select_best_movie_match(
+            self.search_movies(title, language=language),
             title=title,
             release_year=release_year,
         )

--- a/backend/tests/test_tmdb_enrichment.py
+++ b/backend/tests/test_tmdb_enrichment.py
@@ -197,6 +197,70 @@ class TMDBClientTests(unittest.TestCase):
         self.assertEqual(sleeps, [0.2])
         self.assertEqual(len(session.calls), 1)
 
+    def test_find_movie_retries_without_year_filter_for_near_year_release(self):
+        session = FakeHTTPSession(
+            [
+                FakeResponse(200, {"results": []}),
+                FakeResponse(
+                    200,
+                    {
+                        "results": [
+                            {
+                                "id": 55347,
+                                "title": "Beginners",
+                                "release_date": "2011-06-03",
+                                "popularity": 12,
+                            }
+                        ]
+                    },
+                ),
+            ]
+        )
+        client = TMDBClient(bearer_token="read-token", session=session)
+
+        match = client.find_movie("Beginners", release_year=2010)
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match["id"], 55347)
+        self.assertEqual(len(session.calls), 2)
+        self.assertEqual(session.calls[0]["params"]["primary_release_year"], 2010)
+        self.assertNotIn("primary_release_year", session.calls[1]["params"])
+
+    def test_find_movie_does_not_fallback_after_narrow_match(self):
+        session = FakeHTTPSession(
+            [
+                FakeResponse(
+                    200,
+                    {
+                        "results": [
+                            {
+                                "id": 329865,
+                                "title": "Arrival",
+                                "release_date": "2016-11-10",
+                                "popularity": 20,
+                            }
+                        ]
+                    },
+                )
+            ]
+        )
+        client = TMDBClient(bearer_token="read-token", session=session)
+
+        match = client.find_movie("Arrival", release_year=2016)
+
+        self.assertIsNotNone(match)
+        self.assertEqual(match["id"], 329865)
+        self.assertEqual(len(session.calls), 1)
+
+    def test_find_movie_without_year_uses_one_unfiltered_search(self):
+        session = FakeHTTPSession([FakeResponse(200, {"results": []})])
+        client = TMDBClient(bearer_token="read-token", session=session)
+
+        self.assertIsNone(client.find_movie("Unknown Film"))
+
+        self.assertEqual(len(session.calls), 1)
+        self.assertNotIn("primary_release_year", session.calls[0]["params"])
+
     def test_request_exception_does_not_expose_credentials_in_error_or_traceback(self):
         api_key = "super-secret-v3-key"
         bearer_token = "super-secret-bearer-token"


### PR DESCRIPTION
Production cache enrichment exposed that 200 missing candidates all returned not-found. The existing matcher safely accepts exact-title releases within one year, but TMDB primary_release_year filtering prevented those candidates from reaching it.

This keeps the narrow exact-year query first and performs one unfiltered fallback only when that conservative match fails, then applies the same title/year safeguards.

Verification: 147 backend tests passed (1 local PostgreSQL-only skip), 19 focused TMDB tests, and live credentialed checks resolve Beginners (2010/2011), Sing Sing (2023/2024), and Kill (2023/2024). No credentials are logged or committed.