### PR TITLE
Cache unsuccessful TMDB identity lookups

### DIFF
--- a/alembic/versions/20260729_0007_cache_tmdb_lookup_misses.py
+++ b/alembic/versions/20260729_0007_cache_tmdb_lookup_misses.py
@@ -1,0 +1,45 @@
+"""Cache deferred TMDB identity lookups.
+
+Revision ID: 20260729_0007
+Revises: 20260729_0006
+Create Date: 2026-07-29 20:55:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260729_0007"
+down_revision: Union[str, None] = "20260729_0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "movies",
+        sa.Column("tmdb_lookup_attempted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "movies",
+        sa.Column("tmdb_lookup_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "movies",
+        sa.Column("tmdb_lookup_key", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_movies_tmdb_lookup_expires_at",
+        "movies",
+        ["tmdb_lookup_expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_movies_tmdb_lookup_expires_at", table_name="movies")
+    op.drop_column("movies", "tmdb_lookup_key")
+    op.drop_column("movies", "tmdb_lookup_expires_at")
+    op.drop_column("movies", "tmdb_lookup_attempted_at")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -393,6 +393,9 @@ class Movie(Base):
     poster_url = Column(String(500), nullable=True)
     tmdb_id = Column(BigInteger, nullable=True)
     imdb_id = Column(String(32), nullable=True)
+    tmdb_lookup_attempted_at = Column(DateTime(timezone=True), nullable=True)
+    tmdb_lookup_expires_at = Column(DateTime(timezone=True), nullable=True)
+    tmdb_lookup_key = Column(String(64), nullable=True)
     first_seen_profile_sync_id = Column(
         BigInteger,
         ForeignKey("profile_syncs.id", ondelete="SET NULL"),
@@ -447,6 +450,7 @@ class Movie(Base):
         ),
         Index("ix_movies_normalized_title_year", "normalized_title", "release_year"),
         Index("ix_movies_letterboxd_slug", "letterboxd_slug"),
+        Index("ix_movies_tmdb_lookup_expires_at", "tmdb_lookup_expires_at"),
     )
 
 class Rating(Base):

--- a/backend/services/tmdb_enrichment.py
+++ b/backend/services/tmdb_enrichment.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timedelta, timezone
+import hashlib
+import json
 import os
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
 
 from sqlalchemy.orm import Session
 
 from database.models import Movie, MovieEnrichment, MovieWatchProvider
+from services.import_contracts import normalize_title
 from services.tmdb_client import TMDBClient, TMDBError
 
 
@@ -18,6 +21,7 @@ DEFAULT_REGION = "DE"
 DEFAULT_IMAGE_BASE_URL = "https://image.tmdb.org/t/p/w500"
 DEFAULT_PROVIDER_LOGO_BASE_URL = "https://image.tmdb.org/t/p/original"
 PROVIDER_TYPES = ("flatrate", "rent", "buy", "free", "ads")
+TMDB_LOOKUP_MATCHER_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -46,7 +50,9 @@ class EnrichmentStats:
     provider_fetches: int = 0
     enriched: int = 0
     not_found: int = 0
+    not_found_cached: int = 0
     identity_conflicts: int = 0
+    identity_conflicts_cached: int = 0
     failed: int = 0
     provider_rows: int = 0
     dry_run: bool = False
@@ -103,6 +109,27 @@ def _provider_region_expiry(raw_payload: Any, region: str) -> Optional[datetime]
     metadata = _as_dict(_as_dict(raw_payload).get("_spyboxd"))
     expiries = _as_dict(metadata.get("provider_region_expires_at"))
     return _parse_iso_datetime(expiries.get(region.upper()))
+
+
+def _tmdb_lookup_key(
+    title: str,
+    release_year: Optional[int],
+    language: str,
+) -> str:
+    """Fingerprint every input that can change a cached identity-search result."""
+    payload = {
+        "language": language.strip().casefold(),
+        "matcher_version": TMDB_LOOKUP_MATCHER_VERSION,
+        "normalized_title": normalize_title(title),
+        "release_year": release_year,
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _certification_for_region(details: Mapping[str, Any], region: str) -> Optional[str]:
@@ -204,6 +231,7 @@ def _select_candidates(
     refresh: bool,
     limit: Optional[int],
     movie_ids: Optional[Sequence[int]],
+    language: str,
 ) -> List[EnrichmentCandidate]:
     query = (
         db.query(
@@ -214,6 +242,9 @@ def _select_candidates(
             MovieEnrichment.movie_id,
             MovieEnrichment.expires_at,
             MovieEnrichment.raw_payload,
+            Movie.tmdb_lookup_attempted_at,
+            Movie.tmdb_lookup_expires_at,
+            Movie.tmdb_lookup_key,
         )
         .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
         .order_by(Movie.id)
@@ -231,7 +262,7 @@ def _select_candidates(
         )
     }
 
-    ranked_candidates: List[tuple[tuple[int, int, int], EnrichmentCandidate]] = []
+    ranked_candidates: List[tuple[tuple[int, int, int, int], EnrichmentCandidate]] = []
     for (
         movie_id,
         title,
@@ -240,7 +271,22 @@ def _select_candidates(
         enrichment_movie_id,
         expires_at,
         raw_payload,
+        tmdb_lookup_attempted_at,
+        tmdb_lookup_expires_at,
+        tmdb_lookup_key,
     ) in query.all():
+        lookup_attempted_at = _aware_utc(tmdb_lookup_attempted_at)
+        lookup_expiry = _aware_utc(tmdb_lookup_expires_at)
+        current_lookup_key = _tmdb_lookup_key(title, release_year, language)
+        lookup_inputs_match = tmdb_lookup_key == current_lookup_key
+        if (
+            tmdb_id is None
+            and not refresh
+            and lookup_expiry is not None
+            and lookup_expiry > now
+            and lookup_inputs_match
+        ):
+            continue
         details_expiry = _aware_utc(expires_at)
         details_are_stale = details_expiry is None or details_expiry <= now
         provider_expiry = _provider_region_expiry(raw_payload, region)
@@ -261,12 +307,14 @@ def _select_candidates(
             needs_providers=needs_providers,
         )
         # A bounded timer must not let newly imported movies wait behind a
-        # large synchronized cache-expiry backlog. Manual/unbounded runs still
-        # receive every candidate; this changes only processing order.
+        # large synchronized cache-expiry backlog or expired negative lookups.
+        # Manual/unbounded runs still receive every eligible candidate; this
+        # changes only processing order.
         ranked_candidates.append(
             (
                 (
                     0 if enrichment_movie_id is None else 1,
+                    0 if lookup_attempted_at is None or not lookup_inputs_match else 1,
                     0 if tmdb_id is None else 1,
                     int(movie_id),
                 ),
@@ -350,6 +398,9 @@ def _persist_prepared(
     if movie is None:
         raise ValueError(f"Movie {prepared.candidate.movie_id} disappeared during enrichment")
     movie.tmdb_id = prepared.tmdb_id
+    movie.tmdb_lookup_attempted_at = None
+    movie.tmdb_lookup_expires_at = None
+    movie.tmdb_lookup_key = None
 
     enrichment = db.get(MovieEnrichment, movie.id)
     if enrichment is None:
@@ -414,6 +465,29 @@ def _persist_prepared(
     return inserted_provider_rows
 
 
+def _persist_lookup_deferral(
+    db: Session,
+    candidate: EnrichmentCandidate,
+    *,
+    attempted_at: datetime,
+    expires_at: datetime,
+    lookup_key: str,
+) -> bool:
+    movie = db.get(Movie, candidate.movie_id)
+    if movie is None:
+        raise ValueError(f"Movie {candidate.movie_id} disappeared during enrichment")
+    # RSS or another trusted ingestion path may have supplied the identity
+    # while the network search was running. Never overwrite that newer fact
+    # with a stale negative lookup.
+    if movie.tmdb_id is not None:
+        return False
+    movie.tmdb_lookup_attempted_at = attempted_at
+    movie.tmdb_lookup_expires_at = expires_at
+    movie.tmdb_lookup_key = lookup_key
+    db.flush()
+    return True
+
+
 def enrich_movies(
     db: Session,
     client: Optional[TMDBClient],
@@ -452,6 +526,7 @@ def enrich_movies(
         refresh=refresh,
         limit=limit,
         movie_ids=movie_ids,
+        language=language,
     )
     # End the read transaction before any potentially slow network request.
     db.rollback()
@@ -465,6 +540,7 @@ def enrich_movies(
     completed = 0
     for candidate_batch in _chunks(candidates, batch_size):
         prepared_batch: List[PreparedEnrichment] = []
+        missed_batch: List[EnrichmentCandidate] = []
         for candidate in candidate_batch:
             if progress:
                 progress(completed + 1, len(candidates), candidate)
@@ -474,6 +550,7 @@ def enrich_movies(
                 prepared = _prepare_candidate(client, candidate, language=language)
                 if prepared is None:
                     stats.not_found += 1
+                    missed_batch.append(candidate)
                     completed += 1
                     continue
                 if candidate.needs_details:
@@ -490,11 +567,14 @@ def enrich_movies(
 
         successful_writes = 0
         successful_provider_rows = 0
+        successful_miss_writes = 0
+        successful_conflict_writes = 0
         tmdb_owners = _existing_tmdb_owners(
             db,
             (prepared.tmdb_id for prepared in prepared_batch),
         )
         writable_batch: List[PreparedEnrichment] = []
+        conflicted_batch: List[EnrichmentCandidate] = []
         for prepared in prepared_batch:
             candidate = prepared.candidate
             owner = tmdb_owners.get(prepared.tmdb_id)
@@ -510,11 +590,64 @@ def enrich_movies(
                         "reason": "tmdb_id_already_owned",
                     }
                 )
+                conflicted_batch.append(candidate)
                 continue
             # Reserve this identity within the prepared batch as well as
             # respecting mappings already persisted in the database.
             tmdb_owners[prepared.tmdb_id] = (candidate.movie_id, candidate.title)
             writable_batch.append(prepared)
+
+        for candidate in missed_batch:
+            try:
+                with db.begin_nested():
+                    attempted_at = datetime.now(timezone.utc)
+                    if _persist_lookup_deferral(
+                        db,
+                        candidate,
+                        attempted_at=attempted_at,
+                        expires_at=attempted_at + timedelta(days=cache_days),
+                        lookup_key=_tmdb_lookup_key(
+                            candidate.title,
+                            candidate.release_year,
+                            language,
+                        ),
+                    ):
+                        successful_miss_writes += 1
+            except Exception as exc:
+                stats.failed += 1
+                stats.errors.append(
+                    {
+                        "movie_id": candidate.movie_id,
+                        "title": candidate.title,
+                        "error": f"Search-miss cache write failed: {exc}",
+                    }
+                )
+
+        for candidate in conflicted_batch:
+            try:
+                with db.begin_nested():
+                    attempted_at = datetime.now(timezone.utc)
+                    if _persist_lookup_deferral(
+                        db,
+                        candidate,
+                        attempted_at=attempted_at,
+                        expires_at=attempted_at + timedelta(days=cache_days),
+                        lookup_key=_tmdb_lookup_key(
+                            candidate.title,
+                            candidate.release_year,
+                            language,
+                        ),
+                    ):
+                        successful_conflict_writes += 1
+            except Exception as exc:
+                stats.failed += 1
+                stats.errors.append(
+                    {
+                        "movie_id": candidate.movie_id,
+                        "title": candidate.title,
+                        "error": f"Identity-conflict cache write failed: {exc}",
+                    }
+                )
 
         for prepared in writable_batch:
             try:
@@ -542,10 +675,16 @@ def enrich_movies(
         try:
             db.commit()
             stats.enriched += successful_writes
+            stats.not_found_cached += successful_miss_writes
+            stats.identity_conflicts_cached += successful_conflict_writes
             stats.provider_rows += successful_provider_rows
         except Exception as exc:
             db.rollback()
-            stats.failed += successful_writes
+            stats.failed += (
+                successful_writes
+                + successful_miss_writes
+                + successful_conflict_writes
+            )
             stats.errors.append({"movie_id": None, "title": None, "error": f"Batch commit failed: {exc}"})
 
     return stats

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -22,7 +22,8 @@ class AdditiveMigrationContractTests(unittest.TestCase):
         config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
         script = ScriptDirectory.from_config(config)
 
-        self.assertEqual(script.get_heads(), ["20260729_0006"])
+        self.assertEqual(script.get_heads(), ["20260729_0007"])
+        self.assertEqual(script.get_revision("20260729_0007").down_revision, "20260729_0006")
         self.assertEqual(script.get_revision("20260729_0006").down_revision, "20260729_0005")
         self.assertEqual(script.get_revision("20260729_0005").down_revision, "20260729_0004")
         self.assertEqual(script.get_revision("20260729_0004").down_revision, "20260728_0003")
@@ -55,7 +56,15 @@ class AdditiveMigrationContractTests(unittest.TestCase):
             "profiles": {"display_name", "followers_count", "following_count", "last_profile_sync_id"},
             "ratings": {"movie_id", "first_seen_profile_sync_id", "last_seen_profile_sync_id", "removed_at"},
             "reviews": {"movie_id", "source_review_key", "published_at", "removed_at", "tags"},
-            "movies": {"canonical_key", "letterboxd_id", "tmdb_id", "imdb_id"},
+            "movies": {
+                "canonical_key",
+                "letterboxd_id",
+                "tmdb_id",
+                "imdb_id",
+                "tmdb_lookup_attempted_at",
+                "tmdb_lookup_expires_at",
+                "tmdb_lookup_key",
+            },
             "profile_films": {"profile_id", "movie_id", "legacy_rating_id", "watch_count", "rewatch_count"},
             "watch_events": {"profile_id", "movie_id", "event_key", "watched_date", "superseded_at"},
             "profile_data_changes": {"profile_id", "profile_sync_id", "change_type", "before", "after"},
@@ -119,7 +128,7 @@ class AdditiveMigrationPostgresTests(unittest.TestCase):
             connection.execute(text("SET TRANSACTION READ ONLY"))
             try:
                 current_revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
-                self.assertEqual(current_revision, "20260729_0006")
+                self.assertEqual(current_revision, "20260729_0007")
 
                 counts = connection.execute(
                     text(

--- a/backend/tests/test_tmdb_enrichment.py
+++ b/backend/tests/test_tmdb_enrichment.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 import sys
 import traceback
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import requests
 
@@ -15,6 +16,7 @@ BACKEND_DIR = Path(__file__).resolve().parents[1]
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 
+from database.models import Movie
 from services.tmdb_client import (
     DETAIL_APPEND_ENDPOINTS,
     TMDBClient,
@@ -23,7 +25,10 @@ from services.tmdb_client import (
     select_best_movie_match,
 )
 from services.tmdb_enrichment import (
+    EnrichmentCandidate,
+    _persist_lookup_deferral,
     _select_candidates,
+    _tmdb_lookup_key,
     build_enrichment_values,
     enrich_movies,
     provider_rows_for_region,
@@ -101,6 +106,17 @@ class FakeIdentityConflictSession:
         self.rolled_back = False
         self.commits = 0
         self.write_attempts = 0
+        self.movies = {
+            int(row[0]): Movie(
+                id=int(row[0]),
+                canonical_key=f"test:{row[0]}",
+                title=str(row[1]),
+                normalized_title=str(row[1]).casefold(),
+                release_year=row[2],
+                tmdb_id=row[3],
+            )
+            for row in movie_rows
+        }
 
     def query(self, *entities):
         result = self.query_results[self.query_count]
@@ -115,7 +131,15 @@ class FakeIdentityConflictSession:
 
     def begin_nested(self):
         self.write_attempts += 1
-        raise AssertionError("identity conflicts must be skipped before writes")
+        return nullcontext()
+
+    def get(self, model, movie_id):
+        if model is Movie:
+            return self.movies.get(int(movie_id))
+        raise AssertionError(f"Unexpected model lookup: {model}")
+
+    def flush(self):
+        return None
 
 
 class FakeMatchingClient:
@@ -395,7 +419,7 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
     def test_dry_run_selects_stale_movies_without_client_or_writes(self):
         stale = datetime.now(timezone.utc) - timedelta(days=1)
         session = FakeSelectionSession(
-            [(1, "Arrival", 2016, None, None, stale, {})],
+            [(1, "Arrival", 2016, None, None, stale, {}, None, None, None)],
         )
 
         stats = enrich_movies(session, None, region="DE", limit=1, dry_run=True)
@@ -420,6 +444,9 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
                             "provider_region_expires_at": {"DE": fresh.isoformat()}
                         }
                     },
+                    None,
+                    None,
+                    None,
                 )
             ],
         )
@@ -429,13 +456,72 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
         self.assertEqual(stats.selected, 0)
         self.assertTrue(session.rolled_back)
 
+    def test_fresh_negative_lookup_is_skipped_until_expiry(self):
+        now = datetime.now(timezone.utc)
+        lookup_key = _tmdb_lookup_key("Unmatched Film", 2024, "en-US")
+        session = FakeSelectionSession(
+            [
+                (
+                    1,
+                    "Unmatched Film",
+                    2024,
+                    None,
+                    None,
+                    None,
+                    {},
+                    now,
+                    now + timedelta(days=30),
+                    lookup_key,
+                )
+            ],
+        )
+
+        stats = enrich_movies(session, None, region="DE", dry_run=True)
+
+        self.assertEqual(stats.selected, 0)
+        self.assertTrue(session.rolled_back)
+
+    def test_never_attempted_identity_precedes_expired_negative_lookup(self):
+        now = datetime.now(timezone.utc)
+        expired = now - timedelta(days=1)
+        expired_lookup_key = _tmdb_lookup_key("Expired miss", 2023, "en-US")
+        session = FakeSelectionSession(
+            [
+                (
+                    1,
+                    "Expired miss",
+                    2023,
+                    None,
+                    None,
+                    None,
+                    {},
+                    expired,
+                    expired,
+                    expired_lookup_key,
+                ),
+                (2, "Never attempted", 2024, None, None, None, {}, None, None, None),
+            ],
+        )
+
+        candidates = _select_candidates(
+            session,
+            region="DE",
+            now=now,
+            refresh=False,
+            limit=1,
+            movie_ids=None,
+            language="en-US",
+        )
+
+        self.assertEqual([candidate.movie_id for candidate in candidates], [2])
+
     def test_bounded_selection_prioritizes_missing_enrichment_and_tmdb_identity(self):
         stale = datetime.now(timezone.utc) - timedelta(days=1)
         session = FakeSelectionSession(
             [
-                (1, "Stale cached", 2001, 101, 1, stale, {}),
-                (2, "New import", 2002, 202, None, None, {}),
-                (3, "Missing identity", 2003, None, 3, stale, {}),
+                (1, "Stale cached", 2001, 101, 1, stale, {}, None, None, None),
+                (2, "New import", 2002, 202, None, None, {}, None, None, None),
+                (3, "Missing identity", 2003, None, 3, stale, {}, None, None, None),
             ],
         )
 
@@ -446,15 +532,16 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
             refresh=False,
             limit=2,
             movie_ids=None,
+            language="en-US",
         )
 
         self.assertEqual([candidate.movie_id for candidate in candidates], [2, 3])
 
-    def test_identity_conflict_is_reported_and_skipped_before_any_write(self):
+    def test_identity_conflict_is_reported_and_deferred_separately(self):
         session = FakeIdentityConflictSession(
             [
-                (8713, "The Girlfriend", 2025, None, None, None, {}),
-                (9000, "Definitely Missing", 2025, None, None, None, {}),
+                (8713, "The Girlfriend", 2025, None, None, None, {}, None, None, None),
+                (9000, "Definitely Missing", 2025, None, None, None, {}, None, None, None),
             ],
             [(1196348, 147, "The Girlfriend")],
         )
@@ -466,10 +553,14 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
         self.assertEqual(stats.selected, 2)
         self.assertEqual(stats.identity_conflicts, 1)
         self.assertEqual(stats.not_found, 1)
+        self.assertEqual(stats.not_found_cached, 1)
+        self.assertEqual(stats.identity_conflicts_cached, 1)
         self.assertEqual(stats.failed, 0)
         self.assertEqual(stats.enriched, 0)
-        self.assertEqual(session.write_attempts, 0)
+        self.assertEqual(session.write_attempts, 2)
         persist.assert_not_called()
+        self.assertIsNotNone(session.movies[8713].tmdb_lookup_expires_at)
+        self.assertIsNotNone(session.movies[8713].tmdb_lookup_key)
         self.assertEqual(
             stats.identity_conflict_details,
             [
@@ -485,6 +576,166 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
         )
         self.assertEqual(stats.errors, [])
 
+    def test_cached_identity_conflict_does_not_starve_later_candidate(self):
+        rows = [
+            (1, "Duplicate", 2025, None, None, None, {}, None, None, None),
+            (2, "Later Film", 2024, None, None, None, {}, None, None, None),
+        ]
+        first_session = FakeIdentityConflictSession(
+            rows,
+            [(1196348, 147, "Existing Owner")],
+        )
+        client = FakeMatchingClient({"Duplicate": 1196348})
+
+        first_stats = enrich_movies(
+            first_session,
+            client,
+            region="DE",
+            language="en-US",
+            limit=1,
+        )
+
+        self.assertEqual(first_stats.identity_conflicts_cached, 1)
+        deferred = first_session.movies[1]
+        second_session = FakeSelectionSession(
+            [
+                (
+                    1,
+                    "Duplicate",
+                    2025,
+                    None,
+                    None,
+                    None,
+                    {},
+                    deferred.tmdb_lookup_attempted_at,
+                    deferred.tmdb_lookup_expires_at,
+                    deferred.tmdb_lookup_key,
+                ),
+                rows[1],
+            ]
+        )
+
+        second_candidates = _select_candidates(
+            second_session,
+            region="DE",
+            now=datetime.now(timezone.utc),
+            refresh=False,
+            limit=1,
+            movie_ids=None,
+            language="en-US",
+        )
+
+        self.assertEqual([candidate.movie_id for candidate in second_candidates], [2])
+
+    def test_changed_year_or_language_bypasses_fresh_negative_cache(self):
+        now = datetime.now(timezone.utc)
+        expiry = now + timedelta(days=30)
+        stored_key = _tmdb_lookup_key("Unmatched Film", 2023, "en-US")
+        cases = (
+            ("corrected year", 2024, "en-US"),
+            ("changed language", 2023, "fr-FR"),
+        )
+
+        for case, current_year, language in cases:
+            with self.subTest(case=case):
+                session = FakeSelectionSession(
+                    [
+                        (
+                            1,
+                            "Unmatched Film",
+                            current_year,
+                            None,
+                            None,
+                            None,
+                            {},
+                            now,
+                            expiry,
+                            stored_key,
+                        )
+                    ]
+                )
+                candidates = _select_candidates(
+                    session,
+                    region="DE",
+                    now=now,
+                    refresh=False,
+                    limit=1,
+                    movie_ids=None,
+                    language=language,
+                )
+                self.assertEqual([candidate.movie_id for candidate in candidates], [1])
+
+    def test_search_miss_cache_does_not_overwrite_concurrent_tmdb_identity(self):
+        attempted_at = datetime.now(timezone.utc)
+        movie = Movie(
+            id=1,
+            canonical_key="arrival-2016",
+            title="Arrival",
+            normalized_title="arrival",
+            release_year=2016,
+            tmdb_id=329865,
+        )
+        db = Mock()
+        db.get.return_value = movie
+        candidate = EnrichmentCandidate(
+            movie_id=1,
+            title="Arrival",
+            release_year=2016,
+            tmdb_id=None,
+            needs_details=True,
+            needs_providers=True,
+        )
+
+        persisted = _persist_lookup_deferral(
+            db,
+            candidate,
+            attempted_at=attempted_at,
+            expires_at=attempted_at + timedelta(days=30),
+            lookup_key=_tmdb_lookup_key("Arrival", 2016, "en-US"),
+        )
+
+        self.assertFalse(persisted)
+        self.assertIsNone(movie.tmdb_lookup_attempted_at)
+        self.assertIsNone(movie.tmdb_lookup_expires_at)
+        self.assertIsNone(movie.tmdb_lookup_key)
+        db.flush.assert_not_called()
+
+    def test_search_miss_cache_records_bounded_retry_window(self):
+        attempted_at = datetime.now(timezone.utc)
+        expires_at = attempted_at + timedelta(days=30)
+        movie = Movie(
+            id=2,
+            canonical_key="unmatched-film-2024",
+            title="Unmatched Film",
+            normalized_title="unmatched film",
+            release_year=2024,
+        )
+        db = Mock()
+        db.get.return_value = movie
+        candidate = EnrichmentCandidate(
+            movie_id=2,
+            title="Unmatched Film",
+            release_year=2024,
+            tmdb_id=None,
+            needs_details=True,
+            needs_providers=True,
+        )
+
+        lookup_key = _tmdb_lookup_key("Unmatched Film", 2024, "en-US")
+        persisted = _persist_lookup_deferral(
+            db,
+            candidate,
+            attempted_at=attempted_at,
+            expires_at=expires_at,
+            lookup_key=lookup_key,
+        )
+
+        self.assertTrue(persisted)
+        self.assertEqual(movie.tmdb_lookup_attempted_at, attempted_at)
+        self.assertEqual(movie.tmdb_lookup_expires_at, expires_at)
+        self.assertEqual(movie.tmdb_lookup_key, lookup_key)
+        db.flush.assert_called_once_with()
+
     def test_request_credentials_do_not_reach_enrichment_error_json(self):
         api_key = "persisted-secret-v3-key"
         bearer_token = "logged-secret-bearer-token"
@@ -496,7 +747,7 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
         http_session = FakeHTTPSession([request_error])
         client = TMDBClient(api_key=api_key, session=http_session, max_retries=0)
         db = FakeSelectionSession(
-            [(1, "Arrival", 2016, None, None, None, {})],
+            [(1, "Arrival", 2016, None, None, None, {}, None, None, None)],
         )
 
         stats = enrich_movies(db, client, region="DE", batch_size=1)

--- a/scripts/enrich_tmdb.py
+++ b/scripts/enrich_tmdb.py
@@ -53,7 +53,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--cache-days",
         type=positive_integer,
         default=int(os.getenv("TMDB_CACHE_DAYS", "30")),
-        help="Number of days before details/providers are eligible for refresh.",
+        help=(
+            "Number of days before details/providers refresh or an unsuccessful "
+            "identity lookup is retried."
+        ),
     )
     parser.add_argument(
         "--batch-size",


### PR DESCRIPTION
## What changed
- cache unsuccessful TMDB searches for the configured cache window
- defer TMDB identity conflicts separately so a bounded daily batch advances
- invalidate a deferral when normalized title, year, language, or matcher version changes
- keep negative results outside MovieEnrichment so data-coverage metrics remain honest

## Verification
- 153 backend tests passed locally (the PostgreSQL-only test is skipped in the ordinary local run)
- all 3 additive migration tests passed against a disposable PostgreSQL database
- `alembic check`, compileall, and `git diff --check` passed
- focused independent review: GO