### PR TITLE
Add public aggregate dashboard and profile monitoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -761,20 +761,43 @@ jobs:
           done
           [[ "${frontend_ready}" == true ]]
 
-          read -r root_status root_redirect < <(
+          root_status="$(
+            curl --silent --show-error --output /dev/null \
+              --write-out '%{http_code}' --max-time 10 \
+              --header 'Cache-Control: no-cache' \
+              https://spyboxd.com/ 2>/dev/null || true
+          )"
+          [[ "${root_status}" =~ ^2[0-9][0-9]$ ]]
+
+          public_dashboard="$(curl --silent --show-error --fail --max-time 10 \
+            --header 'Cache-Control: no-cache' \
+            https://api.spyboxd.com/api/public/dashboard)"
+          jq --exit-status '
+            (keys | sort) == (["activity_data", "data_health", "rating_distribution", "signal_counts", "system_stats", "timestamp"] | sort)
+            and (.system_stats | keys | sort) == (["global_avg_rating", "total_movies_tracked", "total_profiles", "total_reviews"] | sort)
+            and (.signal_counts | keys | sort) == (["one_day_gap_events", "one_day_gap_pair_hits", "profiles_analyzed", "profiles_with_diary_dates", "same_day_events", "same_day_pair_hits", "shared_titles"] | sort)
+          ' <<<"${public_dashboard}" >/dev/null
+
+          read -r private_status private_redirect < <(
             curl --silent --show-error --output /dev/null \
               --write-out '%{http_code} %{redirect_url}\n' --max-time 10 \
               --header 'Cache-Control: no-cache' \
-              https://spyboxd.com/ 2>/dev/null || true
+              https://spyboxd.com/dashboard 2>/dev/null || true
           )
-          [[ "${root_status}" =~ ^30[1278]$ ]]
-          [[ "${root_redirect}" == https://spyboxd.com/sign-in* ]]
+          [[ "${private_status}" =~ ^30[1278]$ ]]
+          [[ "${private_redirect}" == https://spyboxd.com/sign-in* ]]
 
           protected_api_status="$(curl --silent --show-error --output /dev/null \
             --write-out '%{http_code}' --max-time 10 \
             --header 'Cache-Control: no-cache' \
             https://api.spyboxd.com/profiles/ 2>/dev/null || true)"
           [[ "${protected_api_status}" == 401 ]]
+
+          protected_profile_status="$(curl --silent --show-error --output /dev/null \
+            --write-out '%{http_code}' --max-time 10 \
+            --header 'Cache-Control: no-cache' \
+            https://api.spyboxd.com/public/profile/privacy-check 2>/dev/null || true)"
+          [[ "${protected_profile_status}" == 401 ]]
 
       - name: Roll back externally unhealthy activation
         if: always() && steps.activate.outcome == 'success' && steps.external_smoke.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ API / PostgreSQL
   └─ dashboard snapshot cache in system_metrics.metrics
 
 Frontend
-  ├─ Clerk-authenticated private analytics workspace
-  ├─ per-user tracked-profile visibility and exact-username requests
-  └─ explicit public share pages at /u/<username>
+  ├─ aggregate-only public dashboard at /
+  ├─ Clerk-authenticated private analytics workspace at /dashboard
+  └─ per-user profile catalog, monitoring choices, and new-profile requests
 ```
 
 ## Quick Start
@@ -182,14 +182,18 @@ The enrichment command caches details and provider results, retries transient fa
 - `POST /upload/` is the write path for profile data.
 - Profiles and imported movie data are stored once globally; `user_tracked_profiles`
   controls which profiles each signed-in user can select or analyze.
-- `GET /api/dashboard/analytics` uses the cached global snapshot for admins and
-  computes an access-scoped response for ordinary users. The global snapshot is
-  refreshed after uploads, profile deletes, and data clears.
-- Health checks and `GET /public/profile/{username}` are public. Profile lists,
-  analytics, activity, access requests, and management screens require sign-in.
-- A signed-in user can track a completed profile immediately by exact username.
-  Missing or incomplete profiles become requests for the next residential sync;
-  no global profile directory is exposed to ordinary users.
+- `GET /api/dashboard/analytics` defaults to each ordinary caller's personal
+  monitoring set. An omitted scope preserves the prior global default for admins;
+  admins can explicitly switch between `scope=tracked` and `scope=global`. The
+  global snapshot is refreshed after uploads, profile deletes, and data clears.
+- Health checks and `GET /api/public/dashboard` are public. The dashboard response
+  is a strict aggregate allowlist with no usernames, profile pairs, film titles,
+  watch dates, or profile-level activity.
+- Profile snapshots, lists, analytics, activity, access requests, and management
+  screens require sign-in. The former `/u/<username>` share URL is also protected.
+- A signed-in user can browse the completed profile catalog and choose profiles
+  to monitor. Missing or incomplete usernames become requests for the next
+  residential sync.
 - Admin mutations require a strict boolean admin session claim or a Clerk user ID
   in the server-side `CLERK_ADMIN_USER_IDS` allowlist.
 - Production releases fail closed unless the frontend live keys and backend JWKS
@@ -209,16 +213,20 @@ The enrichment command caches details and provider results, retries transient fa
 - `GET /health`
 - `GET /ready`
 - `GET /health/rss`
-- `GET /public/profile/{username}`
+- `GET /api/public/dashboard`
 
 ### Signed-in workspace
 
 - `GET /api/me`
 - `GET /profiles/`
+- `GET /profiles/tracked`
+- `GET /profiles/catalog`
+- `POST /profiles/{profile_id}/tracking`
 - `POST /profiles/requests`
 - `GET /profiles/requests`
 - `DELETE /profiles/{username}/tracking`
 - `GET /profiles/{username}/analysis`
+- `GET /public/profile/{username}` (legacy path; authenticated and access-scoped)
 - `GET /api/dashboard/analytics`
 - `GET /api/spy-signals?event_source=ratings|events`
 - `GET /api/data-coverage`

--- a/backend/api/routes/profile_access.py
+++ b/backend/api/routes/profile_access.py
@@ -11,7 +11,9 @@ from database.connection import get_db
 from services.profile_access import (
     decide_profile_request,
     ensure_app_user,
+    list_profile_catalog,
     list_profile_requests,
+    track_profile_by_id,
     track_or_request_profile,
     untrack_profile,
 )
@@ -36,6 +38,32 @@ def get_me(
 ):
     ensure_app_user(db, user)
     return {"user_id": user.user_id, "is_admin": user.is_admin}
+
+
+@router.get("/profiles/catalog")
+def get_profile_catalog(
+    search: Optional[str] = Query(default=None, max_length=100),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    user: ClerkUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return list_profile_catalog(
+        db,
+        user,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/profiles/{profile_id}/tracking")
+def create_profile_tracking(
+    profile_id: int,
+    user: ClerkUser = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return track_profile_by_id(db, user, profile_id)
 
 
 @router.get("/profiles/requests")

--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -971,6 +971,22 @@ class AnalyticsRepository:
             "global_avg_rating": _safe_round(global_avg_rating, 2) or 0.0,
             "last_updated": datetime.now(timezone.utc).isoformat()
         }
+
+    def get_public_profile_health(self) -> Dict[str, Any]:
+        """Return aggregate sync health without exposing profile records."""
+
+        active_profiles = self.db.query(Profile).filter(Profile.is_active.is_(True))
+        completed_profiles = active_profiles.filter(
+            Profile.scraping_status == "completed"
+        ).count()
+        latest_sync = active_profiles.filter(
+            Profile.scraping_status == "completed"
+        ).with_entities(func.max(Profile.last_scraped_at)).scalar()
+        return {
+            "active_profiles": active_profiles.count(),
+            "completed_profiles": completed_profiles,
+            "last_synced_at": latest_sync.isoformat() if latest_sync else None,
+        }
     
     def get_top_rated_movies(
         self,
@@ -1022,6 +1038,19 @@ class AnalyticsRepository:
         top_movies_limit: int = 10,
         usernames: Optional[List[str]] = None,
     ) -> Dict[str, Any]:
+        if usernames is None:
+            usernames = [
+                username
+                for (username,) in (
+                    self.db.query(Profile.username)
+                    .filter(
+                        Profile.is_active.is_(True),
+                        Profile.scraping_status == "completed",
+                    )
+                    .order_by(Profile.id.asc())
+                    .all()
+                )
+            ]
         rating_repo = RatingRepository(self.db)
         profile_ids = self._profile_ids_for_usernames(usernames)
 
@@ -1056,7 +1085,15 @@ class AnalyticsRepository:
         return _naive_utc(latest_profile_update)
 
     def _get_profile_count(self) -> int:
-        return self.db.query(func.count(Profile.id)).scalar() or 0
+        return (
+            self.db.query(func.count(Profile.id))
+            .filter(
+                Profile.is_active.is_(True),
+                Profile.scraping_status == "completed",
+            )
+            .scalar()
+            or 0
+        )
 
     def get_dashboard_analytics_snapshot(
         self,

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Depends, Query
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Depends, Query, Response
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from api.routes.activity import router as activity_router
@@ -22,7 +22,7 @@ from database.connection import engine, get_db, init_db
 from database.repository import (
     ProfileRepository, RatingRepository, ReviewRepository, AnalyticsRepository
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from services.data_coverage import (
     extract_data_coverage,
 )
@@ -35,6 +35,7 @@ from services.profile_access import (
     fulfill_pending_requests,
     reopen_fulfilled_requests_for_profile,
     require_profile_access,
+    tracked_profiles,
 )
 from services.operational_health import (
     application_revision,
@@ -116,6 +117,145 @@ class ProfileUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
+class PublicSystemStats(BaseModel):
+    total_profiles: int = Field(ge=0)
+    total_movies_tracked: int = Field(ge=0)
+    total_reviews: int = Field(ge=0)
+    global_avg_rating: float = Field(ge=0, le=5)
+
+
+class PublicActivityPoint(BaseModel):
+    month: str
+    movies_watched: int = Field(ge=0)
+    average_rating: Optional[float] = Field(default=None, ge=0, le=5)
+
+
+class PublicSignalCounts(BaseModel):
+    profiles_analyzed: int = Field(ge=0)
+    profiles_with_diary_dates: int = Field(ge=0)
+    shared_titles: int = Field(ge=0)
+    same_day_events: int = Field(ge=0)
+    one_day_gap_events: int = Field(ge=0)
+    same_day_pair_hits: int = Field(ge=0)
+    one_day_gap_pair_hits: int = Field(ge=0)
+
+
+class PublicDataHealth(BaseModel):
+    active_profiles: int = Field(ge=0)
+    completed_profiles: int = Field(ge=0)
+    last_synced_at: Optional[datetime]
+
+
+class PublicDashboardResponse(BaseModel):
+    system_stats: PublicSystemStats
+    rating_distribution: dict[str, int]
+    activity_data: list[PublicActivityPoint]
+    signal_counts: PublicSignalCounts
+    data_health: PublicDataHealth
+    timestamp: datetime
+
+
+def _safe_nonnegative_int(value) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        numeric = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return max(0, numeric)
+
+
+def _safe_public_timestamp(value) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            pass
+    return datetime.now(timezone.utc)
+
+
+def _safe_public_rating(value, default: Optional[float] = None) -> Optional[float]:
+    numeric = _safe_json_float(value)
+    if numeric is None or not 0 <= numeric <= 5:
+        return default
+    return numeric
+
+
+def _public_dashboard_payload(
+    snapshot: dict,
+    profile_health: dict,
+) -> dict:
+    """Allowlist an aggregate-only dashboard response.
+
+    The cached internal snapshot deliberately contains usernames, profile pairs,
+    titles, watch dates, and other private workspace details. Never return or
+    shallow-copy that object from an anonymous endpoint.
+    """
+
+    system_stats = snapshot.get("system_stats") or {}
+    raw_summary = (snapshot.get("group_signals") or {}).get("summary") or {}
+    activity_data = snapshot.get("activity_data") or []
+    rating_distribution = {}
+    for rating, count in (snapshot.get("rating_distribution") or {}).items():
+        numeric_rating = _safe_json_float(rating)
+        if (
+            numeric_rating is None
+            or not 0.5 <= numeric_rating <= 5.0
+            or abs(numeric_rating * 2 - round(numeric_rating * 2)) > 1e-9
+        ):
+            continue
+        rating_distribution[f"{numeric_rating:.1f}"] = _safe_nonnegative_int(count)
+
+    return {
+        "system_stats": {
+            "total_profiles": _safe_nonnegative_int(system_stats.get("total_profiles")),
+            "total_movies_tracked": _safe_nonnegative_int(system_stats.get("total_movies_tracked")),
+            "total_reviews": _safe_nonnegative_int(system_stats.get("total_reviews")),
+            "global_avg_rating": _safe_public_rating(
+                system_stats.get("global_avg_rating"),
+                0.0,
+            ) or 0.0,
+        },
+        "rating_distribution": rating_distribution,
+        "activity_data": [
+            {
+                "month": point["month"],
+                "movies_watched": _safe_nonnegative_int(point.get("movies_watched")),
+                "average_rating": _safe_public_rating(point.get("average_rating")),
+            }
+            for point in activity_data
+            if isinstance(point, dict)
+            and isinstance(point.get("month"), str)
+            and re.fullmatch(r"\d{4}-(?:0[1-9]|1[0-2])", point["month"])
+        ],
+        "signal_counts": {
+            key: _safe_nonnegative_int(raw_summary.get(key))
+            for key in (
+                "profiles_analyzed",
+                "profiles_with_diary_dates",
+                "shared_titles",
+                "same_day_events",
+                "one_day_gap_events",
+                "same_day_pair_hits",
+                "one_day_gap_pair_hits",
+            )
+        },
+        "data_health": {
+            "active_profiles": _safe_nonnegative_int(profile_health.get("active_profiles")),
+            "completed_profiles": _safe_nonnegative_int(profile_health.get("completed_profiles")),
+            "last_synced_at": (
+                _safe_public_timestamp(profile_health.get("last_synced_at"))
+                if profile_health.get("last_synced_at")
+                else None
+            ),
+        },
+        "timestamp": _safe_public_timestamp(snapshot.get("timestamp")),
+    }
+
+
 def _get_cors_origins() -> List[str]:
     configured = os.getenv("CORS_ALLOWED_ORIGINS", "").strip()
     if configured:
@@ -161,11 +301,12 @@ def _refresh_dashboard_snapshot_cache(db: Session) -> None:
 
 
 def _record_owner_export_publication_consent(analyzer_profile, publish_owner_data: bool) -> None:
-    """Require an explicit admin attestation before owner-export data becomes public.
+    """Require an explicit admin attestation before owner-export data becomes shared.
 
     Official exports can contain records that are not visible on a public
-    Letterboxd profile. Spyboxd's analytics routes are public, so importing an
-    export is a publication action, not merely a file upload.
+    Letterboxd profile. Spyboxd stores profiles once for its signed-in shared
+    workspace, so importing an export is a publication action to authorized
+    users, not merely a private file upload.
     """
     if getattr(analyzer_profile, "source_kind", None) != "letterboxd_export":
         return
@@ -247,16 +388,19 @@ def rss_health_check(db: Session = Depends(get_db)):
 
 
 @app.get("/public/profile/{username}")
-async def get_public_profile(username: str, db: Session = Depends(get_db)):
+async def get_public_profile(
+    username: str,
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
     """
-    Public profile snapshot used by share pages/OG images.
-    Only exposes completed, active profiles.
+    Signed-in profile snapshot used by the legacy share-page URL.
+    Access is limited to profiles visible to the caller.
     """
-    profile_repo = ProfileRepository(db)
     rating_repo = RatingRepository(db)
 
-    profile = profile_repo.get_profile_by_username(username)
-    if not profile or not profile.is_active:
+    profile = require_profile_access(db, user, username)
+    if not profile.is_active:
         raise HTTPException(status_code=404, detail="Profile not found")
 
     if profile.scraping_status != "completed":
@@ -325,18 +469,10 @@ def extract_zip_file(uploaded_file, temp_dir):
     return extract_dir
 
 # Profile Management Endpoints
-@app.get("/profiles/")
-async def list_profiles(
-    db: Session = Depends(get_db),
-    user: ClerkUser = Depends(get_current_user),
-):
-    """Get active profiles visible to the signed-in user."""
+def _serialize_profiles(db: Session, profiles) -> dict:
     rating_repo = RatingRepository(db)
-    
-    profiles = [profile for profile in accessible_profiles(db, user) if profile.is_active]
-    
     profile_list = []
-    for profile in profiles:
+    for profile in (profile for profile in profiles if profile.is_active):
         profile_dict = profile.to_dict()
         all_entries = rating_repo.get_ratings_by_profile(profile.id)
         
@@ -361,24 +497,73 @@ async def list_profiles(
     
     return {"profiles": profile_list}
 
-@app.get("/api/dashboard/analytics")
-async def get_consolidated_dashboard_analytics(
+
+@app.get("/profiles/")
+async def list_profiles(
     db: Session = Depends(get_db),
     user: ClerkUser = Depends(get_current_user),
 ):
-    """Get dashboard analytics over profiles visible to the signed-in user."""
-    ensure_app_user(db, user)
+    """Get the caller's profiles, or the managed global library for admins."""
+
+    return _serialize_profiles(db, accessible_profiles(db, user))
+
+
+@app.get("/profiles/tracked")
+async def list_tracked_profiles(
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """Get the caller's personal monitoring set without an admin bypass."""
+
+    return _serialize_profiles(db, tracked_profiles(db, user))
+
+
+@app.get("/api/dashboard/analytics")
+async def get_consolidated_dashboard_analytics(
+    scope: Optional[str] = Query(default=None, pattern="^(tracked|global)$"),
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """Get dashboard analytics with backward-compatible admin defaults."""
     analytics_repo = AnalyticsRepository(db)
-    if not user.is_admin:
-        usernames = authorize_profile_usernames(db, user, None)
-        return analytics_repo.build_dashboard_analytics_snapshot(
+    effective_scope = scope or ("global" if user.is_admin else "tracked")
+    if effective_scope == "global":
+        ensure_app_user(db, user)
+        if not user.is_admin:
+            raise HTTPException(status_code=403, detail="Admin role required for global analytics")
+        return analytics_repo.get_dashboard_analytics_snapshot(
             group_limit=6,
             top_movies_limit=10,
-            usernames=usernames,
         )
-    return analytics_repo.get_dashboard_analytics_snapshot(
+
+    usernames = [
+        profile.username
+        for profile in tracked_profiles(db, user)
+        if profile.is_active and profile.scraping_status == "completed"
+    ]
+    return analytics_repo.build_dashboard_analytics_snapshot(
         group_limit=6,
         top_movies_limit=10,
+        usernames=usernames,
+    )
+
+
+@app.get("/api/public/dashboard", response_model=PublicDashboardResponse)
+async def get_public_dashboard_analytics(
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    """Return one identity-free aggregate snapshot for the public homepage."""
+
+    analytics_repo = AnalyticsRepository(db)
+    snapshot = analytics_repo.get_dashboard_analytics_snapshot(
+        group_limit=6,
+        top_movies_limit=10,
+    )
+    response.headers["Cache-Control"] = "public, max-age=60, stale-while-revalidate=300"
+    return _public_dashboard_payload(
+        snapshot,
+        analytics_repo.get_public_profile_health(),
     )
 
 

--- a/backend/services/profile_access.py
+++ b/backend/services/profile_access.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, Optional, Sequence
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, text
+from sqlalchemy import false, func, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, joinedload
 
@@ -15,6 +15,7 @@ from database.models import (
     AppUser,
     Profile,
     ProfileAccessRequest,
+    Rating,
     UserTrackedProfile,
 )
 
@@ -122,13 +123,132 @@ def accessible_profiles(db: Session, clerk_user: ClerkUser) -> list[Profile]:
     app_user = ensure_app_user(db, clerk_user)
     if clerk_user.is_admin:
         return db.query(Profile).order_by(Profile.updated_at.desc()).all()
+    return tracked_profiles(db, clerk_user, app_user=app_user)
+
+
+def tracked_profiles(
+    db: Session,
+    clerk_user: ClerkUser,
+    *,
+    app_user: Optional[AppUser] = None,
+) -> list[Profile]:
+    """Return only the caller's personal monitoring set, including for admins."""
+
+    resolved_user = app_user or ensure_app_user(db, clerk_user)
     return (
         db.query(Profile)
         .join(UserTrackedProfile, UserTrackedProfile.profile_id == Profile.id)
-        .filter(UserTrackedProfile.user_id == app_user.id)
+        .filter(UserTrackedProfile.user_id == resolved_user.id)
         .order_by(Profile.updated_at.desc())
         .all()
     )
+
+
+def list_profile_catalog(
+    db: Session,
+    clerk_user: ClerkUser,
+    *,
+    search: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """List completed profiles a signed-in user can choose to monitor.
+
+    The catalog intentionally exposes only recognition fields and aggregate film
+    counts. Pending, errored, and inactive profiles stay in the admin library
+    and are never offered as selectable monitoring targets.
+    """
+
+    app_user = ensure_app_user(db, clerk_user)
+    tracked_profile_ids = {
+        profile_id
+        for (profile_id,) in (
+            db.query(UserTrackedProfile.profile_id)
+            .filter(UserTrackedProfile.user_id == app_user.id)
+            .all()
+        )
+    }
+
+    query = db.query(Profile).filter(
+        Profile.is_active.is_(True),
+        Profile.scraping_status == "completed",
+    )
+    normalized_search = (search or "").strip().casefold()
+    if normalized_search:
+        pattern = f"%{normalized_search}%"
+        query = query.filter(
+            func.lower(Profile.username).like(pattern)
+            | func.lower(func.coalesce(Profile.display_name, "")).like(pattern)
+        )
+
+    total = query.count()
+    profiles = (
+        query.order_by(func.lower(Profile.username).asc(), Profile.id.asc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    profile_ids = [profile.id for profile in profiles]
+    rating_counts = {
+        profile_id: count
+        for profile_id, count in (
+            db.query(Rating.profile_id, func.count(Rating.id))
+            .filter(Rating.profile_id.in_(profile_ids) if profile_ids else false())
+            .group_by(Rating.profile_id)
+            .all()
+        )
+    }
+
+    return {
+        "profiles": [
+            {
+                "id": profile.id,
+                "username": profile.username,
+                "display_name": profile.display_name,
+                "profile_image_url": profile.profile_image_url,
+                "total_films": rating_counts.get(profile.id, 0),
+                "is_tracked": profile.id in tracked_profile_ids,
+            }
+            for profile in profiles
+        ],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def track_profile_by_id(
+    db: Session,
+    clerk_user: ClerkUser,
+    profile_id: int,
+) -> dict[str, Any]:
+    """Idempotently monitor one selectable catalog profile for this user."""
+
+    app_user = ensure_app_user(db, clerk_user)
+    profile = (
+        db.query(Profile)
+        .filter(
+            Profile.id == profile_id,
+            Profile.is_active.is_(True),
+            Profile.scraping_status == "completed",
+        )
+        .first()
+    )
+    if profile is None:
+        raise HTTPException(status_code=404, detail="Selectable profile not found")
+
+    _add_tracking(
+        db,
+        app_user_id=app_user.id,
+        profile_id=profile.id,
+        source="direct",
+    )
+    db.commit()
+    return {
+        "message": f"{profile.username} is now monitored.",
+        "status": "tracked",
+        "profile": profile_summary(profile),
+    }
 
 
 def authorize_profile_usernames(

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -35,10 +35,13 @@ from backend.services.profile_access import (
     authorize_profile_usernames,
     decide_profile_request,
     fulfill_pending_requests,
+    list_profile_catalog,
     list_profile_requests,
     reopen_fulfilled_requests_for_profile,
     require_profile_access,
+    track_profile_by_id,
     track_or_request_profile,
+    tracked_profiles,
     untrack_profile,
 )
 
@@ -112,6 +115,153 @@ def test_existing_completed_profile_is_tracked_case_insensitively_and_idempotent
     with pytest.raises(HTTPException) as raised:
         authorize_profile_usernames(database, _user(), ["Beta"])
     assert raised.value.status_code == 403
+
+
+def test_signed_in_catalog_lists_only_selectable_profiles_and_tracks_by_id(database):
+    selectable = _profile(1, "Alpha")
+    selectable.display_name = "Alpha Viewer"
+    pending = _profile(2, "Pending", completed=False)
+    inactive = _profile(3, "Inactive")
+    inactive.is_active = False
+    database.add_all([selectable, pending, inactive])
+    database.add(
+        Rating(
+            id=1,
+            profile_id=selectable.id,
+            movie_title="Catalog Film",
+            movie_year=2026,
+            rating=4.0,
+        )
+    )
+    database.commit()
+
+    initial = list_profile_catalog(database, _user())
+    assert initial["total"] == 1
+    assert initial["profiles"] == [
+        {
+            "id": 1,
+            "username": "Alpha",
+            "display_name": "Alpha Viewer",
+            "profile_image_url": None,
+            "total_films": 1,
+            "is_tracked": False,
+        }
+    ]
+
+    tracked = track_profile_by_id(database, _user(), selectable.id)
+    assert tracked["status"] == "tracked"
+    assert list_profile_catalog(database, _user())["profiles"][0]["is_tracked"] is True
+
+    with pytest.raises(HTTPException) as unavailable:
+        track_profile_by_id(database, _user(), pending.id)
+    assert unavailable.value.status_code == 404
+
+
+def test_profile_catalog_tracking_is_isolated_per_user(database):
+    database.add(_profile(1, "Alpha"))
+    database.commit()
+
+    track_profile_by_id(database, _user("first"), 1)
+
+    assert list_profile_catalog(database, _user("first"))["profiles"][0]["is_tracked"] is True
+    assert list_profile_catalog(database, _user("second"))["profiles"][0]["is_tracked"] is False
+
+
+def test_admin_personal_monitoring_is_separate_from_global_library_access(database):
+    alpha = _profile(1, "Alpha")
+    beta = _profile(2, "Beta")
+    database.add_all([alpha, beta])
+    database.commit()
+    admin_user = _user("admin", admin=True)
+
+    track_profile_by_id(database, admin_user, alpha.id)
+
+    assert [profile.username for profile in tracked_profiles(database, admin_user)] == ["Alpha"]
+    assert {profile.username for profile in accessible_profiles(database, admin_user)} == {"Alpha", "Beta"}
+
+
+def test_non_admin_cannot_request_global_dashboard_scope(database):
+    with pytest.raises(HTTPException) as forbidden:
+        asyncio.run(
+            backend_main.get_consolidated_dashboard_analytics(
+                scope="global",
+                db=database,
+                user=_user(),
+            )
+        )
+    assert forbidden.value.status_code == 403
+
+
+def test_omitted_dashboard_scope_preserves_admin_global_default(database, monkeypatch):
+    sentinel = {"scope": "global"}
+    monkeypatch.setattr(
+        backend_main.AnalyticsRepository,
+        "get_dashboard_analytics_snapshot",
+        lambda self, *, group_limit, top_movies_limit: sentinel,
+    )
+
+    result = asyncio.run(
+        backend_main.get_consolidated_dashboard_analytics(
+            scope=None,
+            db=database,
+            user=_user("admin", admin=True),
+        )
+    )
+
+    assert result is sentinel
+
+
+def test_omitted_dashboard_scope_defaults_non_admin_to_tracked_profiles(database):
+    alpha = _profile(1, "Alpha")
+    beta = _profile(2, "Beta")
+    database.add_all([alpha, beta])
+    database.add_all(
+        [
+            Rating(id=1, profile_id=alpha.id, movie_title="Alpha Film", rating=4.0),
+            Rating(id=2, profile_id=beta.id, movie_title="Beta Film", rating=1.0),
+        ]
+    )
+    database.commit()
+    track_profile_by_id(database, _user(), alpha.id)
+
+    result = asyncio.run(
+        backend_main.get_consolidated_dashboard_analytics(
+            scope=None,
+            db=database,
+            user=_user(),
+        )
+    )
+
+    assert result["system_stats"]["total_profiles"] == 1
+    assert result["system_stats"]["total_movies_tracked"] == 1
+    assert result["rating_distribution"] == {"4.0": 1}
+
+
+def test_explicit_tracked_dashboard_scope_limits_admin_to_personal_set(database):
+    alpha = _profile(1, "Alpha")
+    beta = _profile(2, "Beta")
+    database.add_all([alpha, beta])
+    database.add_all(
+        [
+            Rating(id=1, profile_id=alpha.id, movie_title="Alpha Film", rating=4.0),
+            Rating(id=2, profile_id=beta.id, movie_title="Beta Film", rating=1.0),
+        ]
+    )
+    database.commit()
+    admin_user = _user("admin", admin=True)
+    track_profile_by_id(database, admin_user, alpha.id)
+
+    result = asyncio.run(
+        backend_main.get_consolidated_dashboard_analytics(
+            scope="tracked",
+            db=database,
+            user=admin_user,
+        )
+    )
+
+    assert result["system_stats"]["total_profiles"] == 1
+    assert result["system_stats"]["total_movies_tracked"] == 1
+    assert result["rating_distribution"] == {"4.0": 1}
 
 
 def test_unknown_request_is_casefolded_idempotent_and_fulfills_only_after_sync(database):
@@ -593,6 +743,28 @@ def test_dashboard_snapshot_never_treats_empty_scope_as_global(database):
     assert empty["rating_distribution"] == {}
     assert empty["activity_data"] == []
     assert empty["group_signals"]["summary"]["profiles_analyzed"] == 0
+
+
+def test_global_dashboard_snapshot_excludes_unready_and_inactive_profiles(database):
+    ready = _profile(1, "Ready")
+    pending = _profile(2, "Pending", completed=False)
+    inactive = _profile(3, "Inactive")
+    inactive.is_active = False
+    database.add_all([ready, pending, inactive])
+    database.add_all(
+        [
+            Rating(id=1, profile_id=ready.id, movie_title="Ready Film", rating=4.0),
+            Rating(id=2, profile_id=pending.id, movie_title="Pending Film", rating=2.0),
+            Rating(id=3, profile_id=inactive.id, movie_title="Inactive Film", rating=1.0),
+        ]
+    )
+    database.commit()
+
+    snapshot = AnalyticsRepository(database).build_dashboard_analytics_snapshot()
+
+    assert snapshot["system_stats"]["total_profiles"] == 1
+    assert snapshot["system_stats"]["total_movies_tracked"] == 1
+    assert snapshot["rating_distribution"] == {"4.0": 1}
 
 
 def test_admin_allowlist_is_server_side_and_metadata_boolean_is_strict(monkeypatch):

--- a/backend/tests/test_public_dashboard.py
+++ b/backend/tests/test_public_dashboard.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+
+from backend.main import PublicDashboardResponse, _public_dashboard_payload
+
+
+def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
+    sentinel = "private-user-sentinel"
+    snapshot = {
+        "system_stats": {
+            "total_profiles": 13,
+            "total_movies_tracked": 4000,
+            "total_reviews": 700,
+            "global_avg_rating": 3.75,
+            "last_updated": "2026-07-30T10:00:00Z",
+        },
+        "top_rated_movies": [{"title": "Private Film Sentinel"}],
+        "rating_distribution": {"4.0": 250, sentinel: 1},
+        "activity_data": [
+            {"month": "2026-07", "movies_watched": 80, "average_rating": 3.8},
+            {"month": sentinel, "movies_watched": 1, "average_rating": 5.0},
+        ],
+        "group_signals": {
+            "summary": {
+                "profiles_analyzed": 13,
+                "profiles_with_diary_dates": 12,
+                "shared_titles": 300,
+                "same_day_events": 20,
+                "one_day_gap_events": 8,
+                "same_day_pair_hits": 24,
+                "one_day_gap_pair_hits": 9,
+                "strongest_alignment_pair": {"profiles": [sentinel, "other"]},
+                "most_shared_title": {"title": "Private Film Sentinel"},
+            },
+            "same_day_events": [
+                {"participants": [{"username": sentinel}], "title": "Private Film Sentinel"}
+            ],
+        },
+        "timestamp": "2026-07-30T10:00:00Z",
+    }
+
+    payload = _public_dashboard_payload(
+        snapshot,
+        {
+            "active_profiles": 14,
+            "completed_profiles": 13,
+            "last_synced_at": "2026-07-30T09:55:00Z",
+        },
+    )
+    validated = PublicDashboardResponse.model_validate(payload).model_dump(mode="json")
+
+    assert set(validated) == {
+        "system_stats",
+        "rating_distribution",
+        "activity_data",
+        "signal_counts",
+        "data_health",
+        "timestamp",
+    }
+    assert set(validated["signal_counts"]) == {
+        "profiles_analyzed",
+        "profiles_with_diary_dates",
+        "shared_titles",
+        "same_day_events",
+        "one_day_gap_events",
+        "same_day_pair_hits",
+        "one_day_gap_pair_hits",
+    }
+    serialized = json.dumps(validated).lower()
+    assert sentinel not in serialized
+    assert "private film sentinel" not in serialized
+    for forbidden_key in ("username", "profiles", "participants", "title", "profile_id"):
+        assert f'"{forbidden_key}"' not in serialized

--- a/backend/tests/test_route_access_matrix.py
+++ b/backend/tests/test_route_access_matrix.py
@@ -33,6 +33,9 @@ def _dependency_names(route: APIRoute) -> set[str]:
 def test_data_bearing_reads_require_a_clerk_user():
     protected_reads = {
         "/profiles/",
+        "/profiles/tracked",
+        "/profiles/catalog",
+        "/public/profile/{username}",
         "/api/dashboard/analytics",
         "/api/spy-signals",
         "/profiles/{username}/analysis",
@@ -51,8 +54,8 @@ def test_data_bearing_reads_require_a_clerk_user():
         assert "get_current_user" in _dependency_names(_route("GET", path)), path
 
 
-def test_health_and_explicit_share_profile_remain_public():
-    public_reads = {"/health", "/ready", "/health/rss", "/public/profile/{username}"}
+def test_health_and_aggregate_dashboard_remain_public():
+    public_reads = {"/health", "/ready", "/health/rss", "/api/public/dashboard"}
     for path in public_reads:
         dependencies = _dependency_names(_route("GET", path))
         assert "get_current_user" not in dependencies
@@ -69,3 +72,4 @@ def test_existing_mutations_keep_admin_or_ingestion_auth():
     for method, path in admin_routes:
         assert "get_admin_user" in _dependency_names(_route(method, path))
     assert "get_active_upload_user" in _dependency_names(_route("POST", "/upload/"))
+    assert "get_current_user" in _dependency_names(_route("POST", "/profiles/{profile_id}/tracking"))

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -13,3 +13,33 @@ test('backend admin truth exposes management and the residential sync queue', as
   await expect(page.getByText('@queuedprofile', { exact: true }).last()).toBeVisible();
   await expect(page.getByText('Awaiting residential sync', { exact: true })).toBeVisible();
 });
+
+test('admin library mutations refresh the selectable profile catalog', async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+  page.on('dialog', (dialog) => dialog.accept());
+  let catalogRequestCount = 0;
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname === '/profiles/catalog') catalogRequestCount += 1;
+  });
+
+  await page.goto('/profiles');
+  await expect(page.getByTestId('profile-catalog-result-summary')).toBeVisible();
+  const initialCatalogRequestCount = catalogRequestCount;
+  await page.getByTestId('tracked-profile-grid').getByTitle('Delete profile').first().click();
+
+  await expect(page.getByText('Profile deleted successfully.')).toBeVisible();
+  await expect.poll(() => catalogRequestCount).toBeGreaterThan(initialCatalogRequestCount);
+});
+
+test('an admin can switch between personal monitoring and the preserved global dashboard', async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+
+  await page.goto('/dashboard');
+
+  await expect(page.getByText('Analytics across the complete managed profile library')).toBeVisible();
+  await page.getByRole('button', { name: 'Monitored', exact: true }).click();
+  await expect(page.getByText('Analytics across the Letterboxd profiles you monitor')).toBeVisible();
+  await page.getByRole('button', { name: 'Global admin' }).click();
+  await expect(page.getByText('Analytics across the complete managed profile library')).toBeVisible();
+  await expect(page.getByText('Managed Profiles', { exact: true }).first()).toBeVisible();
+});

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -2,16 +2,37 @@ import { expect, test } from '@playwright/test';
 
 import { installApiMocks } from './fixtures/api';
 
-test('an anonymous visitor is redirected from the app to sign in', async ({ page }) => {
+test('the aggregate dashboard is the anonymous landing page', async ({ page }) => {
   await installApiMocks(page, { authenticated: false });
+
+  const apiRequests: Array<{ path: string; authorization?: string }> = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.protocol === 'http:' && url.port === '8000' && ['127.0.0.1', 'localhost'].includes(url.hostname)) {
+      apiRequests.push({
+        path: url.pathname,
+        authorization: request.headers().authorization,
+      });
+    }
+  });
 
   await page.goto('/');
 
-  await expect(page).toHaveURL(/\/sign-in(?:\/|\?|$)/);
-  await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByTestId('public-dashboard')).toBeVisible();
+  await expect(page.getByRole('heading', { name: /without exposing anyone's profile/i })).toBeVisible();
+  const signInLink = page.getByRole('link', { name: 'Sign in to monitor profiles' });
+  await expect(signInLink).toBeVisible();
+  await expect(signInLink).toHaveAttribute('href', '/sign-in?redirect_url=%2Fprofiles');
+  await expect(page.getByRole('link', { name: 'Sign in for private tools' }))
+    .toHaveAttribute('href', '/sign-in?redirect_url=%2Fprofiles');
+  await expect(page.getByText('@alpha', { exact: true })).toHaveCount(0);
+  expect(apiRequests.length).toBeGreaterThanOrEqual(1);
+  expect(apiRequests.every(({ path }) => path === '/api/public/dashboard')).toBe(true);
+  expect(apiRequests.every(({ authorization }) => authorization === undefined)).toBe(true);
 });
 
-for (const path of ['/upload', '/users']) {
+for (const path of ['/dashboard', '/profiles', '/analysis', '/compare', '/spy-signals', '/watch-together', '/u/alpha']) {
   test(`an anonymous visitor cannot bypass auth with ${path}`, async ({ page }) => {
     await installApiMocks(page, { authenticated: false });
 

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -119,6 +119,35 @@ const groupSignals = {
   follow_paths: [],
 };
 
+const publicDashboard = {
+  system_stats: {
+    total_profiles: profiles.length,
+    total_movies_tracked: 4_321,
+    total_reviews: 680,
+    global_avg_rating: 3.7,
+  },
+  rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
+  activity_data: [
+    { month: '2026-06', movies_watched: 20, average_rating: 3.8 },
+    { month: '2026-07', movies_watched: 24, average_rating: 3.9 },
+  ],
+  signal_counts: {
+    profiles_analyzed: profiles.length,
+    profiles_with_diary_dates: profiles.length,
+    shared_titles: 42,
+    same_day_events: 1,
+    one_day_gap_events: 0,
+    same_day_pair_hits: 1,
+    one_day_gap_pair_hits: 0,
+  },
+  data_health: {
+    active_profiles: profiles.length,
+    completed_profiles: profiles.length,
+    last_synced_at: '2026-07-29T12:00:00Z',
+  },
+  timestamp: '2026-07-29T12:00:00Z',
+};
+
 const dataCoverage = {
   generated_at: '2026-07-29T12:00:00Z',
   overall_score: 100,
@@ -234,6 +263,10 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   const path = url.pathname.replace(/\/$/, '') || '/';
   const method = route.request().method();
 
+  if (path === '/api/public/dashboard' && method === 'GET') {
+    return json(route, publicDashboard);
+  }
+
   if (route.request().headers().authorization !== 'Bearer e2e-token') {
     return route.fulfill({
       status: 401,
@@ -244,6 +277,43 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
 
   if (path === '/api/me') return json(route, { user_id: 'user_e2e', is_admin: isAdmin });
   if (path === '/profiles' && method === 'GET') return json(route, { profiles: state.profiles });
+  if (path === '/profiles/tracked' && method === 'GET') return json(route, { profiles: state.profiles });
+  if (path === '/profiles/catalog' && method === 'GET') {
+    const search = (url.searchParams.get('search') ?? '').trim().toLowerCase();
+    const limit = Number(url.searchParams.get('limit') ?? 100);
+    const offset = Number(url.searchParams.get('offset') ?? 0);
+    const matchingProfiles = profiles
+      .map((profile, index) => ({ profile, id: index + 1 }))
+      .filter(({ profile }) => !search
+        || profile.username.toLowerCase().includes(search)
+        || (profile.display_name ?? '').toLowerCase().includes(search));
+    return json(route, {
+      profiles: matchingProfiles.slice(offset, offset + limit).map(({ profile, id }) => ({
+        id,
+        username: profile.username,
+        display_name: profile.display_name,
+        profile_image_url: profile.profile_image_url,
+        total_films: profile.total_films,
+        is_tracked: state.profiles.some((tracked) => tracked.username === profile.username),
+      })),
+      total: matchingProfiles.length,
+      limit,
+      offset,
+    });
+  }
+  const trackMatch = path.match(/^\/profiles\/(\d+)\/tracking$/);
+  if (trackMatch && method === 'POST') {
+    const profile = profiles[Number(trackMatch[1]) - 1];
+    if (!profile) return route.fulfill({ status: 404, body: '' });
+    if (!state.profiles.some((tracked) => tracked.username === profile.username)) {
+      state.profiles.push({ ...profile });
+    }
+    return json(route, {
+      message: `${profile.username} is now monitored.`,
+      status: 'tracked',
+      profile: { ...profile, id: Number(trackMatch[1]), is_active: true },
+    });
+  }
   if (path === '/profiles/requests' && method === 'GET') return json(route, { requests: state.requests });
   if (path === '/profiles/requests' && method === 'POST') {
     const payload = route.request().postDataJSON() as { username: string };
@@ -282,6 +352,10 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     const username = decodeURIComponent(untrackMatch[1]);
     state.profiles = state.profiles.filter((profile) => profile.username !== username);
     return json(route, { message: 'Profile removed from your tracked profiles.', status: 'untracked', username });
+  }
+  const deleteProfileMatch = path.match(/^\/profiles\/([^/]+)$/);
+  if (deleteProfileMatch && method === 'DELETE') {
+    return json(route, { message: `${decodeURIComponent(deleteProfileMatch[1])} deleted.` });
   }
   if (path === '/admin/profile-requests' && method === 'GET') return json(route, { requests: isAdmin ? state.requests : [] });
   if (path === '/api/dashboard/analytics') {

--- a/frontend/e2e/onboarding.spec.ts
+++ b/frontend/e2e/onboarding.spec.ts
@@ -5,16 +5,16 @@ import { installApiMocks } from './fixtures/api';
 test('an empty profile set guides the user to My Profiles', async ({ page }) => {
   await installApiMocks(page, { profileCount: 0 });
 
-  await page.goto('/');
+  await page.goto('/dashboard');
 
-  await expect(page.getByRole('heading', { name: 'Choose your first profile' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Add or request a profile' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Choose your first monitored profile' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Choose or request a profile' })).toBeVisible();
 });
 
 test('one tracked profile explains how to unlock pair features', async ({ page }) => {
   await installApiMocks(page, { profileCount: 1 });
 
-  await page.goto('/');
+  await page.goto('/dashboard');
 
   await expect(page.getByRole('heading', { name: 'Add one more profile for Spy Signals' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Add or request a profile' })).toBeVisible();

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -42,20 +42,29 @@ test.afterEach(async ({ page }, testInfo: TestInfo) => {
   expect(errors, 'The page must not emit console errors or uncaught exceptions').toEqual([]);
 });
 
-test('signed-in homepage renders the scoped dashboard and navigates to My Profiles', async ({ page }) => {
-  await page.goto('/');
+test('signed-in private dashboard renders the scoped data and navigates to My Profiles', async ({ page }) => {
+  await page.goto('/dashboard');
 
   await expect(page).toHaveTitle(/Spyboxd/);
   await expect(page.getByRole('heading', { level: 1, name: 'Dashboard', exact: true })).toBeVisible();
-  await expect(page.getByText('Your Profiles', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Monitored Profiles', { exact: true }).first()).toBeVisible();
   await expect(page.getByText('10 profiles loaded')).toBeVisible();
   await expectAccountControl(page);
 
-  const manageProfiles = page.getByRole('button', { name: 'Add or manage profiles' });
+  const manageProfiles = page.getByRole('button', { name: 'Choose monitored profiles' });
   await expect(manageProfiles).toBeVisible();
   await manageProfiles.click();
   await expect(page).toHaveURL(/\/profiles$/);
   await expect(page.getByRole('heading', { level: 1, name: 'My Profiles', exact: true })).toBeVisible();
+});
+
+test('signed-in public homepage remains aggregate-only', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByTestId('public-dashboard')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Open My Dashboard' })).toBeVisible();
+  await expect(page.getByText('@alpha', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Most Active Profile', { exact: true })).toHaveCount(0);
 });
 
 test('profiles can be searched without hiding matching data', async ({ page }) => {
@@ -63,9 +72,41 @@ test('profiles can be searched without hiding matching data', async ({ page }) =
 
   await expect(page.getByRole('heading', { level: 1, name: 'My Profiles', exact: true })).toBeVisible();
   await page.getByPlaceholder('Search profiles...').fill('charlie');
-  await expect(page.getByText('@charlie', { exact: true })).toBeVisible();
+  const trackedGrid = page.getByTestId('tracked-profile-grid');
+  await expect(trackedGrid.getByText('@charlie', { exact: true })).toBeVisible();
   await expect(page.getByText('1 of 10 tracked profiles')).toBeVisible();
-  await expect(page.getByText('@alpha', { exact: true })).toHaveCount(0);
+  await expect(trackedGrid.getByText('@alpha', { exact: true })).toHaveCount(0);
+});
+
+test('a signed-in user can choose an existing profile from the catalog', async ({ page }) => {
+  await page.goto('/profiles');
+
+  await expect(page.getByText('10 monitored', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Stop monitoring bravo' }).click();
+  await expect(page.getByText('9 monitored', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Monitor bravo' }).click();
+  await expect(page.getByText('10 monitored', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Stop monitoring bravo' })).toBeVisible();
+});
+
+test('available-profile search is server-backed and reports the bounded result set', async ({ page }) => {
+  const catalogRequests: URL[] = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === '/profiles/catalog') catalogRequests.push(url);
+  });
+
+  await page.goto('/profiles');
+  const catalog = page.getByRole('region', { name: 'Choose profiles to monitor' });
+  await catalog.getByPlaceholder('Search available profiles...').fill('juliet');
+
+  await expect(catalog.getByTestId('profile-catalog-result-summary')).toHaveText('1 matching synced profile');
+  await expect(catalog.getByText(/^@juliet · /)).toBeVisible();
+  await expect(catalog.getByText(/^@alpha · /)).toHaveCount(0);
+  await expect.poll(() => catalogRequests.some((url) => (
+    url.searchParams.get('search') === 'juliet'
+      && url.searchParams.get('limit') === '100'
+  ))).toBe(true);
 });
 
 test('a new Letterboxd username becomes a visible pending request', async ({ page }) => {

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import Dashboard from '../../views/Dashboard';
+import Dashboard from '../../../views/Dashboard';
 
 export default function DashboardPage() {
   return <Dashboard />;

--- a/frontend/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/frontend/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -4,6 +4,7 @@ export default function SignInPage() {
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <SignIn
+        fallbackRedirectUrl="/dashboard"
         appearance={{
           elements: {
             rootBox: 'mx-auto',

--- a/frontend/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -4,6 +4,7 @@ export default function SignUpPage() {
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <SignUp
+        fallbackRedirectUrl="/dashboard"
         appearance={{
           elements: {
             rootBox: 'mx-auto',

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ClerkProvider afterSignOutUrl="/sign-in">
+    <ClerkProvider afterSignOutUrl="/">
       <html lang="en">
         <body>
           <Providers>{children}</Providers>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,5 @@
+import PublicDashboard from '../views/PublicDashboard';
+
+export default function PublicDashboardPage() {
+  return <PublicDashboard />;
+}

--- a/frontend/src/app/u/[username]/page.tsx
+++ b/frontend/src/app/u/[username]/page.tsx
@@ -1,51 +1,26 @@
-import type { Metadata } from 'next';
+'use client';
+
 import Link from 'next/link';
-import { notFound } from 'next/navigation';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { profileApi } from '../../../services/api';
+import LoadingSpinner from '../../../components/LoadingSpinner';
+import ErrorMessage from '../../../components/ErrorMessage';
 
-const API_URL = process.env.API_URL ?? 'http://localhost:8000';
+export default function ProfileSnapshotPage() {
+  const params = useParams<{ username: string }>();
+  const username = params.username;
+  const profileQuery = useQuery({
+    queryKey: ['profile-snapshot', username],
+    queryFn: () => profileApi.getProfileSnapshot(username),
+    enabled: Boolean(username),
+  });
 
-interface Props {
-  params: Promise<{ username: string }>;
-}
-
-async function getPublicProfile(username: string) {
-  try {
-    const res = await fetch(
-      `${API_URL}/public/profile/${encodeURIComponent(username)}`,
-      { next: { revalidate: 3600 } }
-    );
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
+  if (profileQuery.isLoading) return <LoadingSpinner message="Loading profile…" />;
+  if (profileQuery.error || !profileQuery.data) {
+    return <ErrorMessage message="This profile is unavailable or you do not have access." />;
   }
-}
-
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { username } = await params;
-  const profile = await getPublicProfile(username);
-
-  if (!profile) {
-    return { title: `${username} — Spyboxd` };
-  }
-
-  const description = `${profile.total_films} films watched · ${profile.avg_rating?.toFixed(1)}★ avg · ${profile.total_reviews} reviews`;
-
-  return {
-    title: `${profile.username} on Spyboxd`,
-    description,
-    openGraph: {
-      title: `${profile.username} on Spyboxd`,
-      description,
-    },
-  };
-}
-
-export default async function PublicProfilePage({ params }: Props) {
-  const { username } = await params;
-  const profile = await getPublicProfile(username);
-
-  if (!profile) notFound();
+  const profile = profileQuery.data;
 
   return (
     <main className="min-h-screen flex items-center justify-center px-4 py-12">
@@ -78,9 +53,9 @@ export default async function PublicProfilePage({ params }: Props) {
         </div>
 
         <p className="text-center text-xs text-white/30">
-          Powered by{' '}
-          <Link href="/" className="text-cinema-400 font-medium hover:text-cinema-300 transition-colors">
-            Spyboxd
+          Back to{' '}
+          <Link href="/dashboard" className="text-cinema-400 font-medium hover:text-cinema-300 transition-colors">
+            My Dashboard
           </Link>
         </p>
       </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -27,11 +27,11 @@ interface LayoutProps {
 
 const NAVIGATION_ITEMS = [
   {
-    path: '/',
-    label: 'Dashboard',
+    path: '/dashboard',
+    label: 'My Dashboard',
     icon: HomeIcon,
     activeIcon: HomeIconSolid,
-    description: 'Overview & Analytics',
+    description: 'Your Profile Overview',
   },
   {
     path: '/spy-signals',
@@ -82,7 +82,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     setCurrentTime(new Date());
   }, []);
 
-  const isActive = (path: string) => pathname === path || (path !== '/' && pathname.startsWith(`${path}/`));
+  const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`);
   const activeItem = NAVIGATION_ITEMS.find((item) => isActive(item.path));
   const isInsightWorkspace = isActive('/compare') || isActive('/watch-together');
 
@@ -256,7 +256,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 animate={{ x: 0, opacity: 1 }}
                 transition={{ delay: 0.5 }}
               >
-                {activeItem?.label || 'Dashboard'}
+                {activeItem?.label || 'My Dashboard'}
               </motion.h2>
               <motion.p 
                 className="text-white/60 text-sm mt-1"

--- a/frontend/src/components/insights/InsightUI.tsx
+++ b/frontend/src/components/insights/InsightUI.tsx
@@ -18,20 +18,22 @@ export function formatCalendarDate(value: string | null | undefined): string {
 }
 
 export function ProfileAvatar({ profile, username, size = 'md' }: {
-  profile?: ProfileInfo;
+  profile?: Pick<ProfileInfo, 'username'> & Partial<Pick<ProfileInfo, 'profile_image_url' | 'avatar_url'>>;
   username?: string;
   size?: 'sm' | 'md' | 'lg';
 }) {
   const name = profile?.username ?? username ?? '?';
   const imageUrl = profile?.profile_image_url ?? profile?.avatar_url;
+  const [failedUrl, setFailedUrl] = React.useState<string | null>(null);
   const dimensions = size === 'lg' ? 'h-11 w-11 text-sm' : size === 'sm' ? 'h-7 w-7 text-[10px]' : 'h-9 w-9 text-xs';
 
-  if (imageUrl) {
+  if (imageUrl && imageUrl !== failedUrl) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
       <img
         src={imageUrl}
         alt=""
+        onError={() => setFailedUrl(imageUrl)}
         className={`${dimensions} shrink-0 rounded-full border border-cinema-400/35 object-cover`}
       />
     );

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,9 +1,9 @@
 import { clerkMiddleware } from '@clerk/nextjs/server';
 
 const PUBLIC_ROUTE_PATTERNS = [
+  /^\/$/,
   /^\/sign-in(?:\/.*)?$/,
   /^\/sign-up(?:\/.*)?$/,
-  /^\/u(?:\/.*)?$/,
 ];
 
 export default clerkMiddleware(async (auth, request) => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -108,6 +108,22 @@ export interface ProfileRequestSubmission {
   request: ProfileRequest | null;
 }
 
+export interface ProfileCatalogItem {
+  id: number;
+  username: string;
+  display_name: string | null;
+  profile_image_url: string | null;
+  total_films: number;
+  is_tracked: boolean;
+}
+
+export interface ProfileCatalogResponse {
+  profiles: ProfileCatalogItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export const authApi = {
   getCurrentUser: async (): Promise<CurrentUser> => {
     const response = await api.get('/api/me');
@@ -171,6 +187,30 @@ export const profileApi = {
     return response.data.profiles || [];
   },
 
+  getTrackedProfiles: async (): Promise<ProfileInfo[]> => {
+    const response = await api.get('/profiles/tracked');
+    return response.data.profiles || [];
+  },
+
+  getCatalog: async (search?: string, limit = 100): Promise<ProfileCatalogResponse> => {
+    const response = await api.get('/profiles/catalog', {
+      params: {
+        limit,
+        ...(search?.trim() ? { search: search.trim() } : {}),
+      },
+    });
+    return response.data;
+  },
+
+  trackExisting: async (profileId: number): Promise<{
+    message: string;
+    status: 'tracked';
+    profile: ProfileRequestProfile;
+  }> => {
+    const response = await api.post(`/profiles/${profileId}/tracking`);
+    return response.data;
+  },
+
   // Get profile analysis
   getAnalysis: async (username: string): Promise<ProfileAnalysis> => {
     const response = await api.get(`/profiles/${username}/analysis`);
@@ -225,6 +265,15 @@ export const profileApi = {
 
   stopTracking: async (username: string): Promise<{ message: string; status: 'untracked'; username: string }> => {
     const response = await api.delete(`/profiles/${encodeURIComponent(username)}/tracking`);
+    return response.data;
+  },
+
+  getProfileSnapshot: async (username: string): Promise<ProfileInfo & {
+    bio?: string | null;
+    location?: string | null;
+    website?: string | null;
+  }> => {
+    const response = await api.get(`/public/profile/${encodeURIComponent(username)}`);
     return response.data;
   },
 };
@@ -410,11 +459,39 @@ export interface DashboardAnalytics {
   timestamp: string;
 }
 
+export interface PublicDashboardAnalytics {
+  system_stats: Omit<SystemStats, 'last_updated'>;
+  rating_distribution: Record<string, number>;
+  activity_data: ActivityData[];
+  signal_counts: {
+    profiles_analyzed: number;
+    profiles_with_diary_dates: number;
+    shared_titles: number;
+    same_day_events: number;
+    one_day_gap_events: number;
+    same_day_pair_hits: number;
+    one_day_gap_pair_hits: number;
+  };
+  data_health: {
+    active_profiles: number;
+    completed_profiles: number;
+    last_synced_at: string | null;
+  };
+  timestamp: string;
+}
+
 // Dashboard API endpoints
 export const dashboardApi = {
   // Get dashboard analytics
-  getAnalytics: async (): Promise<DashboardAnalytics> => {
-    const response = await api.get('/api/dashboard/analytics');
+  getAnalytics: async (scope: 'tracked' | 'global' = 'tracked'): Promise<DashboardAnalytics> => {
+    const response = await api.get('/api/dashboard/analytics', { params: { scope } });
+    return response.data;
+  },
+};
+
+export const publicDashboardApi = {
+  getAnalytics: async (): Promise<PublicDashboardAnalytics> => {
+    const response = await api.get('/api/public/dashboard');
     return response.data;
   },
 };

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { profileApi, dashboardApi, changesApi } from '../services/api';
@@ -34,30 +34,60 @@ import { useCurrentUser } from '../hooks/useCurrentUser';
 
 const Dashboard: React.FC = () => {
   const [deletingProfile, setDeletingProfile] = useState<string | null>(null);
+  const [dashboardScope, setDashboardScope] = useState<'tracked' | 'global'>('global');
   const router = useRouter();
+  const queryClient = useQueryClient();
   const currentUserQuery = useCurrentUser();
   const isAdmin = currentUserQuery.data?.is_admin ?? false;
+  const isGlobalAdminView = isAdmin && dashboardScope === 'global';
+  const effectiveDashboardScope: 'tracked' | 'global' = isGlobalAdminView ? 'global' : 'tracked';
   
   const { data: profiles, isLoading, error, refetch } = useQuery({
-    queryKey: ['profiles'],
-    queryFn: profileApi.getProfiles,
+    queryKey: ['profiles', 'dashboard', effectiveDashboardScope],
+    queryFn: () => isGlobalAdminView ? profileApi.getProfiles() : profileApi.getTrackedProfiles(),
+    enabled: currentUserQuery.isSuccess,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
   const { data: analytics, isLoading: analyticsLoading, refetch: refetchAnalytics } = useQuery({
-    queryKey: ['dashboard-analytics'],
-    queryFn: dashboardApi.getAnalytics,
+    queryKey: ['dashboard-analytics', effectiveDashboardScope],
+    queryFn: () => dashboardApi.getAnalytics(isGlobalAdminView ? 'global' : 'tracked'),
+    enabled: currentUserQuery.isSuccess,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
   const recentChangesQuery = useQuery({
-    queryKey: ['recent-changes', 'latest-sync', 6],
-    queryFn: () => changesApi.getRecentChanges({ limit: 6, latestSyncOnly: true }),
+    queryKey: ['recent-changes', 'latest-sync', 6, effectiveDashboardScope, (profiles ?? []).map((profile) => profile.username)],
+    queryFn: () => changesApi.getRecentChanges({
+      profiles: isGlobalAdminView ? undefined : (profiles ?? []).map((profile) => profile.username),
+      limit: 6,
+      latestSyncOnly: true,
+    }),
+    enabled: currentUserQuery.isSuccess && (isGlobalAdminView || (profiles?.length ?? 0) > 0),
     staleTime: 2 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
+
+  const adminScopeToggle = isAdmin ? (
+    <div className="inline-flex rounded-xl border border-white/10 bg-black/20 p-1" aria-label="Dashboard scope">
+      <button
+        type="button"
+        onClick={() => setDashboardScope('tracked')}
+        className={`rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${dashboardScope === 'tracked' ? 'bg-cinema-500 text-white' : 'text-white/55 hover:text-white'}`}
+      >
+        Monitored
+      </button>
+      <button
+        type="button"
+        onClick={() => setDashboardScope('global')}
+        className={`rounded-lg px-3 py-2 text-xs font-semibold transition-colors ${dashboardScope === 'global' ? 'bg-cinema-500 text-white' : 'text-white/55 hover:text-white'}`}
+      >
+        Global admin
+      </button>
+    </div>
+  ) : null;
 
   // Handle profile deletion
   const handleDeleteProfile = async (username: string) => {
@@ -65,7 +95,13 @@ const Dashboard: React.FC = () => {
       setDeletingProfile(username);
       try {
         await profileApi.deleteProfile(username);
-        await Promise.all([refetch(), refetchAnalytics()]);
+        await Promise.all([
+          refetch(),
+          refetchAnalytics(),
+          queryClient.invalidateQueries({ queryKey: ['profiles'] }),
+          queryClient.invalidateQueries({ queryKey: ['profile-catalog'] }),
+          queryClient.invalidateQueries({ queryKey: ['recent-changes'] }),
+        ]);
       } catch (error) {
         console.error('Failed to delete profile:', error);
       } finally {
@@ -93,11 +129,14 @@ const Dashboard: React.FC = () => {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
       >
-        <div>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
           <h1 className="mb-2 text-4xl font-bold text-white text-glow">Dashboard</h1>
           <p className="text-white/60">
-            {isAdmin ? 'Analytics across the Letterboxd profiles you manage.' : 'Analytics across the Letterboxd profiles you track.'}
+            {isGlobalAdminView ? 'Analytics across the complete managed profile library.' : 'Analytics across the Letterboxd profiles you monitor.'}
           </p>
+          </div>
+          {adminScopeToggle}
         </div>
         <section className="card-cinema flex min-h-80 flex-col items-center justify-center px-6 text-center">
           <motion.div
@@ -107,11 +146,11 @@ const Dashboard: React.FC = () => {
           >
             <FilmIcon className="h-10 w-10 text-cinema-400" />
           </motion.div>
-          <h2 className="mt-6 text-2xl font-bold text-white">{isAdmin ? 'Add the first managed profile' : 'Choose your first profile'}</h2>
+          <h2 className="mt-6 text-2xl font-bold text-white">{isGlobalAdminView ? 'Add the first managed profile' : 'Choose your first monitored profile'}</h2>
           <p className="mt-3 max-w-lg text-sm leading-6 text-white/60">
-            {isAdmin
+            {isGlobalAdminView
               ? 'Create a placeholder or publish the first residential full sync to start the managed library.'
-              : 'Add an existing Letterboxd profile instantly, or request a new username for the next residential sync. Your dashboard and analysis will use only the profiles you track.'}
+              : 'Choose an existing Letterboxd profile, or request a new username for the next residential sync. This dashboard uses only the profiles you monitor.'}
           </p>
           <button
             type="button"
@@ -119,7 +158,7 @@ const Dashboard: React.FC = () => {
             className="btn-primary mt-6 flex items-center gap-2"
           >
             <PlusIcon className="h-5 w-5" />
-            {isAdmin ? 'Manage profiles' : 'Add or request a profile'}
+            {isGlobalAdminView ? 'Manage profiles' : 'Choose or request a profile'}
           </button>
         </section>
       </motion.div>
@@ -170,7 +209,7 @@ const Dashboard: React.FC = () => {
             Dashboard
           </h1>
           <p className="text-white/60">
-            {isAdmin ? 'Analytics across the Letterboxd profiles you manage' : 'Analytics across the Letterboxd profiles you track'}
+            {isGlobalAdminView ? 'Analytics across the complete managed profile library' : 'Analytics across the Letterboxd profiles you monitor'}
           </p>
         </div>
         
@@ -180,6 +219,7 @@ const Dashboard: React.FC = () => {
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.3 }}
         >
+          {adminScopeToggle}
           <motion.button 
             onClick={handleRefreshAll}
             className="btn-secondary flex items-center space-x-2"
@@ -197,7 +237,7 @@ const Dashboard: React.FC = () => {
             whileTap={{ scale: 0.95 }}
           >
             <PlusIcon className="w-5 h-5" />
-            <span>{isAdmin ? 'Manage Profiles' : 'Add or manage profiles'}</span>
+            <span>{isGlobalAdminView ? 'Manage Profiles' : 'Choose monitored profiles'}</span>
           </motion.button>
         </motion.div>
       </motion.div>
@@ -210,7 +250,7 @@ const Dashboard: React.FC = () => {
         transition={{ delay: 0.4 }}
       >
         <StatsCard
-          title={isAdmin ? 'Managed Profiles' : 'Your Profiles'}
+          title={isGlobalAdminView ? 'Managed Profiles' : 'Monitored Profiles'}
           value={totalProfiles}
           subtitle={`${activeProfiles} ready for analysis`}
           icon={Users}
@@ -218,18 +258,18 @@ const Dashboard: React.FC = () => {
         />
         
         <StatsCard
-          title={isAdmin ? 'Films in Managed Set' : 'Films in Your Set'}
+          title={isGlobalAdminView ? 'Films in Managed Set' : 'Films in Monitored Set'}
           value={totalMovies}
-          subtitle={`Across ${isAdmin ? 'managed' : 'tracked'} profiles`}
+          subtitle={`Across ${isGlobalAdminView ? 'managed' : 'monitored'} profiles`}
           icon={Film}
           gradient="from-blue-500/20 to-blue-600/10"
           delay={0.1}
         />
         
         <StatsCard
-          title={isAdmin ? 'Reviews in Managed Set' : 'Reviews in Your Set'}
+          title={isGlobalAdminView ? 'Reviews in Managed Set' : 'Reviews in Monitored Set'}
           value={totalReviews}
-          subtitle={`Across ${isAdmin ? 'managed' : 'tracked'} profiles`}
+          subtitle={`Across ${isGlobalAdminView ? 'managed' : 'monitored'} profiles`}
           icon={MessageCircle}
           gradient="from-purple-500/20 to-purple-600/10"
           delay={0.2}
@@ -238,7 +278,7 @@ const Dashboard: React.FC = () => {
         <StatsCard
           title="Group Average"
           value={avgRating.toFixed(1)}
-          subtitle={`${activeProfiles} ${isAdmin ? 'managed' : 'tracked'} profiles synced`}
+          subtitle={`${activeProfiles} ${isGlobalAdminView ? 'managed' : 'monitored'} profiles synced`}
           icon={Star}
           gradient="from-yellow-500/20 to-yellow-600/10"
           delay={0.3}
@@ -389,7 +429,7 @@ const Dashboard: React.FC = () => {
       >
         <div className="flex items-center justify-between">
           <h2 className="text-2xl font-bold text-white">
-            {isAdmin ? 'Managed Profiles' : 'Your Profiles'}
+            {isGlobalAdminView ? 'Managed Profiles' : 'Monitored Profiles'}
           </h2>
           <span className="text-white/60 text-sm">
             {profilesArray.length} {profilesArray.length === 1 ? 'profile' : 'profiles'} loaded
@@ -407,7 +447,7 @@ const Dashboard: React.FC = () => {
                   key={profile.username}
                   profile={profile}
                   index={index}
-                  onDelete={isAdmin ? handleDeleteProfile : undefined}
+                  onDelete={isGlobalAdminView ? handleDeleteProfile : undefined}
                   isDeleting={deletingProfile === profile.username}
                 />
               ))}
@@ -449,7 +489,7 @@ const Dashboard: React.FC = () => {
                   whileTap={{ scale: 0.95 }}
                 >
                   <PlusIcon className="w-5 h-5" />
-                  <span>{isAdmin ? 'Manage Profiles' : 'Add or request a profile'}</span>
+                  <span>{isGlobalAdminView ? 'Manage Profiles' : 'Choose or request a profile'}</span>
                 </motion.button>
                 
                 <motion.button 

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -22,6 +22,7 @@ import {
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import LoadingSpinner from '../components/LoadingSpinner';
 import ErrorMessage from '../components/ErrorMessage';
+import { ProfileAvatar } from '../components/insights/InsightUI';
 import toast from 'react-hot-toast';
 
 const REQUEST_STATUS_COPY: Record<ProfileRequestStatus, { label: string; description: string; className: string }> = {
@@ -47,6 +48,9 @@ const REQUEST_STATUS_COPY: Record<ProfileRequestStatus, { label: string; descrip
   },
 };
 
+const PROFILE_CATALOG_RESULT_LIMIT = 100;
+const PROFILE_CATALOG_SEARCH_DELAY_MS = 250;
+
 
 const ProfileManager: React.FC = () => {
   const searchParams = useSearchParams();
@@ -55,12 +59,15 @@ const ProfileManager: React.FC = () => {
   const isAdmin = currentUserQuery.data?.is_admin ?? false;
 
   const [searchTerm, setSearchTerm] = useState('');
+  const [catalogSearchTerm, setCatalogSearchTerm] = useState('');
+  const [debouncedCatalogSearchTerm, setDebouncedCatalogSearchTerm] = useState('');
   const [requestedUsername, setRequestedUsername] = useState('');
   const [isAddingProfile, setIsAddingProfile] = useState(false);
   const [newProfileUsername, setNewProfileUsername] = useState('');
   const [filterStatus, setFilterStatus] = useState<string>('all');
   const [deletingProfile, setDeletingProfile] = useState<string | null>(null);
   const [untrackingProfile, setUntrackingProfile] = useState<string | null>(null);
+  const [trackingProfileId, setTrackingProfileId] = useState<number | null>(null);
   const [adminNotes, setAdminNotes] = useState<Record<number, string>>({});
   const [exportFiles, setExportFiles] = useState<FileList | null>(null);
   const [hasOwnerPublishingConsent, setHasOwnerPublishingConsent] = useState(false);
@@ -75,9 +82,25 @@ const ProfileManager: React.FC = () => {
     }
   }, [isAdmin, searchParams, router]);
 
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedCatalogSearchTerm(catalogSearchTerm.trim());
+    }, PROFILE_CATALOG_SEARCH_DELAY_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [catalogSearchTerm]);
+
   const { data: profiles, isLoading, error } = useQuery({
     queryKey: ['profiles'],
     queryFn: profileApi.getProfiles,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const adminTrackedProfilesQuery = useQuery({
+    queryKey: ['profiles', 'tracked', 'profile-manager'],
+    queryFn: profileApi.getTrackedProfiles,
+    enabled: isAdmin,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -86,6 +109,16 @@ const ProfileManager: React.FC = () => {
     queryKey: ['profile-requests'],
     queryFn: profileApi.getRequests,
     staleTime: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const profileCatalogQuery = useQuery({
+    queryKey: ['profile-catalog', debouncedCatalogSearchTerm],
+    queryFn: () => profileApi.getCatalog(
+      debouncedCatalogSearchTerm,
+      PROFILE_CATALOG_RESULT_LIMIT,
+    ),
+    staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
@@ -99,7 +132,9 @@ const ProfileManager: React.FC = () => {
 
   const refreshProfileSurfaces = () => Promise.all([
     queryClient.invalidateQueries({ queryKey: ['profiles'] }),
+    queryClient.invalidateQueries({ queryKey: ['profile-catalog'] }),
     queryClient.invalidateQueries({ queryKey: ['profile-requests'] }),
+    queryClient.invalidateQueries({ queryKey: ['admin-profile-requests'] }),
     queryClient.invalidateQueries({ queryKey: ['dashboard-analytics'] }),
     queryClient.invalidateQueries({ queryKey: ['recent-changes'] }),
   ]);
@@ -117,6 +152,22 @@ const ProfileManager: React.FC = () => {
     },
     onError: (requestError: Error) => {
       toast.error(`Could not submit profile: ${requestError.message}`);
+    },
+  });
+
+  const trackCatalogProfileMutation = useMutation({
+    mutationFn: async (profileId: number) => {
+      setTrackingProfileId(profileId);
+      return profileApi.trackExisting(profileId);
+    },
+    onSuccess: (result) => {
+      void refreshProfileSurfaces();
+      setTrackingProfileId(null);
+      toast.success(`${result.profile.username} added to your monitored profiles.`);
+    },
+    onError: (trackError: Error) => {
+      setTrackingProfileId(null);
+      toast.error(`Could not monitor profile: ${trackError.message}`);
     },
   });
 
@@ -164,7 +215,7 @@ const ProfileManager: React.FC = () => {
   const addProfileMutation = useMutation({
     mutationFn: profileApi.createProfile,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profiles'] });
+      void refreshProfileSurfaces();
       setIsAddingProfile(false);
       setNewProfileUsername('');
       toast.success('Profile added successfully.');
@@ -180,7 +231,7 @@ const ProfileManager: React.FC = () => {
       return profileApi.deleteProfile(username);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['profiles'] });
+      void refreshProfileSurfaces();
       toast.success('Profile deleted successfully.');
       setDeletingProfile(null);
     },
@@ -193,7 +244,7 @@ const ProfileManager: React.FC = () => {
   const exportUploadMutation = useMutation({
     mutationFn: (files: FileList) => profileApi.uploadFiles(files, { publish_owner_data: true }),
     onSuccess: (result) => {
-      void queryClient.invalidateQueries({ queryKey: ['profiles'] });
+      void refreshProfileSurfaces();
       const loadedCount = result.loaded_profiles.length;
       const sourceKinds = Array.from(new Set((result.imports ?? []).map((item) => item.source_kind)));
       const provenanceCopy = sourceKinds.length > 0 ? ` Provenance: ${sourceKinds.join(', ')}.` : '';
@@ -209,6 +260,14 @@ const ProfileManager: React.FC = () => {
   });
 
   const profilesArray = Array.isArray(profiles) ? profiles : [];
+  const catalogProfiles = profileCatalogQuery.data?.profiles ?? [];
+  const catalogTotal = profileCatalogQuery.data?.total ?? 0;
+  const catalogResultLimit = profileCatalogQuery.data?.limit ?? PROFILE_CATALOG_RESULT_LIMIT;
+  const catalogProfileNoun = catalogTotal === 1 ? 'profile' : 'profiles';
+  const isCatalogSearchPending = catalogSearchTerm.trim() !== debouncedCatalogSearchTerm;
+  const monitoredProfileCount = isAdmin
+    ? adminTrackedProfilesQuery.data?.length
+    : profilesArray.length;
   const normalizedRequestedUsername = requestedUsername.trim().replace(/^@/, '');
   const filteredProfiles = profilesArray.filter((profile) => {
     const matchesSearch = profile.username.toLowerCase().includes(searchTerm.toLowerCase());
@@ -288,6 +347,99 @@ const ProfileManager: React.FC = () => {
         className="card-cinema"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.25 }}
+        aria-labelledby="profile-catalog-title"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="flex flex-wrap items-center gap-3">
+              <h2 id="profile-catalog-title" className="text-xl font-bold text-white">Choose profiles to monitor</h2>
+              <span className="rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-2.5 py-1 text-xs font-semibold text-cinema-200">
+                {isAdmin && adminTrackedProfilesQuery.error
+                  ? 'Monitoring count unavailable'
+                  : `${monitoredProfileCount ?? '…'} monitored`}
+              </span>
+            </div>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
+              Select any synced profile already in Spyboxd. Your choices are private to your account, power the Monitored view in My Dashboard, and can be changed at any time.
+              {isAdmin ? ' The default global admin dashboard and library controls remain explicit and separate.' : ''}
+            </p>
+          </div>
+          <label className="relative w-full lg:max-w-sm">
+            <span className="sr-only">Search available profiles</span>
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" />
+            <input
+              type="search"
+              placeholder="Search available profiles..."
+              value={catalogSearchTerm}
+              onChange={(event) => setCatalogSearchTerm(event.target.value)}
+              className="input-field w-full pl-10"
+            />
+          </label>
+        </div>
+
+        {profileCatalogQuery.isLoading || profileCatalogQuery.isFetching || isCatalogSearchPending ? (
+          <p className="mt-5 text-sm text-white/45">
+            {catalogSearchTerm.trim() ? 'Searching synced profiles…' : 'Loading available profiles…'}
+          </p>
+        ) : profileCatalogQuery.error ? (
+          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 rounded-xl border border-red-400/20 bg-red-400/5 p-4">
+            <p className="text-sm text-red-200">Available profiles could not be loaded.</p>
+            <button type="button" onClick={() => void profileCatalogQuery.refetch()} className="btn-secondary px-3 py-2 text-xs">Try again</button>
+          </div>
+        ) : catalogProfiles.length === 0 ? (
+          <p className="mt-5 rounded-xl border border-white/10 bg-black/15 p-4 text-sm text-white/45">
+            {catalogSearchTerm.trim() ? 'No synced profiles match that search.' : 'No synced profiles are available yet.'}
+          </p>
+        ) : (
+          <>
+            <p className="mt-5 text-xs text-white/45" data-testid="profile-catalog-result-summary">
+              {catalogProfiles.length === catalogTotal
+                ? `${catalogTotal.toLocaleString()} ${debouncedCatalogSearchTerm ? 'matching ' : ''}synced ${catalogProfileNoun}`
+                : `Showing ${catalogProfiles.length.toLocaleString()} of ${catalogTotal.toLocaleString()} ${debouncedCatalogSearchTerm ? 'matching ' : ''}synced ${catalogProfileNoun}`}
+              {catalogTotal > catalogProfiles.length
+                ? ` · Results are limited to ${catalogResultLimit.toLocaleString()} per search; refine the search to find the rest.`
+                : ''}
+            </p>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {catalogProfiles.map((profile) => {
+                const isBusy = trackingProfileId === profile.id || untrackingProfile === profile.username;
+                return (
+                  <article key={profile.id} className="flex min-w-0 items-center gap-3 rounded-xl border border-white/10 bg-black/15 p-3">
+                    <ProfileAvatar profile={profile} size="lg" />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-semibold text-white">{profile.display_name || profile.username}</p>
+                      <p className="truncate text-xs text-white/45">@{profile.username} · {profile.total_films.toLocaleString()} films</p>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={isBusy}
+                      onClick={() => {
+                        if (profile.is_tracked) {
+                          untrackProfileMutation.mutate(profile.username);
+                        } else {
+                          trackCatalogProfileMutation.mutate(profile.id);
+                        }
+                      }}
+                      aria-label={`${profile.is_tracked ? 'Stop monitoring' : 'Monitor'} ${profile.username}`}
+                      className={profile.is_tracked
+                        ? 'rounded-lg border border-emerald-400/25 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-200 transition-colors hover:bg-emerald-400/20 disabled:opacity-50'
+                        : 'rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-3 py-2 text-xs font-semibold text-cinema-200 transition-colors hover:bg-cinema-500/20 disabled:opacity-50'}
+                    >
+                      {isBusy ? 'Saving…' : profile.is_tracked ? 'Monitoring' : 'Monitor'}
+                    </button>
+                  </article>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </motion.section>
+
+      <motion.section
+        className="card-cinema"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.3 }}
       >
         <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,.75fr)] lg:items-end">
@@ -297,9 +449,9 @@ const ProfileManager: React.FC = () => {
                 <UserPlus className="h-5 w-5" />
               </span>
               <div>
-                <h2 className="text-xl font-bold text-white">Track a Letterboxd profile</h2>
+                <h2 className="text-xl font-bold text-white">Request a profile that is not listed</h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-white/60">
-                  Existing profiles are added immediately. New usernames are sent for review and, once accepted, queued for the next residential full sync.
+                  Enter a Letterboxd username that Spyboxd does not have yet. It will be sent for review and, once accepted, queued for the next residential full sync.
                 </p>
               </div>
             </div>
@@ -648,7 +800,7 @@ const ProfileManager: React.FC = () => {
       >
         <AnimatePresence mode="popLayout">
           {filteredProfiles.length > 0 ? (
-            <motion.div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" layout>
+            <motion.div data-testid="tracked-profile-grid" className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" layout>
               {filteredProfiles.map((profile) => {
                 const badge = getStatusBadge(profile.scraping_status);
                 const coverageSummary =

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { UserButton, useAuth } from '@clerk/nextjs';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { Activity, CalendarClock, Film, MessageCircle, Radar, Star, Users } from 'lucide-react';
+import ActivityChart from '../components/Charts/ActivityChart';
+import RatingDistributionChart from '../components/Charts/RatingDistributionChart';
+import StatsCard from '../components/Charts/StatsCard';
+import ErrorMessage from '../components/ErrorMessage';
+import LoadingSpinner from '../components/LoadingSpinner';
+import { publicDashboardApi } from '../services/api';
+
+export default function PublicDashboard() {
+  const { isSignedIn } = useAuth();
+  const dashboardQuery = useQuery({
+    queryKey: ['public-dashboard-analytics'],
+    queryFn: publicDashboardApi.getAnalytics,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  if (dashboardQuery.isLoading) return <LoadingSpinner message="Loading Spyboxd totals…" />;
+  if (dashboardQuery.error || !dashboardQuery.data) {
+    return <ErrorMessage message="The public dashboard could not be loaded." />;
+  }
+
+  const analytics = dashboardQuery.data;
+  const stats = analytics.system_stats;
+  const signals = analytics.signal_counts;
+  const lastSync = analytics.data_health.last_synced_at
+    ? new Date(analytics.data_health.last_synced_at).toLocaleDateString()
+    : 'Not yet';
+
+  return (
+    <main className="min-h-screen px-4 py-6 sm:px-8 lg:px-12" data-testid="public-dashboard">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <header className="flex flex-col gap-5 border-b border-white/10 pb-6 sm:flex-row sm:items-center sm:justify-between">
+          <Link href="/" className="flex items-center gap-3" aria-label="Spyboxd public dashboard">
+            <span className="grid h-11 w-11 place-items-center rounded-xl bg-gradient-to-br from-cinema-400 to-cinema-600 text-xl font-black text-white shadow-glow">S</span>
+            <span>
+              <span className="block text-xl font-bold text-white">Spyboxd</span>
+              <span className="block text-xs text-white/45">Aggregate Letterboxd signals</span>
+            </span>
+          </Link>
+          <div className="flex items-center gap-3">
+            {isSignedIn ? (
+              <>
+                <Link href="/dashboard" className="btn-primary">Open My Dashboard</Link>
+                <UserButton />
+              </>
+            ) : (
+              <Link href="/sign-in?redirect_url=%2Fprofiles" className="btn-primary">Sign in to monitor profiles</Link>
+            )}
+          </div>
+        </header>
+
+        <motion.section
+          className="space-y-3 py-4"
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+        >
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cinema-300">Public dashboard</p>
+          <h1 className="max-w-4xl text-4xl font-bold leading-tight text-white text-glow sm:text-5xl">
+            Movie activity at a glance, without exposing anyone&apos;s profile.
+          </h1>
+          <p className="max-w-3xl text-base leading-7 text-white/60">
+            These are database-wide totals and anonymous distributions. Sign in to choose the profiles you monitor, compare people, and investigate same-day watches.
+          </p>
+        </motion.section>
+
+        <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4" aria-label="Aggregate totals">
+          <StatsCard title="Profiles analyzed" value={stats.total_profiles} subtitle={`${analytics.data_health.completed_profiles} ready for analysis`} icon={Users} />
+          <StatsCard title="Unique films" value={stats.total_movies_tracked} subtitle="Across the aggregate dataset" icon={Film} gradient="from-blue-500/20 to-blue-600/10" delay={0.05} />
+          <StatsCard title="Reviews" value={stats.total_reviews} subtitle="Imported review records" icon={MessageCircle} gradient="from-purple-500/20 to-purple-600/10" delay={0.1} />
+          <StatsCard title="Average rating" value={stats.global_avg_rating.toFixed(1)} subtitle="Across rated entries" icon={Star} gradient="from-yellow-500/20 to-yellow-600/10" delay={0.15} />
+        </section>
+
+        <section className="grid grid-cols-1 gap-8 xl:grid-cols-2" aria-label="Aggregate charts">
+          <RatingDistributionChart data={analytics.rating_distribution} globalAverage={stats.global_avg_rating} />
+          <ActivityChart data={analytics.activity_data} />
+        </section>
+
+        <section className="card-cinema overflow-hidden" aria-labelledby="anonymous-signals-title">
+          <div className="flex items-start gap-4">
+            <span className="rounded-2xl border border-cinema-400/30 bg-cinema-500/15 p-3 text-cinema-300"><Radar className="h-7 w-7" /></span>
+            <div>
+              <h2 id="anonymous-signals-title" className="text-2xl font-bold text-white">Anonymous spy-signal totals</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">Counts show how much overlap exists in the dataset. Names, profile pairs, titles, ratings, and watch dates stay inside the signed-in workspace.</p>
+            </div>
+          </div>
+          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <AggregateSignal icon={Activity} label="Same-day events" value={signals.same_day_events} />
+            <AggregateSignal icon={CalendarClock} label="One-day echoes" value={signals.one_day_gap_events} />
+            <AggregateSignal icon={Film} label="Shared titles" value={signals.shared_titles} />
+            <AggregateSignal icon={Users} label="Profiles with dates" value={signals.profiles_with_diary_dates} />
+          </div>
+          <div className="mt-6 flex flex-col gap-4 border-t border-white/10 pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-white/45">Latest completed profile sync: <span className="font-medium text-white/70">{lastSync}</span></p>
+            <Link href={isSignedIn ? '/profiles' : '/sign-in?redirect_url=%2Fprofiles'} className="btn-secondary text-center">
+              {isSignedIn ? 'Choose monitored profiles' : 'Sign in for private tools'}
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}
+
+function AggregateSignal({ icon: Icon, label, value }: { icon: typeof Activity; label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/15 p-4">
+      <Icon className="h-5 w-5 text-cinema-300" />
+      <p className="mt-3 text-2xl font-bold text-white">{value.toLocaleString()}</p>
+      <p className="mt-1 text-xs text-white/50">{label}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- make `/` a strictly aggregate public dashboard and move the existing private dashboard to `/dashboard`
- protect every profile-bearing page and API, including the legacy profile snapshot route
- add authenticated catalog search, per-user monitoring controls, and missing-profile requests
- preserve the admin global dashboard and management workflow
- extend production smoke checks for the public schema and private route boundaries

## Verification
- 187 backend tests passed
- Alembic model/schema parity passed
- frontend typecheck, lint, and production build passed
- 48 Playwright tests passed across desktop and mobile
- 28 Clerk/deployment guard tests passed
- local rendered anonymous and protected-route checks passed