### PR TITLE
Fix Clerk sign-in contrast

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -45,6 +45,8 @@ test('the aggregate dashboard is the anonymous landing page', async ({ page }) =
   await signInLink.click();
   await expect(page).toHaveURL(/\/sign-in(?:\/|\?|$)/);
   await expect(page.getByRole('heading', { name: 'Sign in', exact: true })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.documentElement).colorScheme))
+    .toContain('dark');
 });
 
 for (const authenticated of [false, true]) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,7 @@
   
   html {
     scroll-behavior: smooth;
+    color-scheme: dark;
   }
   
   body {


### PR DESCRIPTION
## Summary
- advertise the app's dark color scheme to Clerk
- add a focused auth regression assertion

## Verification
- npm run lint
- npm run typecheck
- npm run build
- CI=1 npm run test:e2e -- auth.spec.ts (24 passed)