### PR TITLE
Correct monthly activity calendar semantics

### DIFF
--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -2,7 +2,7 @@ import math
 from collections import defaultdict
 from itertools import combinations
 from sqlalchemy.orm import Session
-from sqlalchemy import desc, false, func, and_, or_, extract
+from sqlalchemy import and_, case, desc, extract, false, func, or_
 from .models import (
     Movie,
     MovieList,
@@ -20,7 +20,7 @@ from .models import (
     WatchEvent,
     WatchlistItem,
 )
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional, Dict, Any, Tuple
 
 
@@ -30,6 +30,34 @@ def _format_month_bucket(year: int, month: int) -> str:
 
 RATING_MIN = 0.0
 RATING_MAX = 5.0
+DASHBOARD_SNAPSHOT_FORMAT_VERSION = 2
+DASHBOARD_ACTIVITY_MONTHS = 12
+
+
+def _shift_month_start(month_start: date, offset: int) -> date:
+    """Move a first-of-month date by ``offset`` calendar months."""
+    month_index = month_start.year * 12 + month_start.month - 1 + offset
+    year, zero_based_month = divmod(month_index, 12)
+    return date(year, zero_based_month + 1, 1)
+
+
+def _coerce_utc_now(value: Optional[datetime] = None) -> datetime:
+    timestamp = value or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp.astimezone(timezone.utc)
+
+
+def _dashboard_snapshot_meta(as_of: date) -> Dict[str, Any]:
+    current_month_start = as_of.replace(day=1)
+    return {
+        "format_version": DASHBOARD_SNAPSHOT_FORMAT_VERSION,
+        "activity_window_start": _shift_month_start(
+            current_month_start,
+            -(DASHBOARD_ACTIVITY_MONTHS - 1),
+        ).isoformat(),
+        "activity_as_of": as_of.isoformat(),
+    }
 
 
 def _coerce_finite_float(value: Any) -> Optional[float]:
@@ -786,34 +814,94 @@ class RatingRepository:
         
         return {str(rating): count for rating, count in results}
     
-    def get_monthly_watch_stats(self, profile_id: int, months: int = 12) -> List[Dict]:
-        """Get monthly watching statistics"""
-        cutoff_date = datetime.utcnow().date() - timedelta(days=months * 30)
-        year_bucket = extract('year', Rating.watched_date)
-        month_bucket = extract('month', Rating.watched_date)
+    def _get_monthly_watch_activity(
+        self,
+        profile_ids: Optional[List[int]],
+        *,
+        months: int,
+        as_of: Optional[date] = None,
+    ) -> List[Dict]:
+        """Aggregate active dated watch occurrences into calendar months."""
+        if months <= 0 or (profile_ids is not None and not profile_ids):
+            return []
 
-        results = self.db.query(
-            year_bucket.label('year'),
-            month_bucket.label('month'),
-            func.count(Rating.id).label('count'),
-            func.avg(Rating.rating).label('avg_rating')
+        activity_as_of = as_of or datetime.now(timezone.utc).date()
+        current_month_start = activity_as_of.replace(day=1)
+        window_start = _shift_month_start(current_month_start, -(months - 1))
+        year_bucket = extract("year", WatchEvent.watched_date)
+        month_bucket = extract("month", WatchEvent.watched_date)
+        valid_rating = case(
+            (
+                and_(
+                    WatchEvent.rating >= 0.5,
+                    WatchEvent.rating <= RATING_MAX,
+                ),
+                WatchEvent.rating,
+            ),
+            else_=None,
+        )
+
+        query = self.db.query(
+            year_bucket.label("year"),
+            month_bucket.label("month"),
+            func.count(WatchEvent.id).label("watch_count"),
+            func.avg(valid_rating).label("avg_rating"),
         ).filter(
-            Rating.profile_id == profile_id,
-            Rating.watched_date >= cutoff_date,
-            Rating.rating.is_(None) | and_(Rating.rating >= RATING_MIN, Rating.rating <= RATING_MAX),
-        ).group_by(
-            year_bucket,
-            month_bucket
-        ).order_by(year_bucket, month_bucket).all()
-        
-        return [
-            {
-                'month': _format_month_bucket(year, month),
-                'movies_watched': count,
-                'average_rating': _safe_round(avg_rating, 2)
+            WatchEvent.watched_date >= window_start,
+            WatchEvent.watched_date <= activity_as_of,
+            WatchEvent.superseded_at.is_(None),
+        )
+        if profile_ids is not None:
+            query = query.filter(WatchEvent.profile_id.in_(profile_ids))
+
+        results = (
+            query.group_by(year_bucket, month_bucket)
+            .order_by(year_bucket, month_bucket)
+            .all()
+        )
+        if not results:
+            return []
+
+        activity_by_month = {
+            _format_month_bucket(year, month): {
+                "movies_watched": int(watch_count),
+                "average_rating": _safe_round(avg_rating, 2),
             }
-            for year, month, count, avg_rating in results
-        ]
+            for year, month, watch_count, avg_rating in results
+        }
+
+        activity = []
+        for offset in range(months):
+            month_start = _shift_month_start(window_start, offset)
+            month_key = _format_month_bucket(month_start.year, month_start.month)
+            monthly_values = activity_by_month.get(month_key)
+            activity.append(
+                {
+                    "month": month_key,
+                    "movies_watched": (
+                        monthly_values["movies_watched"] if monthly_values else 0
+                    ),
+                    "average_rating": (
+                        monthly_values["average_rating"] if monthly_values else None
+                    ),
+                    "is_partial": month_start == current_month_start,
+                }
+            )
+        return activity
+
+    def get_monthly_watch_stats(
+        self,
+        profile_id: int,
+        months: int = 12,
+        *,
+        as_of: Optional[date] = None,
+    ) -> List[Dict]:
+        """Get calendar-aligned monthly watch-event statistics for one profile."""
+        return self._get_monthly_watch_activity(
+            [profile_id],
+            months=months,
+            as_of=as_of,
+        )
 
     def get_global_rating_distribution(
         self,
@@ -839,39 +927,16 @@ class RatingRepository:
     def get_global_monthly_activity(
         self,
         profile_ids: Optional[List[int]] = None,
+        *,
+        months: int = DASHBOARD_ACTIVITY_MONTHS,
+        as_of: Optional[date] = None,
     ) -> List[Dict]:
-        """Get monthly activity across all or an explicit profile scope."""
-        cutoff_date = datetime.now().date() - timedelta(days=365)
-        year_bucket = extract('year', Rating.watched_date)
-        month_bucket = extract('month', Rating.watched_date)
-
-        query = self.db.query(
-            year_bucket.label('year'),
-            month_bucket.label('month'),
-            func.count(Rating.id).label('movies_watched'),
-            func.avg(Rating.rating).label('avg_rating')
-        ).filter(
-            Rating.watched_date >= cutoff_date,
-            Rating.watched_date.isnot(None),
-            Rating.rating.is_(None) | and_(Rating.rating >= RATING_MIN, Rating.rating <= RATING_MAX),
+        """Get calendar-aligned monthly watch-event activity for a profile scope."""
+        return self._get_monthly_watch_activity(
+            profile_ids,
+            months=months,
+            as_of=as_of,
         )
-        if profile_ids is not None:
-            query = query.filter(
-                Rating.profile_id.in_(profile_ids) if profile_ids else false()
-            )
-        results = query.group_by(
-            year_bucket,
-            month_bucket
-        ).order_by(year_bucket, month_bucket).all()
-        
-        return [
-            {
-                'month': _format_month_bucket(year, month),
-                'movies_watched': count,
-                'average_rating': _safe_round(avg_rating, 2)
-            }
-            for year, month, count, avg_rating in results
-        ]
 
 class ReviewRepository:
     def __init__(self, db: Session):
@@ -1037,7 +1102,10 @@ class AnalyticsRepository:
         group_limit: int = 6,
         top_movies_limit: int = 10,
         usernames: Optional[List[str]] = None,
+        *,
+        now: Optional[datetime] = None,
     ) -> Dict[str, Any]:
+        generated_at = _coerce_utc_now(now)
         if usernames is None:
             usernames = [
                 username
@@ -1065,12 +1133,13 @@ class AnalyticsRepository:
             ),
             "activity_data": rating_repo.get_global_monthly_activity(
                 profile_ids=profile_ids,
+                as_of=generated_at.date(),
             ),
             "group_signals": self.get_group_correlation_metrics(
                 usernames=usernames,
                 limit=group_limit,
             ),
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": generated_at.isoformat(),
         }
 
     def _get_latest_metrics_record(self) -> Optional[SystemMetrics]:
@@ -1099,13 +1168,18 @@ class AnalyticsRepository:
         self,
         group_limit: int = 6,
         top_movies_limit: int = 10,
+        *,
+        now: Optional[datetime] = None,
     ) -> Dict[str, Any]:
+        requested_at = _coerce_utc_now(now)
+        expected_meta = _dashboard_snapshot_meta(requested_at.date())
         latest_metrics = self._get_latest_metrics_record()
         latest_profile_update = self._get_latest_profile_update()
         current_profile_count = self._get_profile_count()
 
         if latest_metrics and isinstance(latest_metrics.metrics, dict):
             dashboard_snapshot = latest_metrics.metrics.get("dashboard_snapshot")
+            snapshot_meta = latest_metrics.metrics.get("dashboard_snapshot_meta")
             snapshot_timestamp = _naive_utc(latest_metrics.timestamp)
             cached_profile_count = None
             if isinstance(dashboard_snapshot, dict):
@@ -1114,11 +1188,11 @@ class AnalyticsRepository:
                     .get("system_stats", {})
                     .get("total_profiles")
                 )
-            if dashboard_snapshot and (
+            if dashboard_snapshot and snapshot_meta == expected_meta and (
                 cached_profile_count == current_profile_count
+                and snapshot_timestamp is not None
                 and (
                     latest_profile_update is None
-                    or snapshot_timestamp is None
                     or latest_profile_update <= snapshot_timestamp
                 )
             ):
@@ -1127,24 +1201,32 @@ class AnalyticsRepository:
         return self.refresh_dashboard_analytics_snapshot(
             group_limit=group_limit,
             top_movies_limit=top_movies_limit,
+            now=requested_at,
         )
 
     def refresh_dashboard_analytics_snapshot(
         self,
         group_limit: int = 6,
         top_movies_limit: int = 10,
+        *,
+        now: Optional[datetime] = None,
     ) -> Dict[str, Any]:
+        refreshed_at = _coerce_utc_now(now)
         snapshot = self.build_dashboard_analytics_snapshot(
             group_limit=group_limit,
             top_movies_limit=top_movies_limit,
+            now=refreshed_at,
         )
         system_stats = snapshot["system_stats"]
-        metrics_payload = {"dashboard_snapshot": snapshot}
+        metrics_payload = {
+            "dashboard_snapshot": snapshot,
+            "dashboard_snapshot_meta": _dashboard_snapshot_meta(refreshed_at.date()),
+        }
 
         latest_metrics = self._get_latest_metrics_record()
         if latest_metrics:
             existing_metrics = latest_metrics.metrics if isinstance(latest_metrics.metrics, dict) else {}
-            latest_metrics.timestamp = datetime.now(timezone.utc)
+            latest_metrics.timestamp = refreshed_at
             latest_metrics.total_profiles = system_stats["total_profiles"]
             latest_metrics.total_movies_tracked = system_stats["total_movies_tracked"]
             latest_metrics.total_reviews = system_stats["total_reviews"]
@@ -1155,7 +1237,7 @@ class AnalyticsRepository:
             }
         else:
             latest_metrics = SystemMetrics(
-                timestamp=datetime.now(timezone.utc),
+                timestamp=refreshed_at,
                 total_profiles=system_stats["total_profiles"],
                 total_movies_tracked=system_stats["total_movies_tracked"],
                 total_reviews=system_stats["total_reviews"],

--- a/backend/main.py
+++ b/backend/main.py
@@ -128,6 +128,7 @@ class PublicActivityPoint(BaseModel):
     month: str
     movies_watched: int = Field(ge=0)
     average_rating: Optional[float] = Field(default=None, ge=0, le=5)
+    is_partial: bool
 
 
 class PublicSignalCounts(BaseModel):
@@ -225,6 +226,7 @@ def _public_dashboard_payload(
                 "month": point["month"],
                 "movies_watched": _safe_nonnegative_int(point.get("movies_watched")),
                 "average_rating": _safe_public_rating(point.get("average_rating")),
+                "is_partial": point.get("is_partial") is True,
             }
             for point in activity_data
             if isinstance(point, dict)

--- a/backend/tests/test_monthly_activity.py
+++ b/backend/tests/test_monthly_activity.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.database.models import (
+    Base,
+    Movie,
+    Profile,
+    Rating,
+    SystemMetrics,
+    WatchEvent,
+)
+from backend.database.repository import (
+    DASHBOARD_SNAPSHOT_FORMAT_VERSION,
+    AnalyticsRepository,
+    RatingRepository,
+)
+
+
+AS_OF = date(2026, 7, 30)
+EXPECTED_MONTHS = [
+    "2025-08",
+    "2025-09",
+    "2025-10",
+    "2025-11",
+    "2025-12",
+    "2026-01",
+    "2026-02",
+    "2026-03",
+    "2026-04",
+    "2026-05",
+    "2026-06",
+    "2026-07",
+]
+
+
+@pytest.fixture()
+def database():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _sqlite_compatibility(dbapi_connection, _connection_record):
+        dbapi_connection.create_function(
+            "char_length",
+            1,
+            lambda value: len(value) if value is not None else None,
+        )
+
+    Base.metadata.create_all(
+        engine,
+        tables=[
+            Profile.__table__,
+            Movie.__table__,
+            Rating.__table__,
+            WatchEvent.__table__,
+            SystemMetrics.__table__,
+        ],
+    )
+    session = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield session
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _profile(profile_id: int, username: str) -> Profile:
+    return Profile(
+        id=profile_id,
+        username=username,
+        is_active=True,
+        scraping_status="completed",
+    )
+
+
+def _movie(movie_id: int, title: str) -> Movie:
+    normalized = title.casefold().replace(" ", "-")
+    return Movie(
+        id=movie_id,
+        canonical_key=f"test:{normalized}",
+        title=title,
+        normalized_title=title.casefold(),
+    )
+
+
+def _watch_event(
+    event_id: int,
+    *,
+    profile_id: int,
+    movie_id: int,
+    watched_date: date,
+    rating: float | None = None,
+    rewatch: bool = False,
+    superseded: bool = False,
+) -> WatchEvent:
+    return WatchEvent(
+        id=event_id,
+        profile_id=profile_id,
+        movie_id=movie_id,
+        event_key=f"test-event:{event_id}",
+        watched_date=watched_date,
+        rating=rating,
+        is_rewatch=rewatch,
+        is_liked=False,
+        has_review=False,
+        tags=[],
+        source_kind="diary_csv",
+        superseded_at=(
+            datetime(2026, 7, 1, tzinfo=timezone.utc)
+            if superseded
+            else None
+        ),
+    )
+
+
+def _seed_monthly_activity(database) -> tuple[Profile, Profile]:
+    alpha = _profile(1, "alpha")
+    beta = _profile(2, "beta")
+    film = _movie(1, "Repeat Film")
+    database.add_all([alpha, beta, film])
+    database.add_all(
+        [
+            # A rolling 365-day query incorrectly exposed this as a tiny Jul 2025 bucket.
+            _watch_event(
+                1,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 7, 31),
+                rating=5.0,
+            ),
+            _watch_event(
+                2,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 8, 1),
+                rating=4.0,
+            ),
+            # Rewatches and unrated diary entries are still watch occurrences.
+            _watch_event(
+                3,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 8, 2),
+                rating=None,
+                rewatch=True,
+            ),
+            _watch_event(
+                4,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 9, 2),
+                rating=2.0,
+            ),
+            _watch_event(
+                5,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 9, 3),
+                rating=4.0,
+            ),
+            _watch_event(
+                6,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2025, 10, 1),
+                rating=1.0,
+                superseded=True,
+            ),
+            _watch_event(
+                7,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=AS_OF,
+                rating=3.5,
+            ),
+            # A bad future diary date must not leak into the current MTD bucket.
+            _watch_event(
+                8,
+                profile_id=alpha.id,
+                movie_id=film.id,
+                watched_date=date(2026, 7, 31),
+                rating=5.0,
+            ),
+            # A second profile proves explicit profile scoping remains intact.
+            _watch_event(
+                9,
+                profile_id=beta.id,
+                movie_id=film.id,
+                watched_date=date(2026, 6, 15),
+                rating=1.5,
+            ),
+        ]
+    )
+    database.commit()
+    return alpha, beta
+
+
+def test_global_monthly_activity_uses_exact_calendar_window_and_event_grain(database):
+    alpha, _beta = _seed_monthly_activity(database)
+
+    activity = RatingRepository(database).get_global_monthly_activity(
+        profile_ids=[alpha.id],
+        as_of=AS_OF,
+    )
+
+    assert [point["month"] for point in activity] == EXPECTED_MONTHS
+    assert len(activity) == 12
+    assert "2025-07" not in {point["month"] for point in activity}
+    assert [point["is_partial"] for point in activity] == [False] * 11 + [True]
+    assert [point["is_partial"] for point in activity] == [False] * 11 + [True]
+
+    by_month = {point["month"]: point for point in activity}
+    assert by_month["2025-08"]["movies_watched"] == 2
+    assert by_month["2025-08"]["average_rating"] == 4.0
+    assert by_month["2025-09"]["movies_watched"] == 2
+    assert by_month["2025-09"]["average_rating"] == 3.0
+    assert by_month["2025-10"]["movies_watched"] == 0
+    assert by_month["2025-10"]["average_rating"] is None
+    assert by_month["2026-06"]["movies_watched"] == 0
+    assert by_month["2026-07"]["movies_watched"] == 1
+    assert by_month["2026-07"]["average_rating"] == 3.5
+
+
+def test_monthly_activity_zero_fills_only_a_nonempty_explicit_scope(database):
+    alpha, _beta = _seed_monthly_activity(database)
+    repository = RatingRepository(database)
+
+    activity = repository.get_global_monthly_activity(
+        profile_ids=[alpha.id],
+        as_of=AS_OF,
+    )
+
+    assert len(activity) == 12
+    assert sum(point["movies_watched"] == 0 for point in activity) == 9
+    assert repository.get_global_monthly_activity(profile_ids=[], as_of=AS_OF) == []
+    assert repository.get_global_monthly_activity(profile_ids=[999], as_of=AS_OF) == []
+
+
+def test_first_day_of_month_marks_an_empty_current_bucket_as_partial(database):
+    alpha, _beta = _seed_monthly_activity(database)
+
+    activity = RatingRepository(database).get_global_monthly_activity(
+        profile_ids=[alpha.id],
+        as_of=date(2026, 7, 1),
+    )
+
+    assert activity[-1] == {
+        "month": "2026-07",
+        "movies_watched": 0,
+        "average_rating": None,
+        "is_partial": True,
+    }
+
+
+def test_per_profile_monthly_activity_matches_the_same_global_scope(database):
+    alpha, _beta = _seed_monthly_activity(database)
+    repository = RatingRepository(database)
+
+    per_profile = repository.get_monthly_watch_stats(
+        alpha.id,
+        months=12,
+        as_of=AS_OF,
+    )
+    scoped_global = repository.get_global_monthly_activity(
+        profile_ids=[alpha.id],
+        as_of=AS_OF,
+    )
+
+    assert per_profile == scoped_global
+
+
+def _snapshot(profile_count: int = 1) -> dict:
+    return {
+        "system_stats": {
+            "total_profiles": profile_count,
+            "total_movies_tracked": 1,
+            "total_reviews": 0,
+            "global_avg_rating": 4.0,
+        },
+        "top_rated_movies": [],
+        "rating_distribution": {"4.0": 1},
+        "activity_data": [],
+        "group_signals": {},
+        "timestamp": "2026-07-30T10:00:00+00:00",
+    }
+
+
+def _snapshot_meta(as_of: date) -> dict:
+    return {
+        "format_version": DASHBOARD_SNAPSHOT_FORMAT_VERSION,
+        "activity_window_start": "2025-08-01",
+        "activity_as_of": as_of.isoformat(),
+    }
+
+
+def _seed_cached_snapshot(database, *, timestamp: datetime, meta: dict | None) -> dict:
+    cached = _snapshot()
+    metrics = {"dashboard_snapshot": cached}
+    if meta is not None:
+        metrics["dashboard_snapshot_meta"] = meta
+    database.add(
+        SystemMetrics(
+            id=1,
+            timestamp=timestamp,
+            total_profiles=1,
+            total_movies_tracked=1,
+            total_reviews=0,
+            active_scraping_jobs=0,
+            metrics=metrics,
+        )
+    )
+    database.commit()
+    return cached
+
+
+def test_dashboard_cache_reuses_matching_metadata(database, monkeypatch):
+    now = datetime(2026, 7, 30, 10, tzinfo=timezone.utc)
+    profile = _profile(1, "alpha")
+    profile.updated_at = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    database.add(profile)
+    cached = _seed_cached_snapshot(
+        database,
+        timestamp=now,
+        meta=_snapshot_meta(now.date()),
+    )
+    repository = AnalyticsRepository(database)
+
+    def unexpected_refresh(**_kwargs):
+        raise AssertionError("a current snapshot must be reused")
+
+    monkeypatch.setattr(repository, "refresh_dashboard_analytics_snapshot", unexpected_refresh)
+
+    assert repository.get_dashboard_analytics_snapshot(now=now) == cached
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        None,
+        {
+            "format_version": DASHBOARD_SNAPSHOT_FORMAT_VERSION - 1,
+            "activity_window_start": "2025-08-01",
+            "activity_as_of": AS_OF.isoformat(),
+        },
+    ],
+)
+def test_dashboard_cache_invalidates_legacy_or_version_mismatched_metadata(
+    database,
+    monkeypatch,
+    meta,
+):
+    now = datetime(2026, 7, 30, 10, tzinfo=timezone.utc)
+    profile = _profile(1, "alpha")
+    profile.updated_at = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    database.add(profile)
+    _seed_cached_snapshot(database, timestamp=now, meta=meta)
+    repository = AnalyticsRepository(database)
+    rebuilt = {**_snapshot(), "timestamp": now.isoformat(), "rebuilt": True}
+    calls = []
+
+    def refresh(*, group_limit, top_movies_limit, now):
+        calls.append((group_limit, top_movies_limit, now))
+        return rebuilt
+
+    monkeypatch.setattr(repository, "refresh_dashboard_analytics_snapshot", refresh)
+
+    assert repository.get_dashboard_analytics_snapshot(now=now) == rebuilt
+    assert calls == [(6, 10, now)]
+
+
+def test_dashboard_cache_invalidates_on_day_rollover(database, monkeypatch):
+    cached_at = datetime(2026, 7, 30, 23, 59, tzinfo=timezone.utc)
+    requested_at = datetime(2026, 7, 31, 0, 1, tzinfo=timezone.utc)
+    profile = _profile(1, "alpha")
+    profile.updated_at = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    database.add(profile)
+    _seed_cached_snapshot(
+        database,
+        timestamp=cached_at,
+        meta=_snapshot_meta(cached_at.date()),
+    )
+    repository = AnalyticsRepository(database)
+    calls = []
+
+    def refresh(*, group_limit, top_movies_limit, now):
+        calls.append((group_limit, top_movies_limit, now))
+        return {**_snapshot(), "rebuilt": True}
+
+    monkeypatch.setattr(repository, "refresh_dashboard_analytics_snapshot", refresh)
+
+    result = repository.get_dashboard_analytics_snapshot(now=requested_at)
+
+    assert result["rebuilt"] is True
+    assert calls == [(6, 10, requested_at)]
+
+
+def test_dashboard_cache_rejects_a_null_timestamp(database, monkeypatch):
+    now = datetime(2026, 7, 30, 10, tzinfo=timezone.utc)
+    profile = _profile(1, "alpha")
+    profile.updated_at = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    database.add(profile)
+    _seed_cached_snapshot(
+        database,
+        timestamp=now,
+        meta=_snapshot_meta(now.date()),
+    )
+    metrics = database.get(SystemMetrics, 1)
+    metrics.timestamp = None
+    database.commit()
+    repository = AnalyticsRepository(database)
+    calls = []
+
+    def refresh(*, group_limit, top_movies_limit, now):
+        calls.append((group_limit, top_movies_limit, now))
+        return {**_snapshot(), "rebuilt": True}
+
+    monkeypatch.setattr(repository, "refresh_dashboard_analytics_snapshot", refresh)
+
+    result = repository.get_dashboard_analytics_snapshot(now=now)
+
+    assert result["rebuilt"] is True
+    assert calls == [(6, 10, now)]
+
+
+def test_dashboard_refresh_persists_matching_snapshot_metadata(database, monkeypatch):
+    now = datetime(2026, 7, 30, 10, tzinfo=timezone.utc)
+    repository = AnalyticsRepository(database)
+    built = _snapshot(profile_count=0)
+    calls = []
+
+    def build(*, group_limit, top_movies_limit, now):
+        calls.append((group_limit, top_movies_limit, now))
+        return built
+
+    monkeypatch.setattr(repository, "build_dashboard_analytics_snapshot", build)
+
+    assert repository.refresh_dashboard_analytics_snapshot(now=now) == built
+
+    metrics = database.query(SystemMetrics).one()
+    assert metrics.timestamp == now.replace(tzinfo=None)
+    assert metrics.metrics["dashboard_snapshot"] == built
+    assert metrics.metrics["dashboard_snapshot_meta"] == _snapshot_meta(now.date())
+    assert calls == [(6, 10, now)]

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -25,6 +25,7 @@ from backend.database.models import (
     Rating,
     Review,
     UserTrackedProfile,
+    WatchEvent,
     WatchlistItem,
 )
 from backend.database.repository import AnalyticsRepository
@@ -77,6 +78,7 @@ def database():
             WatchlistItem.__table__,
             Rating.__table__,
             Review.__table__,
+            WatchEvent.__table__,
         ],
     )
     session = sessionmaker(bind=engine, expire_on_commit=False)()
@@ -750,21 +752,57 @@ def test_global_dashboard_snapshot_excludes_unready_and_inactive_profiles(databa
     pending = _profile(2, "Pending", completed=False)
     inactive = _profile(3, "Inactive")
     inactive.is_active = False
-    database.add_all([ready, pending, inactive])
+    movie = Movie(
+        id=1,
+        canonical_key="test:dashboard-film",
+        title="Dashboard Film",
+        normalized_title="dashboard film",
+    )
+    database.add_all([ready, pending, inactive, movie])
     database.add_all(
         [
             Rating(id=1, profile_id=ready.id, movie_title="Ready Film", rating=4.0),
             Rating(id=2, profile_id=pending.id, movie_title="Pending Film", rating=2.0),
             Rating(id=3, profile_id=inactive.id, movie_title="Inactive Film", rating=1.0),
+            WatchEvent(
+                id=1,
+                profile_id=ready.id,
+                movie_id=movie.id,
+                event_key="ready-watch",
+                watched_date=datetime(2026, 7, 15).date(),
+                rating=4.0,
+                source_kind="diary_csv",
+            ),
+            WatchEvent(
+                id=2,
+                profile_id=pending.id,
+                movie_id=movie.id,
+                event_key="pending-watch",
+                watched_date=datetime(2026, 7, 15).date(),
+                rating=2.0,
+                source_kind="diary_csv",
+            ),
+            WatchEvent(
+                id=3,
+                profile_id=inactive.id,
+                movie_id=movie.id,
+                event_key="inactive-watch",
+                watched_date=datetime(2026, 7, 15).date(),
+                rating=1.0,
+                source_kind="diary_csv",
+            ),
         ]
     )
     database.commit()
 
-    snapshot = AnalyticsRepository(database).build_dashboard_analytics_snapshot()
+    snapshot = AnalyticsRepository(database).build_dashboard_analytics_snapshot(
+        now=datetime(2026, 7, 30, tzinfo=timezone.utc),
+    )
 
     assert snapshot["system_stats"]["total_profiles"] == 1
     assert snapshot["system_stats"]["total_movies_tracked"] == 1
     assert snapshot["rating_distribution"] == {"4.0": 1}
+    assert sum(point["movies_watched"] for point in snapshot["activity_data"]) == 1
 
 
 def test_admin_allowlist_is_server_side_and_metadata_boolean_is_strict(monkeypatch):

--- a/backend/tests/test_public_dashboard.py
+++ b/backend/tests/test_public_dashboard.py
@@ -18,7 +18,18 @@ def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
         "top_rated_movies": [{"title": "Private Film Sentinel"}],
         "rating_distribution": {"4.0": 250, sentinel: 1},
         "activity_data": [
-            {"month": "2026-07", "movies_watched": 80, "average_rating": 3.8},
+            {
+                "month": "2026-06",
+                "movies_watched": 0,
+                "average_rating": None,
+                "is_partial": False,
+            },
+            {
+                "month": "2026-07",
+                "movies_watched": 80,
+                "average_rating": 3.8,
+                "is_partial": True,
+            },
             {"month": sentinel, "movies_watched": 1, "average_rating": 5.0},
         ],
         "group_signals": {
@@ -67,6 +78,20 @@ def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
         "same_day_pair_hits",
         "one_day_gap_pair_hits",
     }
+    assert validated["activity_data"] == [
+        {
+            "month": "2026-06",
+            "movies_watched": 0,
+            "average_rating": None,
+            "is_partial": False,
+        },
+        {
+            "month": "2026-07",
+            "movies_watched": 80,
+            "average_rating": 3.8,
+            "is_partial": True,
+        },
+    ]
     serialized = json.dumps(validated).lower()
     assert sentinel not in serialized
     assert "private film sentinel" not in serialized

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -128,8 +128,9 @@ const publicDashboard = {
   },
   rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
   activity_data: [
-    { month: '2026-06', movies_watched: 20, average_rating: 3.8 },
-    { month: '2026-07', movies_watched: 24, average_rating: 3.9 },
+    { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
+    { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
+    { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
   ],
   signal_counts: {
     profiles_analyzed: profiles.length,
@@ -162,8 +163,9 @@ const profileAnalysis = {
   data_coverage: profiles[0].data_coverage,
   rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
   monthly_stats: [
-    { month: '2026-06', movies_watched: 20, average_rating: 3.8 },
-    { month: '2026-07', movies_watched: 24, average_rating: 3.9 },
+    { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
+    { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
+    { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
   ],
   recent_watching_trend: Array.from({ length: 8 }, (_, index) => ({
     movie_title: `Recent Watch ${index + 1}`,
@@ -428,8 +430,9 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
       top_rated_movies: [],
       rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
       activity_data: [
-        { month: '2026-06', movies_watched: 20, average_rating: 3.8 },
-        { month: '2026-07', movies_watched: 24, average_rating: 3.9 },
+        { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
+        { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
+        { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
       ],
       group_signals: groupSignals,
       timestamp: '2026-07-29T12:00:00Z',

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -114,6 +114,25 @@ test('signed-in public homepage remains aggregate-only', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
 });
 
+test('watching activity identifies month-to-date events and excludes them from the completed-month average', async ({ page }) => {
+  await page.goto('/');
+
+  const activityChart = page.getByRole('region', { name: 'Watching Activity' });
+  await expect(activityChart).toBeVisible();
+  await expect(activityChart.getByText(
+    'Monthly watch events · July 2026 is month to date; average uses completed months',
+    { exact: true },
+  )).toBeVisible();
+  await expect(activityChart.getByLabel('Average watch events per completed month')).toHaveText('15.0');
+  await expect(activityChart.getByText('Avg/Completed Month', { exact: true })).toBeVisible();
+  await expect(activityChart.getByRole('img')).toHaveAccessibleName(
+    /July 2026 is month to date and is excluded from the completed-month average.*15\.0 watch events per completed month/,
+  );
+  await expect(activityChart.getByRole('list', { name: 'Watching Activity data points' })).toContainText(
+    'July 2026, month to date: 90 watch events; average rating 3.9',
+  );
+});
+
 test('analysis list panels keep intrinsic heights without animated glass artifacts', async ({ page }) => {
   await page.goto('/analysis');
 

--- a/frontend/src/components/Charts/ActivityChart.tsx
+++ b/frontend/src/components/Charts/ActivityChart.tsx
@@ -29,6 +29,7 @@ interface ActivityData {
   month: string;
   movies_watched: number;
   average_rating: number | null;
+  is_partial: boolean;
 }
 
 interface ActivityChartProps {
@@ -36,19 +37,36 @@ interface ActivityChartProps {
   title?: string;
 }
 
+function formatMonth(monthValue: string, month: 'short' | 'long', year: '2-digit' | 'numeric') {
+  const [yearValue, monthValuePart] = monthValue.split('-').map(Number);
+  const date = new Date(Date.UTC(yearValue, monthValuePart - 1, 1));
+  return date.toLocaleDateString('en-US', { month, year, timeZone: 'UTC' });
+}
+
 const ActivityChart: React.FC<ActivityChartProps> = ({ 
   data, 
   title = "Watching Activity" 
 }) => {
+  const partialPoint = data.find((item) => item.is_partial);
+  const completedPoints = data.filter((item) => !item.is_partial);
+  const completedTotal = completedPoints.reduce((sum, item) => sum + item.movies_watched, 0);
+  const completedAverage = completedPoints.length > 0
+    ? completedTotal / completedPoints.length
+    : null;
+  const partialMonth = partialPoint
+    ? formatMonth(partialPoint.month, 'long', 'numeric')
+    : null;
+  const chartAccessibilityLabel = partialMonth
+    ? `${title}. ${partialMonth} is month to date and is excluded from the completed-month average. ${completedAverage === null ? 'No completed-month average is available.' : `Average: ${completedAverage.toFixed(1)} watch events per completed month.`}`
+    : `${title}. ${completedAverage === null ? 'No completed-month average is available.' : `Average: ${completedAverage.toFixed(1)} watch events per completed month.`}`;
+
   const chartData = {
-    labels: data.map(item => {
-      const [year, month] = item.month.split('-');
-      const date = new Date(parseInt(year), parseInt(month) - 1);
-      return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
-    }),
+    labels: data.map((item) => (
+      `${formatMonth(item.month, 'short', '2-digit')}${item.is_partial ? ' (MTD)' : ''}`
+    )),
     datasets: [
       {
-        label: 'Movies Watched',
+        label: 'Watch Events',
         data: data.map(item => item.movies_watched),
         borderColor: '#f57c00',
         backgroundColor: 'rgba(245, 124, 0, 0.1)',
@@ -66,7 +84,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
       },
       {
         label: 'Average Rating',
-        data: data.map(item => item.average_rating ? item.average_rating * 10 : null), // Scale to make visible
+        data: data.map(item => item.average_rating !== null ? item.average_rating * 10 : null), // Scale to make visible
         borderColor: '#64748b',
         backgroundColor: 'rgba(100, 116, 139, 0.1)',
         borderWidth: 2,
@@ -117,7 +135,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
         },
         title: {
           display: true,
-          text: 'Movies Watched',
+          text: 'Watch Events',
           color: '#f57c00',
           font: {
             family: 'Inter',
@@ -180,11 +198,12 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
         padding: 12,
         callbacks: {
           label: (context) => {
+            const periodSuffix = data[context.dataIndex]?.is_partial ? ' (MTD)' : '';
             if (context.dataset.label === 'Average Rating') {
               const rating = (context.raw as number) / 10;
-              return `${context.dataset.label}: ${rating.toFixed(1)} ⭐`;
+              return `${context.dataset.label}${periodSuffix}: ${rating.toFixed(1)} ⭐`;
             }
-            return `${context.dataset.label}: ${context.raw}`;
+            return `${context.dataset.label}${periodSuffix}: ${context.raw}`;
           },
         },
       },
@@ -195,11 +214,9 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
     },
   };
 
-  const totalMovies = data.reduce((sum, item) => sum + item.movies_watched, 0);
-  const avgMoviesPerMonth = data.length > 0 ? totalMovies / data.length : 0;
-
   return (
-    <motion.div 
+    <motion.section
+      aria-label={title}
       className="card-cinema h-96"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
@@ -208,7 +225,11 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
       <div className="flex items-center justify-between mb-6">
         <div>
           <h3 className="text-lg font-semibold text-white">{title}</h3>
-          <p className="text-white/60 text-sm">Monthly viewing patterns</p>
+          <p className="text-white/60 text-sm">
+            {partialMonth
+              ? `Monthly watch events · ${partialMonth} is month to date; average uses completed months`
+              : 'Monthly watch events'}
+          </p>
         </div>
         
         <motion.div 
@@ -217,8 +238,13 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
           animate={{ opacity: 1, scale: 1 }}
           transition={{ delay: 0.4 }}
         >
-          <div className="text-xl font-bold text-cinema-400">{avgMoviesPerMonth.toFixed(1)}</div>
-          <div className="text-xs text-white/60">Avg/Month</div>
+          <output
+            aria-label="Average watch events per completed month"
+            className="block text-xl font-bold text-cinema-400"
+          >
+            {completedAverage === null ? '—' : completedAverage.toFixed(1)}
+          </output>
+          <div className="text-xs text-white/60">Avg/Completed Month</div>
         </motion.div>
       </div>
       
@@ -230,7 +256,23 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 1, delay: 0.3 }}
           >
-            <Line data={chartData} options={options} />
+            <Line
+              aria-label={chartAccessibilityLabel}
+              data={chartData}
+              options={options}
+              role="img"
+            />
+            <ul className="sr-only" aria-label={`${title} data points`}>
+              {data.map((item) => (
+                <li key={item.month}>
+                  {formatMonth(item.month, 'long', 'numeric')}
+                  {item.is_partial ? ', month to date' : ''}: {item.movies_watched} watch events;{' '}
+                  {item.average_rating === null
+                    ? 'average rating unavailable'
+                    : `average rating ${item.average_rating.toFixed(1)}`}
+                </li>
+              ))}
+            </ul>
           </motion.div>
         ) : (
           <motion.div 
@@ -248,7 +290,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
           </motion.div>
         )}
       </div>
-    </motion.div>
+    </motion.section>
   );
 };
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -315,6 +315,7 @@ export interface ActivityData {
   month: string;
   movies_watched: number;
   average_rating: number | null;
+  is_partial: boolean;
 }
 
 export interface GroupSignalMovie {


### PR DESCRIPTION
## Summary
- aggregate active watch events in exactly 12 calendar-aligned months
- mark the current month as MTD and exclude it from the completed-month average
- invalidate legacy/stale dashboard snapshots by format and activity date
- add focused backend and browser regression coverage

## Verification
- `199 passed, 1 skipped, 19 subtests passed` (backend; optional dedicated PostgreSQL migration test skipped locally)
- `alembic check`
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `npm run build`
- `CI=true npm run test:e2e` (`64 passed`)
- local PostgreSQL/public API: 12 points, Aug 2025–Jul 2026, Jul 2026 marked partial, completed-month average 155.2