### PR TITLE
Fix analysis panel flicker

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -148,6 +148,57 @@ const publicDashboard = {
   timestamp: '2026-07-29T12:00:00Z',
 };
 
+const profileAnalysis = {
+  username: 'alpha',
+  total_films: 1_200,
+  rated_films: 900,
+  liked_films: 180,
+  avg_rating: 3.7,
+  total_reviews: 2,
+  join_date: '2020-01-01',
+  last_scraped_at: '2026-07-29T12:00:00Z',
+  scraping_status: 'completed',
+  enhanced_metrics: {},
+  data_coverage: profiles[0].data_coverage,
+  rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
+  monthly_stats: [
+    { month: '2026-06', movies_watched: 20, average_rating: 3.8 },
+    { month: '2026-07', movies_watched: 24, average_rating: 3.9 },
+  ],
+  recent_watching_trend: Array.from({ length: 8 }, (_, index) => ({
+    movie_title: `Recent Watch ${index + 1}`,
+    movie_year: 2026,
+    watched_date: `2026-07-${String(29 - index).padStart(2, '0')}`,
+    rating: 4,
+    is_rewatch: false,
+  })),
+  recent_ratings: Array.from({ length: 12 }, (_, index) => ({
+    movie_title: `Recent Rating ${index + 1}`,
+    movie_year: 2026,
+    watched_date: null,
+    rating: 3.5 + (index % 3) * 0.5,
+    is_rewatch: false,
+  })),
+  recent_reviews: [
+    {
+      movie_title: 'Short Review',
+      movie_year: 2026,
+      rating: 4.5,
+      review_text: 'A concise fixture review.',
+      published_date: '2026-07-29',
+      likes_count: 0,
+    },
+    {
+      movie_title: 'Another Review',
+      movie_year: 2026,
+      rating: 4,
+      review_text: 'A second concise fixture review.',
+      published_date: '2026-07-28',
+      likes_count: 0,
+    },
+  ],
+};
+
 const dataCoverage = {
   generated_at: '2026-07-29T12:00:00Z',
   overall_score: 100,
@@ -278,6 +329,13 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   if (path === '/api/me') return json(route, { user_id: 'user_e2e', is_admin: isAdmin });
   if (path === '/profiles' && method === 'GET') return json(route, { profiles: state.profiles });
   if (path === '/profiles/tracked' && method === 'GET') return json(route, { profiles: state.profiles });
+  const analysisMatch = path.match(/^\/profiles\/([^/]+)\/analysis$/);
+  if (analysisMatch && method === 'GET') {
+    return json(route, {
+      ...profileAnalysis,
+      username: decodeURIComponent(analysisMatch[1]),
+    });
+  }
   if (path === '/profiles/catalog' && method === 'GET') {
     const search = (url.searchParams.get('search') ?? '').trim().toLowerCase();
     const limit = Number(url.searchParams.get('limit') ?? 100);

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -67,6 +67,54 @@ test('signed-in public homepage remains aggregate-only', async ({ page }) => {
   await expect(page.getByText('Most Active Profile', { exact: true })).toHaveCount(0);
 });
 
+test('analysis list panels keep intrinsic heights without animated glass artifacts', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const watchesPanel = page.getByRole('heading', { name: 'Recent Watches', exact: true }).locator('..');
+  const coveragePanel = page.getByRole('heading', { name: 'Coverage Notes', exact: true }).locator('..');
+  const ratingsPanel = page.getByRole('heading', { name: 'Recent Ratings', exact: true }).locator('..');
+  const reviewsPanel = page.getByRole('heading', { name: 'Recent Reviews', exact: true }).locator('..');
+
+  await expect(ratingsPanel).toBeVisible();
+  for (const panel of [watchesPanel, coveragePanel, ratingsPanel, reviewsPanel]) {
+    const compositorStyles = await panel.evaluate((element) => {
+      const styles = window.getComputedStyle(element);
+      return {
+        backdropFilter: styles.backdropFilter,
+        boxShadow: styles.boxShadow,
+        transitionDuration: styles.transitionDuration,
+      };
+    });
+    expect(compositorStyles).toEqual({
+      backdropFilter: 'none',
+      boxShadow: 'none',
+      transitionDuration: '0s',
+    });
+  }
+
+  if ((page.viewportSize()?.width ?? 0) >= 1280) {
+    const [watchesBox, coverageBox, ratingsBox, reviewsBox] = await Promise.all([
+      watchesPanel.boundingBox(),
+      coveragePanel.boundingBox(),
+      ratingsPanel.boundingBox(),
+      reviewsPanel.boundingBox(),
+    ]);
+    expect(coverageBox!.height).toBeLessThan(watchesBox!.height);
+    expect(reviewsBox!.height).toBeLessThan(ratingsBox!.height);
+  }
+
+  const shimmers = page.getByTestId('stats-card-shimmer');
+  expect(await shimmers.count()).toBeGreaterThan(0);
+  const shimmerTransformsBefore = await shimmers.evaluateAll((elements) => (
+    elements.map((element) => window.getComputedStyle(element).transform)
+  ));
+  await page.waitForTimeout(300);
+  const shimmerTransformsAfter = await shimmers.evaluateAll((elements) => (
+    elements.map((element) => window.getComputedStyle(element).transform)
+  ));
+  expect(shimmerTransformsAfter).toEqual(shimmerTransformsBefore);
+});
+
 test('profiles can be searched without hiding matching data', async ({ page }) => {
   await page.goto('/profiles');
 

--- a/frontend/src/components/Charts/StatsCard.tsx
+++ b/frontend/src/components/Charts/StatsCard.tsx
@@ -41,19 +41,10 @@ const StatsCard: React.FC<StatsCardProps> = ({
       }}
     >
       {/* Animated background gradient */}
-      <motion.div
-        className="absolute inset-0 bg-gradient-to-r from-transparent via-cinema-400/5 to-transparent"
-        animate={{
-          x: ['-100%', '100%'],
-        }}
-        transition={{
-          duration: 3,
-          repeat: Infinity,
-          repeatType: 'loop',
-          ease: 'linear',
-        }}
-        style={{ opacity: 0 }}
-        whileHover={{ opacity: 1 }}
+      <div
+        aria-hidden="true"
+        data-testid="stats-card-shimmer"
+        className="pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-cinema-400/5 to-transparent opacity-0 group-hover:translate-x-full group-hover:opacity-100 group-hover:transition-transform group-hover:duration-1000 group-hover:ease-linear"
       />
 
       <div className="relative z-10">
@@ -91,17 +82,9 @@ const StatsCard: React.FC<StatsCardProps> = ({
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: delay + 0.2, duration: 0.5 }}
         >
-          <motion.h3 
-            className="text-3xl font-bold text-white text-glow"
-            animate={{ textShadow: [
-              "0 0 20px rgba(229, 81, 0, 0.5)",
-              "0 0 30px rgba(229, 81, 0, 0.7)",
-              "0 0 20px rgba(229, 81, 0, 0.5)"
-            ]}}
-            transition={{ duration: 2, repeat: Infinity }}
-          >
+          <h3 className="text-3xl font-bold text-white text-glow">
             {typeof value === 'number' ? value.toLocaleString() : value}
-          </motion.h3>
+          </h3>
         </motion.div>
 
         {/* Title and Subtitle */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -78,6 +78,12 @@
            hover:from-cinema-500/20 hover:to-cinema-600/10 hover:border-cinema-400/30
            transition-all duration-500;
   }
+
+  /* Stable treatment for tall, non-interactive analysis panels. */
+  .analysis-panel {
+    @apply rounded-2xl border border-cinema-400/20 bg-gradient-to-br
+           from-cinema-500/10 to-cinema-600/5 p-6;
+  }
   
   .card-noir {
     @apply bg-noir-800/50 backdrop-blur-md rounded-2xl border border-noir-700/50 

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -173,9 +173,9 @@ const Analysis: React.FC = () => {
             />
           </div>
 
-          <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+          <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-3">
             <motion.div
-              className="card-cinema xl:col-span-2"
+              className="analysis-panel xl:col-span-2"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}
@@ -215,7 +215,7 @@ const Analysis: React.FC = () => {
             </motion.div>
 
             <motion.div
-              className="card-cinema"
+              className="analysis-panel"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.25 }}
@@ -242,9 +242,9 @@ const Analysis: React.FC = () => {
             </motion.div>
           </div>
 
-          <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          <div className="grid grid-cols-1 items-start gap-6 xl:grid-cols-2">
             <motion.div
-              className="card-cinema"
+              className="analysis-panel"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.3 }}
@@ -279,7 +279,7 @@ const Analysis: React.FC = () => {
             </motion.div>
 
             <motion.div
-              className="card-cinema"
+              className="analysis-panel"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.35 }}


### PR DESCRIPTION
## Summary
- keep the four long analysis panels at their intrinsic content height
- remove blur, shadow, and hover transitions from those non-interactive panels
- replace continuously running invisible stat-card animations with hover-only CSS
- add desktop and mobile regression coverage for panel geometry and idle shimmer behavior

## Verification
- npm run lint
- npm run typecheck
- CI=1 npm run test:e2e (50 passed)