### PR TITLE
Allow production deploys without Clerk bridge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,7 +193,7 @@ jobs:
             RELEASE_SHA="$1"
             REMOTE_BUNDLE="$2"
             REMOTE_CHECKSUM="$3"
-            CLERK_BRIDGE_EDGE="$4"
+            CLERK_BRIDGE_EDGE="${4:-}"
 
             case "${RELEASE_SHA}" in
               *[!0-9a-f]*|'')

--- a/deploy/test_validate_clerk_production.py
+++ b/deploy/test_validate_clerk_production.py
@@ -517,6 +517,7 @@ class ClerkProductionValidatorTests(unittest.TestCase):
         self.assertIn('old_release=""', release_script)
         self.assertIn("vars.PRODUCTION_CLERK_BRIDGE_EDGE", workflow)
         self.assertIn('"${previous_target}:${RELEASE_SHA}"', workflow)
+        self.assertIn('CLERK_BRIDGE_EDGE="${4:-}"', workflow)
         self.assertIn('SPYBOXD_CLERK_BRIDGE_EDGE="${CLERK_BRIDGE_EDGE}"', workflow)
         self.assertIn(
             "Stopped the failed Clerk bridge without activating the incompatible development artifact.",


### PR DESCRIPTION
## Summary
- treat a missing fourth SSH argument as an empty one-time Clerk bridge value
- preserve strict validation when a bridge edge is configured
- add the behavior to the existing deploy workflow contract test

## Why
SSH command serialization omits an empty final argument. With `set -u`, the remote release wrapper exited before activation after the one-time bridge variable was correctly removed. Recovery restored the previous healthy release.

## Verified
- targeted bridge and redirect guard tests
- full production Clerk/deploy guard suite (28 tests)
- shell reproduction with no fourth argument
- workflow YAML parse and `git diff --check`