### PR TITLE
Fix production redirect smoke check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -763,7 +763,7 @@ jobs:
 
           read -r root_status root_redirect < <(
             curl --silent --show-error --output /dev/null \
-              --write-out '%{http_code} %{redirect_url}' --max-time 10 \
+              --write-out '%{http_code} %{redirect_url}\n' --max-time 10 \
               --header 'Cache-Control: no-cache' \
               https://spyboxd.com/ 2>/dev/null || true
           )

--- a/deploy/test_validate_clerk_production.py
+++ b/deploy/test_validate_clerk_production.py
@@ -527,6 +527,16 @@ class ClerkProductionValidatorTests(unittest.TestCase):
             workflow,
         )
 
+    def test_external_smoke_redirect_probe_is_line_terminated(self) -> None:
+        workflow = (SCRIPT.parents[1] / ".github/workflows/deploy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "--write-out '%{http_code} %{redirect_url}\\n' --max-time 10",
+            workflow,
+        )
+
     def test_runtime_rejects_development_key_previous_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             frontend, api, manifest, _ = self.write_runtime_files(Path(directory))


### PR DESCRIPTION
## Summary
- terminate the curl redirect probe with a newline so strict Bash `read` succeeds
- add a regression assertion to the existing production Clerk/deploy guard suite

## Verified
- targeted regression test
- full `deploy/test_validate_clerk_production.py` suite (28 tests)
- workflow YAML parse
- `git diff --check`