### PR TITLE
Restore visible login and logout controls

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,6 +1,17 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 import { installApiMocks } from './fixtures/api';
+
+const publicDashboardUrl = /^http:\/\/(?:127\.0\.0\.1|localhost):8000\/api\/public\/dashboard$/;
+
+async function expectPublicAuthControl(page: Page, authenticated: boolean) {
+  if (authenticated) {
+    await expect(page.getByRole('button', { name: 'Sign out', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open user menu' })).toBeVisible();
+    return;
+  }
+  await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
+}
 
 test('the aggregate dashboard is the anonymous landing page', async ({ page }) => {
   await installApiMocks(page, { authenticated: false });
@@ -30,7 +41,47 @@ test('the aggregate dashboard is the anonymous landing page', async ({ page }) =
   expect(apiRequests.length).toBeGreaterThanOrEqual(1);
   expect(apiRequests.every(({ path }) => path === '/api/public/dashboard')).toBe(true);
   expect(apiRequests.every(({ authorization }) => authorization === undefined)).toBe(true);
+
+  await signInLink.click();
+  await expect(page).toHaveURL(/\/sign-in(?:\/|\?|$)/);
+  await expect(page.getByRole('heading', { name: 'Sign in', exact: true })).toBeVisible();
 });
+
+for (const authenticated of [false, true]) {
+  const authState = authenticated ? 'signed-in' : 'anonymous';
+
+  test(`the ${authState} public auth header remains available while aggregate data loads`, async ({ page }) => {
+    await installApiMocks(page, { authenticated });
+    let releaseRequest!: () => void;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    await page.route(publicDashboardUrl, async (route) => {
+      await requestGate;
+      await route.fallback();
+    });
+
+    await page.goto('/');
+
+    await expectPublicAuthControl(page, authenticated);
+    await expect(page.getByText('Loading Spyboxd totals…')).toBeVisible();
+
+    releaseRequest();
+    await expect(page.getByRole('heading', { name: /without exposing anyone's profile/i })).toBeVisible();
+  });
+
+  test(`the ${authState} public auth header remains available when aggregate data fails`, async ({ page }) => {
+    await installApiMocks(page, { authenticated });
+    await page.route(publicDashboardUrl, (route) => (
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ detail: 'Unavailable' }) })
+    ));
+
+    await page.goto('/');
+
+    await expectPublicAuthControl(page, authenticated);
+    await expect(page.getByText('The public dashboard could not be loaded.')).toBeVisible();
+  });
+}
 
 for (const path of ['/dashboard', '/profiles', '/analysis', '/compare', '/spy-signals', '/watch-together', '/u/alpha']) {
   test(`an anonymous visitor cannot bypass auth with ${path}`, async ({ page }) => {

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -503,7 +503,10 @@ export async function installApiMocks(
   }
 
   await page.addInitScript(({ signedIn }) => {
-    const user = signedIn ? {
+    const effectiveSignedIn = signedIn && document.cookie.split(';').some((cookie) => (
+      cookie.trim() === 'spyboxd-e2e-auth=1'
+    ));
+    const user = effectiveSignedIn ? {
       id: 'user_e2e',
       firstName: 'E2E',
       lastName: 'User',
@@ -513,7 +516,7 @@ export async function installApiMocks(
       hasImage: false,
       organizationMemberships: [],
     } : null;
-    const session = signedIn ? {
+    const session = effectiveSignedIn ? {
       id: 'sess_e2e',
       status: 'active',
       user,
@@ -532,7 +535,7 @@ export async function installApiMocks(
     const clerk = {
       loaded: true,
       status: 'ready',
-      isSignedIn: false,
+      isSignedIn: effectiveSignedIn,
       client: resources.client,
       session: resources.session,
       user: resources.user,
@@ -558,7 +561,11 @@ export async function installApiMocks(
       buildAfterSignOutUrl: () => '/',
       openSignIn: () => undefined,
       load: async () => undefined,
-      signOut: async () => undefined,
+      signOut: async (options?: { redirectUrl?: string }) => {
+        document.cookie = 'spyboxd-e2e-auth=; Max-Age=0; Path=/; SameSite=Lax';
+        document.cookie = 'spyboxd-e2e-auth=; Max-Age=0; Path=/; Domain=localhost; SameSite=Lax';
+        window.location.assign(options?.redirectUrl ?? '/');
+      },
       mountUserButton(node: HTMLElement) {
         const button = document.createElement('button');
         button.type = 'button';

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type ConsoleMessage, type Page, type TestInfo } from '@playwright/test';
+import { expect, test, type ConsoleMessage, type Locator, type Page, type TestInfo } from '@playwright/test';
 
 import { installApiMocks, MISSING_POSTER_URL } from './fixtures/api';
 
@@ -10,6 +10,9 @@ function isExpectedMissingPosterError(message: ConsoleMessage): boolean {
 }
 
 async function expectAccountControl(page: Page) {
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  await expect(signOut).toBeVisible();
+  await expectInsideViewport(page, signOut);
   if ((page.viewportSize()?.width ?? 0) < 1024) {
     await page.getByRole('button', { name: 'Open navigation' }).click();
     await expect(page.getByRole('button', { name: 'Open user menu' })).toBeVisible();
@@ -17,6 +20,18 @@ async function expectAccountControl(page: Page) {
     return;
   }
   await expect(page.getByRole('button', { name: 'Open user menu' })).toBeVisible();
+}
+
+async function expectInsideViewport(page: Page, locator: Locator) {
+  await expect.poll(async () => {
+    const viewport = page.viewportSize();
+    const box = await locator.boundingBox();
+    if (!viewport || !box) return false;
+    return box.x >= 0
+      && box.y >= 0
+      && box.x + box.width <= viewport.width
+      && box.y + box.height <= viewport.height;
+  }).toBe(true);
 }
 
 test.beforeEach(async ({ page }) => {
@@ -58,13 +73,45 @@ test('signed-in private dashboard renders the scoped data and navigates to My Pr
   await expect(page.getByRole('heading', { level: 1, name: 'My Profiles', exact: true })).toBeVisible();
 });
 
+test('private workspace sign out returns to the anonymous dashboard', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  await expect(signOut).toBeVisible();
+  await expectInsideViewport(page, signOut);
+  await signOut.click();
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
+});
+
+test('insight workspace sign out returns to the anonymous dashboard', async ({ page }) => {
+  await page.goto('/compare');
+
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  await expect(signOut).toBeVisible();
+  await expectInsideViewport(page, signOut);
+  await signOut.click();
+
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
+});
+
 test('signed-in public homepage remains aggregate-only', async ({ page }) => {
   await page.goto('/');
 
   await expect(page.getByTestId('public-dashboard')).toBeVisible();
   await expect(page.getByRole('link', { name: 'Open My Dashboard' })).toBeVisible();
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  await expect(signOut).toBeVisible();
+  await expectInsideViewport(page, signOut);
+  await expect(page.getByRole('button', { name: 'Open user menu' })).toBeVisible();
   await expect(page.getByText('@alpha', { exact: true })).toHaveCount(0);
   await expect(page.getByText('Most Active Profile', { exact: true })).toHaveCount(0);
+
+  await signOut.click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
 });
 
 test('analysis list panels keep intrinsic heights without animated glass artifacts', async ({ page }) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { UserButton, useAuth } from '@clerk/nextjs';
+import { SignOutButton, UserButton, useAuth } from '@clerk/nextjs';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   HomeIcon,
@@ -19,7 +19,7 @@ import {
   SignalIcon as SignalIconSolid,
   ScaleIcon as ScaleIconSolid,
 } from '@heroicons/react/24/solid';
-import { Menu, UsersRound, X } from 'lucide-react';
+import { LogOut, Menu, UsersRound, X } from 'lucide-react';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -85,6 +85,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`);
   const activeItem = NAVIGATION_ITEMS.find((item) => isActive(item.path));
   const isInsightWorkspace = isActive('/compare') || isActive('/watch-together');
+  const signInHref = `/sign-in?redirect_url=${encodeURIComponent(pathname)}`;
 
   return (
     <motion.div 
@@ -128,15 +129,35 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 <p className="hidden text-sm font-medium text-white/60 lg:block">User Analytics</p>
               </div>
             </div>
-            <button
-              type="button"
-              onClick={() => setMobileNavOpen((open) => !open)}
-              className="grid h-10 w-10 place-items-center rounded-lg border border-white/10 text-white/70 hover:bg-white/5 hover:text-white lg:hidden"
-              aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
-              aria-expanded={mobileNavOpen}
-            >
-              {mobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            </button>
+            <div className="flex items-center gap-2 lg:hidden">
+              {isSignedIn ? (
+                <SignOutButton redirectUrl="/">
+                  <button
+                    type="button"
+                    className="inline-flex h-10 items-center gap-2 rounded-lg border border-white/10 px-3 text-xs font-semibold text-white/70 hover:border-cinema-400/30 hover:bg-cinema-500/10 hover:text-white"
+                  >
+                    <LogOut className="h-4 w-4" />
+                    Sign out
+                  </button>
+                </SignOutButton>
+              ) : (
+                <Link
+                  href={signInHref}
+                  className="inline-flex h-10 items-center rounded-lg border border-white/10 px-3 text-xs font-semibold text-white/70 hover:border-cinema-400/30 hover:bg-cinema-500/10 hover:text-white"
+                >
+                  Sign in
+                </Link>
+              )}
+              <button
+                type="button"
+                onClick={() => setMobileNavOpen((open) => !open)}
+                className="grid h-10 w-10 place-items-center rounded-lg border border-white/10 text-white/70 hover:bg-white/5 hover:text-white"
+                aria-label={mobileNavOpen ? 'Close navigation' : 'Open navigation'}
+                aria-expanded={mobileNavOpen}
+              >
+                {mobileNavOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+              </button>
+            </div>
           </motion.div>
 
           <div className={`${mobileNavOpen ? 'mt-4 flex' : 'hidden'} min-h-0 flex-1 flex-col lg:mt-0 lg:flex`}>
@@ -161,7 +182,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             </motion.div>
 
             {/* Navigation Items */}
-            <div className="flex-1 space-y-2">
+            <div className="min-h-0 flex-1 space-y-2 overflow-y-auto overscroll-contain pr-1">
             {NAVIGATION_ITEMS.map((item, index) => {
               const Icon = isActive(item.path) ? item.activeIcon : item.icon;
               return (
@@ -226,13 +247,32 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             })}
             </div>
 
-            <div className="mt-5 hidden items-center gap-3 border-t border-white/10 pt-4 text-sm text-white/60 lg:flex">
-              {isSignedIn && <><UserButton /> Account</>}
-            </div>
+            {isInsightWorkspace && (
+              <div className="mt-5 hidden items-center justify-between gap-3 border-t border-white/10 pt-4 text-sm text-white/60 lg:flex">
+                {isSignedIn ? (
+                  <>
+                    <div className="flex items-center gap-3"><UserButton /> Account</div>
+                    <SignOutButton redirectUrl="/">
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-xs font-semibold text-white/65 hover:border-cinema-400/30 hover:bg-cinema-500/10 hover:text-white"
+                      >
+                        <LogOut className="h-4 w-4" />
+                        Sign out
+                      </button>
+                    </SignOutButton>
+                  </>
+                ) : (
+                  <Link href={signInHref} className="font-semibold text-cinema-300 hover:text-cinema-200">Sign in</Link>
+                )}
+              </div>
+            )}
 
             <div className="mt-5 border-t border-white/10 pt-4 lg:hidden">
-              {isSignedIn && (
-                <div className="flex items-center gap-3 text-sm text-white/60"><UserButton /> Signed in</div>
+              {isSignedIn ? (
+                <div className="flex items-center gap-3 text-sm text-white/60"><UserButton /> Account</div>
+              ) : (
+                <Link href={signInHref} className="text-sm font-semibold text-cinema-300 hover:text-cinema-200">Sign in</Link>
               )}
             </div>
           </div>
@@ -267,6 +307,24 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 {activeItem?.description || 'Welcome to Spyboxd'}
               </motion.p>
             </div>
+            {!isInsightWorkspace && (
+              isSignedIn ? (
+                <div className="flex items-center gap-3">
+                  <UserButton />
+                  <SignOutButton redirectUrl="/">
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-2 rounded-lg border border-white/10 px-3 py-2 text-sm font-semibold text-white/70 hover:border-cinema-400/30 hover:bg-cinema-500/10 hover:text-white"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      Sign out
+                    </button>
+                  </SignOutButton>
+                </div>
+              ) : (
+                <Link href={signInHref} className="btn-secondary">Sign in</Link>
+              )
+            )}
           </div>
         </motion.header>
 

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { UserButton, useAuth } from '@clerk/nextjs';
+import { SignOutButton, UserButton, useAuth } from '@clerk/nextjs';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { Activity, CalendarClock, Film, MessageCircle, Radar, Star, Users } from 'lucide-react';
 import ActivityChart from '../components/Charts/ActivityChart';
 import RatingDistributionChart from '../components/Charts/RatingDistributionChart';
@@ -21,9 +22,18 @@ export default function PublicDashboard() {
     refetchOnWindowFocus: false,
   });
 
-  if (dashboardQuery.isLoading) return <LoadingSpinner message="Loading Spyboxd totals…" />;
+  const renderShell = (content: ReactNode) => (
+    <main className="min-h-screen px-4 py-6 sm:px-8 lg:px-12" data-testid="public-dashboard">
+      <div className="mx-auto max-w-7xl space-y-8">
+        <PublicHeader isSignedIn={isSignedIn} />
+        {content}
+      </div>
+    </main>
+  );
+
+  if (dashboardQuery.isLoading) return renderShell(<LoadingSpinner message="Loading Spyboxd totals…" />);
   if (dashboardQuery.error || !dashboardQuery.data) {
-    return <ErrorMessage message="The public dashboard could not be loaded." />;
+    return renderShell(<ErrorMessage message="The public dashboard could not be loaded." />);
   }
 
   const analytics = dashboardQuery.data;
@@ -33,78 +43,83 @@ export default function PublicDashboard() {
     ? new Date(analytics.data_health.last_synced_at).toLocaleDateString()
     : 'Not yet';
 
-  return (
-    <main className="min-h-screen px-4 py-6 sm:px-8 lg:px-12" data-testid="public-dashboard">
-      <div className="mx-auto max-w-7xl space-y-8">
-        <header className="flex flex-col gap-5 border-b border-white/10 pb-6 sm:flex-row sm:items-center sm:justify-between">
-          <Link href="/" className="flex items-center gap-3" aria-label="Spyboxd public dashboard">
-            <span className="grid h-11 w-11 place-items-center rounded-xl bg-gradient-to-br from-cinema-400 to-cinema-600 text-xl font-black text-white shadow-glow">S</span>
-            <span>
-              <span className="block text-xl font-bold text-white">Spyboxd</span>
-              <span className="block text-xs text-white/45">Aggregate Letterboxd signals</span>
-            </span>
+  return renderShell(
+    <>
+      <motion.section
+        className="space-y-3 py-4"
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+      >
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cinema-300">Public dashboard</p>
+        <h1 className="max-w-4xl text-4xl font-bold leading-tight text-white text-glow sm:text-5xl">
+          Movie activity at a glance, without exposing anyone&apos;s profile.
+        </h1>
+        <p className="max-w-3xl text-base leading-7 text-white/60">
+          These are database-wide totals and anonymous distributions. Sign in to choose the profiles you monitor, compare people, and investigate same-day watches.
+        </p>
+      </motion.section>
+
+      <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4" aria-label="Aggregate totals">
+        <StatsCard title="Profiles analyzed" value={stats.total_profiles} subtitle={`${analytics.data_health.completed_profiles} ready for analysis`} icon={Users} />
+        <StatsCard title="Unique films" value={stats.total_movies_tracked} subtitle="Across the aggregate dataset" icon={Film} gradient="from-blue-500/20 to-blue-600/10" delay={0.05} />
+        <StatsCard title="Reviews" value={stats.total_reviews} subtitle="Imported review records" icon={MessageCircle} gradient="from-purple-500/20 to-purple-600/10" delay={0.1} />
+        <StatsCard title="Average rating" value={stats.global_avg_rating.toFixed(1)} subtitle="Across rated entries" icon={Star} gradient="from-yellow-500/20 to-yellow-600/10" delay={0.15} />
+      </section>
+
+      <section className="grid grid-cols-1 gap-8 xl:grid-cols-2" aria-label="Aggregate charts">
+        <RatingDistributionChart data={analytics.rating_distribution} globalAverage={stats.global_avg_rating} />
+        <ActivityChart data={analytics.activity_data} />
+      </section>
+
+      <section className="card-cinema overflow-hidden" aria-labelledby="anonymous-signals-title">
+        <div className="flex items-start gap-4">
+          <span className="rounded-2xl border border-cinema-400/30 bg-cinema-500/15 p-3 text-cinema-300"><Radar className="h-7 w-7" /></span>
+          <div>
+            <h2 id="anonymous-signals-title" className="text-2xl font-bold text-white">Anonymous spy-signal totals</h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">Counts show how much overlap exists in the dataset. Names, profile pairs, titles, ratings, and watch dates stay inside the signed-in workspace.</p>
+          </div>
+        </div>
+        <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <AggregateSignal icon={Activity} label="Same-day events" value={signals.same_day_events} />
+          <AggregateSignal icon={CalendarClock} label="One-day echoes" value={signals.one_day_gap_events} />
+          <AggregateSignal icon={Film} label="Shared titles" value={signals.shared_titles} />
+          <AggregateSignal icon={Users} label="Profiles with dates" value={signals.profiles_with_diary_dates} />
+        </div>
+        <div className="mt-6 flex flex-col gap-4 border-t border-white/10 pt-6 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-white/45">Latest completed profile sync: <span className="font-medium text-white/70">{lastSync}</span></p>
+          <Link href={isSignedIn ? '/profiles' : '/sign-in?redirect_url=%2Fprofiles'} className="btn-secondary text-center">
+            {isSignedIn ? 'Choose monitored profiles' : 'Sign in for private tools'}
           </Link>
-          <div className="flex items-center gap-3">
-            {isSignedIn ? (
-              <>
-                <Link href="/dashboard" className="btn-primary">Open My Dashboard</Link>
-                <UserButton />
-              </>
-            ) : (
-              <Link href="/sign-in?redirect_url=%2Fprofiles" className="btn-primary">Sign in to monitor profiles</Link>
-            )}
-          </div>
-        </header>
+        </div>
+      </section>
+    </>
+  );
+}
 
-        <motion.section
-          className="space-y-3 py-4"
-          initial={{ opacity: 0, y: 16 }}
-          animate={{ opacity: 1, y: 0 }}
-        >
-          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cinema-300">Public dashboard</p>
-          <h1 className="max-w-4xl text-4xl font-bold leading-tight text-white text-glow sm:text-5xl">
-            Movie activity at a glance, without exposing anyone&apos;s profile.
-          </h1>
-          <p className="max-w-3xl text-base leading-7 text-white/60">
-            These are database-wide totals and anonymous distributions. Sign in to choose the profiles you monitor, compare people, and investigate same-day watches.
-          </p>
-        </motion.section>
-
-        <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-4" aria-label="Aggregate totals">
-          <StatsCard title="Profiles analyzed" value={stats.total_profiles} subtitle={`${analytics.data_health.completed_profiles} ready for analysis`} icon={Users} />
-          <StatsCard title="Unique films" value={stats.total_movies_tracked} subtitle="Across the aggregate dataset" icon={Film} gradient="from-blue-500/20 to-blue-600/10" delay={0.05} />
-          <StatsCard title="Reviews" value={stats.total_reviews} subtitle="Imported review records" icon={MessageCircle} gradient="from-purple-500/20 to-purple-600/10" delay={0.1} />
-          <StatsCard title="Average rating" value={stats.global_avg_rating.toFixed(1)} subtitle="Across rated entries" icon={Star} gradient="from-yellow-500/20 to-yellow-600/10" delay={0.15} />
-        </section>
-
-        <section className="grid grid-cols-1 gap-8 xl:grid-cols-2" aria-label="Aggregate charts">
-          <RatingDistributionChart data={analytics.rating_distribution} globalAverage={stats.global_avg_rating} />
-          <ActivityChart data={analytics.activity_data} />
-        </section>
-
-        <section className="card-cinema overflow-hidden" aria-labelledby="anonymous-signals-title">
-          <div className="flex items-start gap-4">
-            <span className="rounded-2xl border border-cinema-400/30 bg-cinema-500/15 p-3 text-cinema-300"><Radar className="h-7 w-7" /></span>
-            <div>
-              <h2 id="anonymous-signals-title" className="text-2xl font-bold text-white">Anonymous spy-signal totals</h2>
-              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/55">Counts show how much overlap exists in the dataset. Names, profile pairs, titles, ratings, and watch dates stay inside the signed-in workspace.</p>
-            </div>
-          </div>
-          <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            <AggregateSignal icon={Activity} label="Same-day events" value={signals.same_day_events} />
-            <AggregateSignal icon={CalendarClock} label="One-day echoes" value={signals.one_day_gap_events} />
-            <AggregateSignal icon={Film} label="Shared titles" value={signals.shared_titles} />
-            <AggregateSignal icon={Users} label="Profiles with dates" value={signals.profiles_with_diary_dates} />
-          </div>
-          <div className="mt-6 flex flex-col gap-4 border-t border-white/10 pt-6 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-white/45">Latest completed profile sync: <span className="font-medium text-white/70">{lastSync}</span></p>
-            <Link href={isSignedIn ? '/profiles' : '/sign-in?redirect_url=%2Fprofiles'} className="btn-secondary text-center">
-              {isSignedIn ? 'Choose monitored profiles' : 'Sign in for private tools'}
-            </Link>
-          </div>
-        </section>
+function PublicHeader({ isSignedIn }: { isSignedIn: boolean | undefined }) {
+  return (
+    <header className="flex flex-col gap-5 border-b border-white/10 pb-6 sm:flex-row sm:items-center sm:justify-between">
+      <Link href="/" className="flex items-center gap-3" aria-label="Spyboxd public dashboard">
+        <span className="grid h-11 w-11 place-items-center rounded-xl bg-gradient-to-br from-cinema-400 to-cinema-600 text-xl font-black text-white shadow-glow">S</span>
+        <span>
+          <span className="block text-xl font-bold text-white">Spyboxd</span>
+          <span className="block text-xs text-white/45">Aggregate Letterboxd signals</span>
+        </span>
+      </Link>
+      <div className="flex flex-wrap items-center gap-3">
+        {isSignedIn ? (
+          <>
+            <Link href="/dashboard" className="btn-primary whitespace-nowrap">Open My Dashboard</Link>
+            <SignOutButton redirectUrl="/">
+              <button type="button" className="btn-secondary whitespace-nowrap">Sign out</button>
+            </SignOutButton>
+            <UserButton />
+          </>
+        ) : (
+          <Link href="/sign-in?redirect_url=%2Fprofiles" className="btn-primary whitespace-nowrap">Sign in to monitor profiles</Link>
+        )}
       </div>
-    </main>
+    </header>
   );
 }
 


### PR DESCRIPTION
## What changed
- keep the public authentication header visible during aggregate loading and failure states
- show explicit Sign out controls on the public homepage and all private desktop/mobile layouts
- preserve the current private route when a signed-out session goes through sign-in
- keep insight-page account controls visible in short desktop viewports
- exercise login/logout transitions in the Clerk E2E fixture

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `CI=1 npm run test:e2e` (62 passed across Desktop Chrome and Pixel 7)
- independent privacy/security and UI review: no blocking findings