### PR TITLE
Use the Spyboxd brand mark consistently

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from '@clerk/nextjs';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { setApiTokenProvider } from '../services/api';
@@ -57,9 +58,14 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       {authReady ? children : (
         <main className="grid min-h-screen place-items-center px-6" aria-live="polite">
           <div className="text-center">
-            <div className="mx-auto grid h-12 w-12 place-items-center rounded-xl bg-gradient-to-br from-cinema-400 to-cinema-600 shadow-glow">
-              <span className="text-lg font-black text-white">S</span>
-            </div>
+            <Image
+              src="/icon.svg"
+              alt=""
+              width={48}
+              height={48}
+              className="mx-auto h-12 w-12 rounded-xl border border-cinema-400/20 shadow-glow"
+              priority
+            />
             <p className="mt-4 text-sm text-white/55">Preparing Spyboxd…</p>
           </div>
         </main>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { SignOutButton, UserButton, useAuth } from '@clerk/nextjs';
@@ -9,7 +10,6 @@ import {
   HomeIcon,
   ChartBarIcon,
   UserGroupIcon,
-  PlayIcon,
   SignalIcon,
   ScaleIcon,
 } from '@heroicons/react/24/outline';
@@ -121,7 +121,14 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 }}
                 transition={{ duration: 3, repeat: Infinity }}
               >
-                  <PlayIcon className="h-5 w-5 text-white lg:h-6 lg:w-6" />
+                  <Image
+                    src="/icon.svg"
+                    alt=""
+                    width={48}
+                    height={48}
+                    className="h-10 w-10 rounded-xl border border-cinema-400/20 lg:h-12 lg:w-12"
+                    priority
+                  />
                 </motion.div>
               </div>
               <div>

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -3,6 +3,7 @@
 import { SignOutButton, UserButton, useAuth } from '@clerk/nextjs';
 import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
+import Image from 'next/image';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { Activity, CalendarClock, Film, MessageCircle, Radar, Star, Users } from 'lucide-react';
@@ -100,7 +101,14 @@ function PublicHeader({ isSignedIn }: { isSignedIn: boolean | undefined }) {
   return (
     <header className="flex flex-col gap-5 border-b border-white/10 pb-6 sm:flex-row sm:items-center sm:justify-between">
       <Link href="/" className="flex items-center gap-3" aria-label="Spyboxd public dashboard">
-        <span className="grid h-11 w-11 place-items-center rounded-xl bg-gradient-to-br from-cinema-400 to-cinema-600 text-xl font-black text-white shadow-glow">S</span>
+        <Image
+          src="/icon.svg"
+          alt=""
+          width={44}
+          height={44}
+          className="h-11 w-11 rounded-xl border border-cinema-400/20 shadow-glow"
+          priority
+        />
         <span>
           <span className="block text-xl font-bold text-white">Spyboxd</span>
           <span className="block text-xs text-white/45">Aggregate Letterboxd signals</span>


### PR DESCRIPTION
## Summary
- replace the generic public-header `S` tile with the existing Spyboxd spy mark
- use the same mark during app initialization and in the private workspace sidebar
- preserve existing dimensions, layout, accessibility, and glow treatment

## Verification
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `npm run build`
- `CI=true npx playwright test e2e/public-smoke.spec.ts e2e/auth.spec.ts` (`54 passed`)
- rendered the mark at its 48px loading/header scale