### PR TITLE
Use Letterboxd usernames as signup identity

### DIFF
--- a/alembic/versions/20260730_0009_add_letterboxd_identity.py
+++ b/alembic/versions/20260730_0009_add_letterboxd_identity.py
@@ -1,0 +1,58 @@
+"""Add the canonical Letterboxd username to local app users.
+
+Revision ID: 20260730_0009
+Revises: 20260730_0008
+Create Date: 2026-07-30 18:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260730_0009"
+down_revision: Union[str, None] = "20260730_0008"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Keep this nullable for mixed-version deploys and legacy accounts. New
+    # identities are required and validated by the application and Clerk.
+    op.add_column(
+        "app_users",
+        sa.Column("letterboxd_username", sa.String(length=15), nullable=True),
+    )
+    op.add_column(
+        "app_users",
+        sa.Column(
+            "primary_profile_required",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+    )
+    # Rows present at migration time are grandfathered. The server default stays
+    # true so accounts inserted by either application version after this point
+    # cannot bypass primary-profile onboarding during a mixed-version deploy.
+    op.execute(
+        sa.text(
+            "UPDATE app_users SET primary_profile_required = false"
+        )
+    )
+    op.create_index(
+        "uq_app_users_letterboxd_username_lower",
+        "app_users",
+        [sa.text("lower(letterboxd_username)")],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_app_users_letterboxd_username_lower",
+        table_name="app_users",
+    )
+    op.drop_column("app_users", "primary_profile_required")
+    op.drop_column("app_users", "letterboxd_username")

--- a/backend/api/routes/profile_access.py
+++ b/backend/api/routes/profile_access.py
@@ -10,9 +10,9 @@ from auth import ClerkUser, get_admin_user, get_current_user
 from database.connection import get_db
 from services.profile_access import (
     decide_profile_request,
-    ensure_app_user,
     list_profile_catalog,
     list_profile_requests,
+    provision_app_user_identity,
     track_profile_by_id,
     track_or_request_profile,
     untrack_profile,
@@ -36,8 +36,12 @@ def get_me(
     user: ClerkUser = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    ensure_app_user(db, user)
-    return {"user_id": user.user_id, "is_admin": user.is_admin}
+    identity = provision_app_user_identity(db, user)
+    return {
+        "user_id": user.user_id,
+        "is_admin": user.is_admin,
+        **identity,
+    }
 
 
 @router.get("/profiles/catalog")

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -123,6 +123,7 @@ class ClerkUser:
     user_id: str
     session_id: Optional[str]
     is_admin: bool = False
+    letterboxd_username: Optional[str] = None
 
 
 def _configured_admin_user_ids() -> set[str]:
@@ -222,8 +223,20 @@ def get_current_user(
             )
 
     is_admin = _payload_grants_admin(payload, user_id)
+    raw_letterboxd_username = payload.get("letterboxd_username")
+    letterboxd_username = (
+        raw_letterboxd_username.strip()
+        if isinstance(raw_letterboxd_username, str)
+        and raw_letterboxd_username.strip()
+        else None
+    )
 
-    return ClerkUser(user_id=user_id, session_id=session_id, is_admin=is_admin)
+    return ClerkUser(
+        user_id=user_id,
+        session_id=session_id,
+        is_admin=is_admin,
+        letterboxd_username=letterboxd_username,
+    )
 
 
 def get_optional_user(

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -180,6 +180,14 @@ class AppUser(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     clerk_user_id = Column(String(255), unique=True, index=True, nullable=False)
+    # Nullable so the additive migration and application rollback remain safe.
+    # The marker distinguishes grandfathered users from new mandatory identities.
+    letterboxd_username = Column(String(15), nullable=True)
+    primary_profile_required = Column(
+        Boolean,
+        nullable=False,
+        server_default=sql_text("true"),
+    )
     is_active = Column(Boolean, nullable=False, server_default=sql_text("true"))
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at = Column(
@@ -198,6 +206,14 @@ class AppUser(Base):
         "ProfileAccessRequest",
         back_populates="user",
         cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_app_users_letterboxd_username_lower",
+            func.lower(letterboxd_username),
+            unique=True,
+        ),
     )
 
 

--- a/backend/services/profile_access.py
+++ b/backend/services/profile_access.py
@@ -20,7 +20,7 @@ from database.models import (
 )
 
 
-PROFILE_USERNAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,49}")
+PROFILE_USERNAME = re.compile(r"[A-Za-z0-9_]{2,15}")
 REQUEST_STATUSES = {"pending", "approved", "rejected", "fulfilled"}
 ADMIN_DECISIONS = {"approved", "rejected"}
 
@@ -43,34 +43,33 @@ def normalize_profile_username(raw_username: str) -> tuple[str, str]:
     return username, username.casefold()
 
 
+def _normalize_stored_profile_lookup(raw_username: str) -> str:
+    """Normalize an existing profile key without re-validating legacy data.
+
+    New identities and requests must follow Letterboxd's current username
+    rules. Existing rows may predate that validation, however, and users must
+    still be able to remove one from their monitoring set.
+    """
+
+    username = (raw_username or "").strip().lstrip("@")
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Enter a profile username.",
+        )
+    return username.casefold()
+
+
 def ensure_app_user(db: Session, clerk_user: ClerkUser) -> AppUser:
-    app_user = (
+    # Every authenticated entry point goes through identity provisioning. This
+    # prevents a new account from bypassing mandatory onboarding by visiting a
+    # route other than /api/me first.
+    provision_app_user_identity(db, clerk_user)
+    return (
         db.query(AppUser)
         .filter(AppUser.clerk_user_id == clerk_user.user_id)
-        .first()
+        .one()
     )
-    if app_user is not None:
-        if not app_user.is_active:
-            raise HTTPException(status_code=403, detail="User access is disabled")
-        return app_user
-
-    app_user = AppUser(clerk_user_id=clerk_user.user_id)
-    db.add(app_user)
-    try:
-        db.commit()
-        db.refresh(app_user)
-        return app_user
-    except IntegrityError:
-        # A concurrent first request may have inserted the same Clerk identity.
-        db.rollback()
-        app_user = (
-            db.query(AppUser)
-            .filter(AppUser.clerk_user_id == clerk_user.user_id)
-            .one()
-        )
-        if not app_user.is_active:
-            raise HTTPException(status_code=403, detail="User access is disabled")
-        return app_user
 
 
 def _tracked_profile_mapping(db: Session, app_user_id: int) -> dict[str, Profile]:
@@ -362,6 +361,7 @@ def _add_tracking(
     app_user_id: int,
     profile_id: int,
     source: str,
+    enforce_limit: bool = True,
 ) -> UserTrackedProfile:
     # Serialize count-and-insert for one user so concurrent requests cannot
     # both observe a free slot and exceed the per-user tracking cap.
@@ -376,17 +376,18 @@ def _add_tracking(
         .first()
     )
     if tracked is None:
-        tracked_count = (
-            db.query(UserTrackedProfile.id)
-            .filter(UserTrackedProfile.user_id == app_user_id)
-            .count()
-        )
-        max_tracked = _positive_limit("SPYBOXD_MAX_TRACKED_PROFILES_PER_USER", 25)
-        if tracked_count >= max_tracked:
-            raise HTTPException(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                detail=f"You can track at most {max_tracked} profiles.",
+        if enforce_limit:
+            tracked_count = (
+                db.query(UserTrackedProfile.id)
+                .filter(UserTrackedProfile.user_id == app_user_id)
+                .count()
             )
+            max_tracked = _positive_limit("SPYBOXD_MAX_TRACKED_PROFILES_PER_USER", 25)
+            if tracked_count >= max_tracked:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail=f"You can track at most {max_tracked} profiles.",
+                )
         tracked = UserTrackedProfile(
             user_id=app_user_id,
             profile_id=profile_id,
@@ -423,6 +424,305 @@ def profile_summary(profile: Profile) -> dict[str, Any]:
     }
 
 
+def _missing_required_identity() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail=(
+            "Your account is missing its required Letterboxd username. "
+            "Sign out and complete sign-up again, or contact an administrator."
+        ),
+    )
+
+
+def _identity_status_without_provisioning(
+    db: Session,
+    *,
+    app_user: AppUser,
+    username: str,
+    normalized_username: str,
+) -> dict[str, Any]:
+    """Describe a grandfathered identity without creating access or a request."""
+
+    profile = _single_profile_by_normalized_username(db, normalized_username)
+    if profile is not None:
+        tracked = (
+            db.query(UserTrackedProfile.id)
+            .filter(
+                UserTrackedProfile.user_id == app_user.id,
+                UserTrackedProfile.profile_id == profile.id,
+            )
+            .first()
+        )
+        if tracked is not None:
+            return {
+                "letterboxd_username": username,
+                "primary_profile_status": "tracked",
+            }
+
+    request = (
+        db.query(ProfileAccessRequest)
+        .filter(
+            ProfileAccessRequest.user_id == app_user.id,
+            ProfileAccessRequest.normalized_username == normalized_username,
+        )
+        .first()
+    )
+    if request is not None:
+        request_status = (
+            request.status
+            if request.status in {"pending", "approved", "rejected"}
+            else "unlinked"
+        )
+        return {
+            "letterboxd_username": username,
+            "primary_profile_status": request_status,
+        }
+
+    if (
+        profile is not None
+        and profile.is_active
+        and profile.scraping_status == "completed"
+    ):
+        return {
+            "letterboxd_username": username,
+            "primary_profile_status": "available",
+        }
+
+    return {
+        "letterboxd_username": username,
+        "primary_profile_status": "unlinked",
+    }
+
+
+def _provision_app_user_identity_once(
+    db: Session,
+    clerk_user: ClerkUser,
+    *,
+    claimed_username: Optional[str],
+    claimed_normalized_username: Optional[str],
+) -> dict[str, Any]:
+    app_user = (
+        db.query(AppUser)
+        .filter(AppUser.clerk_user_id == clerk_user.user_id)
+        .first()
+    )
+    if app_user is None:
+        if claimed_username is None and not clerk_user.is_admin:
+            raise _missing_required_identity()
+        app_user = AppUser(
+            clerk_user_id=clerk_user.user_id,
+            letterboxd_username=claimed_username,
+            # Admin/service compatibility is intentionally exempt. All new
+            # ordinary accounts must finish the primary-profile flow.
+            primary_profile_required=not clerk_user.is_admin,
+        )
+        db.add(app_user)
+        db.flush()
+    elif not app_user.is_active:
+        raise HTTPException(status_code=403, detail="User access is disabled")
+
+    # Admin identities remain compatible even if an older application process
+    # inserted their row after the migration's grandfathering UPDATE.
+    if clerk_user.is_admin and app_user.primary_profile_required:
+        app_user.primary_profile_required = False
+        db.flush()
+
+    stored_username: Optional[str] = app_user.letterboxd_username
+    stored_normalized_username: Optional[str] = None
+    if stored_username is not None:
+        stored_username, stored_normalized_username = normalize_profile_username(
+            stored_username
+        )
+
+    if claimed_username is not None:
+        if stored_username is None:
+            app_user.letterboxd_username = claimed_username
+            stored_username = claimed_username
+            stored_normalized_username = claimed_normalized_username
+            db.flush()
+        elif stored_normalized_username != claimed_normalized_username:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Your Clerk username no longer matches the Letterboxd username "
+                    "linked to this Spyboxd account. Contact an administrator to migrate it."
+                ),
+            )
+
+    if stored_username is None or stored_normalized_username is None:
+        if app_user.primary_profile_required:
+            raise _missing_required_identity()
+        db.commit()
+        return {
+            "letterboxd_username": None,
+            "primary_profile_status": "unconfigured",
+        }
+
+    if not app_user.primary_profile_required:
+        identity = _identity_status_without_provisioning(
+            db,
+            app_user=app_user,
+            username=stored_username,
+            normalized_username=stored_normalized_username,
+        )
+        db.commit()
+        return identity
+
+    _lock_user_access_mutations(db, app_user.id)
+    profile = _single_profile_by_normalized_username(
+        db,
+        stored_normalized_username,
+    )
+    tracked = None
+    if profile is not None:
+        tracked = (
+            db.query(UserTrackedProfile)
+            .filter(
+                UserTrackedProfile.user_id == app_user.id,
+                UserTrackedProfile.profile_id == profile.id,
+            )
+            .first()
+        )
+    if tracked is not None:
+        db.commit()
+        return {
+            "letterboxd_username": stored_username,
+            "primary_profile_status": "tracked",
+        }
+
+    request = (
+        db.query(ProfileAccessRequest)
+        .filter(
+            ProfileAccessRequest.user_id == app_user.id,
+            ProfileAccessRequest.normalized_username
+            == stored_normalized_username,
+        )
+        .first()
+    )
+
+    # An automatic first-login retry must not undo a moderator's rejection.
+    if request is not None and request.status == "rejected":
+        db.commit()
+        return {
+            "letterboxd_username": stored_username,
+            "primary_profile_status": "rejected",
+        }
+
+    if (
+        profile is not None
+        and profile.is_active
+        and profile.scraping_status == "completed"
+    ):
+        _add_tracking(
+            db,
+            app_user_id=app_user.id,
+            profile_id=profile.id,
+            source="direct",
+            # The mandatory primary identity is not an optional monitoring slot.
+            enforce_limit=False,
+        )
+        if request is not None:
+            request.status = "fulfilled"
+            request.fulfilled_profile_id = profile.id
+            request.resolved_at = datetime.now(timezone.utc)
+        db.commit()
+        return {
+            "letterboxd_username": stored_username,
+            "primary_profile_status": "tracked",
+        }
+
+    if request is not None:
+        request_status = (
+            request.status
+            if request.status in {"pending", "approved", "rejected"}
+            else "unlinked"
+        )
+        db.commit()
+        return {
+            "letterboxd_username": stored_username,
+            "primary_profile_status": request_status,
+        }
+
+    db.add(
+        ProfileAccessRequest(
+            user_id=app_user.id,
+            requested_username=stored_username,
+            normalized_username=stored_normalized_username,
+            status="pending",
+        )
+    )
+    db.flush()
+    db.commit()
+    return {
+        "letterboxd_username": stored_username,
+        "primary_profile_status": "pending",
+    }
+
+
+def provision_app_user_identity(
+    db: Session,
+    clerk_user: ClerkUser,
+) -> dict[str, Any]:
+    """Atomically bind a Clerk identity to its mandatory Letterboxd profile.
+
+    Clerk's stable subject remains the authorization key. The signed username is
+    copied once into the local user row, then the existing shared-profile access
+    model either grants the completed profile or queues exactly one sync request.
+    A migration marker keeps pre-existing users and admins on their old behavior.
+    """
+
+    if clerk_user.user_id == "ingestion-token" and clerk_user.session_id is None:
+        return {
+            "letterboxd_username": None,
+            "primary_profile_status": "unconfigured",
+        }
+
+    claimed_username: Optional[str] = None
+    claimed_normalized_username: Optional[str] = None
+    if clerk_user.letterboxd_username is not None:
+        claimed_username, claimed_normalized_username = normalize_profile_username(
+            clerk_user.letterboxd_username
+        )
+
+    for attempt in range(2):
+        try:
+            return _provision_app_user_identity_once(
+                db,
+                clerk_user,
+                claimed_username=claimed_username,
+                claimed_normalized_username=claimed_normalized_username,
+            )
+        except IntegrityError as exc:
+            db.rollback()
+            concurrent_user = (
+                db.query(AppUser)
+                .filter(AppUser.clerk_user_id == clerk_user.user_id)
+                .first()
+            )
+            if concurrent_user is not None and attempt == 0:
+                continue
+            if claimed_normalized_username is not None:
+                conflicting_user = (
+                    db.query(AppUser)
+                    .filter(
+                        func.lower(AppUser.letterboxd_username)
+                        == claimed_normalized_username
+                    )
+                    .first()
+                )
+                if conflicting_user is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="This Letterboxd username is already linked to another Spyboxd account.",
+                    ) from exc
+            raise
+        except Exception:
+            db.rollback()
+            raise
+
+    raise RuntimeError("Unreachable identity provisioning retry state")
+
+
 def request_summary(
     request: ProfileAccessRequest,
     *,
@@ -454,6 +754,17 @@ def request_summary(
     return summary
 
 
+def _request_is_required_primary(request: ProfileAccessRequest) -> bool:
+    app_user = request.user
+    return bool(
+        app_user is not None
+        and app_user.primary_profile_required
+        and app_user.letterboxd_username
+        and app_user.letterboxd_username.casefold()
+        == request.normalized_username.casefold()
+    )
+
+
 def fulfill_pending_requests(
     db: Session,
     profile: Profile,
@@ -466,6 +777,7 @@ def fulfill_pending_requests(
     normalized = profile.username.casefold()
     requests = (
         db.query(ProfileAccessRequest)
+        .options(joinedload(ProfileAccessRequest.user))
         .filter(
             ProfileAccessRequest.normalized_username == normalized,
             ProfileAccessRequest.status.in_(("pending", "approved")),
@@ -482,6 +794,7 @@ def fulfill_pending_requests(
                 app_user_id=request.user_id,
                 profile_id=profile.id,
                 source="request_fulfillment",
+                enforce_limit=not _request_is_required_primary(request),
             )
         except HTTPException as exc:
             if exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS:
@@ -757,6 +1070,7 @@ def decide_profile_request(
                     app_user_id=request.user_id,
                     profile_id=profile.id,
                     source="request_fulfillment",
+                    enforce_limit=not _request_is_required_primary(request),
                 )
             except HTTPException as exc:
                 if exc.status_code != status.HTTP_429_TOO_MANY_REQUESTS:
@@ -770,8 +1084,16 @@ def decide_profile_request(
 
 
 def untrack_profile(db: Session, clerk_user: ClerkUser, username: str) -> bool:
-    _, normalized = normalize_profile_username(username)
+    normalized = _normalize_stored_profile_lookup(username)
     app_user = ensure_app_user(db, clerk_user)
+    primary_username = app_user.letterboxd_username
+    if app_user.primary_profile_required and primary_username is not None:
+        normalized_primary = primary_username.casefold()
+        if normalized == normalized_primary:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Your primary Letterboxd profile cannot be untracked.",
+            )
     _lock_user_access_mutations(db, app_user.id)
     profile = _single_profile_by_normalized_username(
         db,

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -22,7 +22,8 @@ class AdditiveMigrationContractTests(unittest.TestCase):
         config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
         script = ScriptDirectory.from_config(config)
 
-        self.assertEqual(script.get_heads(), ["20260730_0008"])
+        self.assertEqual(script.get_heads(), ["20260730_0009"])
+        self.assertEqual(script.get_revision("20260730_0009").down_revision, "20260730_0008")
         self.assertEqual(script.get_revision("20260730_0008").down_revision, "20260729_0007")
         self.assertEqual(script.get_revision("20260729_0007").down_revision, "20260729_0006")
         self.assertEqual(script.get_revision("20260729_0006").down_revision, "20260729_0005")
@@ -89,7 +90,12 @@ class AdditiveMigrationContractTests(unittest.TestCase):
             "profile_source_activities": {"profile_id", "movie_id", "activity_type", "activity_date", "date_semantics"},
             "movie_lists": {"tags"},
             "watchlist_items": {"added_date_source_kind"},
-            "app_users": {"clerk_user_id", "is_active"},
+            "app_users": {
+                "clerk_user_id",
+                "letterboxd_username",
+                "primary_profile_required",
+                "is_active",
+            },
             "user_tracked_profiles": {"user_id", "profile_id", "source"},
             "profile_access_requests": {
                 "user_id",
@@ -129,11 +135,36 @@ class AdditiveMigrationContractTests(unittest.TestCase):
         self.assertIn("uq_profiles_username_lower", profile_indexes)
         self.assertTrue(profile_indexes["uq_profiles_username_lower"].unique)
 
+        app_user_indexes = {
+            index.name: index for index in Base.metadata.tables["app_users"].indexes
+        }
+        self.assertIn(
+            "uq_app_users_letterboxd_username_lower",
+            app_user_indexes,
+        )
+        self.assertTrue(
+            app_user_indexes["uq_app_users_letterboxd_username_lower"].unique
+        )
+
         migration_source = (
             REPO_ROOT / "alembic/versions/20260730_0008_add_profile_access.py"
         ).read_text()
         self.assertIn("HAVING count(*) > 1", migration_source)
         self.assertIn("uq_profiles_username_lower", migration_source)
+
+        identity_migration_source = (
+            REPO_ROOT
+            / "alembic/versions/20260730_0009_add_letterboxd_identity.py"
+        ).read_text()
+        self.assertIn(
+            "uq_app_users_letterboxd_username_lower",
+            identity_migration_source,
+        )
+        self.assertIn(
+            "UPDATE app_users SET primary_profile_required = false",
+            identity_migration_source,
+        )
+        self.assertIn("server_default=sa.text(\"true\")", identity_migration_source)
 
 
 @unittest.skipUnless(
@@ -155,7 +186,7 @@ class AdditiveMigrationPostgresTests(unittest.TestCase):
             connection.execute(text("SET TRANSACTION READ ONLY"))
             try:
                 current_revision = connection.execute(text("SELECT version_num FROM alembic_version")).scalar_one()
-                self.assertEqual(current_revision, "20260730_0008")
+                self.assertEqual(current_revision, "20260730_0009")
 
                 counts = connection.execute(
                     text(

--- a/backend/tests/test_auth_context.py
+++ b/backend/tests/test_auth_context.py
@@ -34,6 +34,7 @@ def test_current_user_validates_exact_issuer_and_authorized_party(monkeypatch):
             "sid": "session_one",
             "iss": "https://clerk.example",
             "azp": "https://spyboxd.com",
+            "letterboxd_username": "  FilmFan_7  ",
         }
 
     monkeypatch.setattr(auth.jwt, "decode", decode)
@@ -41,6 +42,7 @@ def test_current_user_validates_exact_issuer_and_authorized_party(monkeypatch):
     user = auth.get_current_user(_credentials())
 
     assert user.user_id == "user_one"
+    assert user.letterboxd_username == "FilmFan_7"
     assert captured["issuer"] == "https://clerk.example"
     assert captured["options"]["verify_iss"] is True
     assert captured["options"]["verify_nbf"] is True
@@ -104,4 +106,23 @@ def test_local_development_defaults_accept_localhost_azp(monkeypatch):
         },
     )
 
-    assert auth.get_current_user(_credentials()).user_id == "local_user"
+    user = auth.get_current_user(_credentials())
+    assert user.user_id == "local_user"
+    assert user.letterboxd_username is None
+
+
+def test_non_string_letterboxd_username_claim_is_ignored(monkeypatch):
+    monkeypatch.setenv("CLERK_JWKS_URL", "https://clerk.example/.well-known/jwks.json")
+    monkeypatch.setenv("CLERK_ISSUER", "https://clerk.example")
+    _stub_jwks(monkeypatch)
+    monkeypatch.setattr(
+        auth.jwt,
+        "decode",
+        lambda *_args, **_kwargs: {
+            "sub": "user_one",
+            "sid": "session_one",
+            "letterboxd_username": {"not": "a string"},
+        },
+    )
+
+    assert auth.get_current_user(_credentials()).letterboxd_username is None

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -38,6 +38,8 @@ from backend.services.profile_access import (
     fulfill_pending_requests,
     list_profile_catalog,
     list_profile_requests,
+    normalize_profile_username,
+    provision_app_user_identity,
     reopen_fulfilled_requests_for_profile,
     require_profile_access,
     track_profile_by_id,
@@ -89,8 +91,40 @@ def database():
         engine.dispose()
 
 
-def _user(user_id: str = "user_one", *, admin: bool = False) -> ClerkUser:
-    return ClerkUser(user_id=user_id, session_id="session", is_admin=admin)
+def _user(
+    user_id: str = "user_one",
+    *,
+    admin: bool = False,
+    letterboxd_username: str | None = None,
+) -> ClerkUser:
+    return ClerkUser(
+        user_id=user_id,
+        session_id="session",
+        is_admin=admin,
+        letterboxd_username=letterboxd_username,
+    )
+
+
+def _legacy_user(
+    database,
+    user_id: str = "user_one",
+    *,
+    admin: bool = False,
+) -> ClerkUser:
+    app_user = (
+        database.query(AppUser)
+        .filter(AppUser.clerk_user_id == user_id)
+        .first()
+    )
+    if app_user is None:
+        database.add(
+            AppUser(
+                clerk_user_id=user_id,
+                primary_profile_required=False,
+            )
+        )
+        database.commit()
+    return _user(user_id, admin=admin)
 
 
 def _profile(profile_id: int, username: str, *, completed: bool = True) -> Profile:
@@ -102,20 +136,277 @@ def _profile(profile_id: int, username: str, *, completed: bool = True) -> Profi
     )
 
 
+@pytest.mark.parametrize(
+    "raw_username,canonical",
+    [
+        ("ab", "ab"),
+        (" FilmFan_7 ", "FilmFan_7"),
+        ("@Viewer", "Viewer"),
+        ("123456789012345", "123456789012345"),
+    ],
+)
+def test_letterboxd_username_validation_accepts_the_source_contract(
+    raw_username,
+    canonical,
+):
+    assert normalize_profile_username(raw_username) == (
+        canonical,
+        canonical.casefold(),
+    )
+
+
+@pytest.mark.parametrize(
+    "raw_username",
+    [
+        "a",
+        "1234567890123456",
+        "with-hyphen",
+        "has space",
+        "film.fan",
+        "fílmfan",
+    ],
+)
+def test_letterboxd_username_validation_rejects_non_letterboxd_handles(
+    raw_username,
+):
+    with pytest.raises(HTTPException) as raised:
+        normalize_profile_username(raw_username)
+    assert raised.value.status_code == 400
+
+
+def test_primary_identity_tracks_an_existing_profile_atomically_and_idempotently(
+    database,
+):
+    database.add(_profile(1, "Alpha"))
+    database.commit()
+    user = _user(letterboxd_username="aLpHa")
+
+    first = provision_app_user_identity(database, user)
+    second = provision_app_user_identity(database, user)
+
+    assert first == second == {
+        "letterboxd_username": "aLpHa",
+        "primary_profile_status": "tracked",
+    }
+    app_user = database.query(AppUser).one()
+    assert app_user.letterboxd_username == "aLpHa"
+    assert app_user.primary_profile_required is True
+    assert database.query(UserTrackedProfile).count() == 1
+    assert database.query(ProfileAccessRequest).count() == 0
+
+
+def test_primary_identity_creates_one_pending_request_and_preserves_rejection(
+    database,
+):
+    user = _user(letterboxd_username="New_User")
+
+    first = provision_app_user_identity(database, user)
+    repeated = provision_app_user_identity(database, user)
+    request = database.query(ProfileAccessRequest).one()
+    request.status = "rejected"
+    database.commit()
+    after_rejection = provision_app_user_identity(database, user)
+
+    assert first["primary_profile_status"] == "pending"
+    assert repeated["primary_profile_status"] == "pending"
+    assert after_rejection["primary_profile_status"] == "rejected"
+    assert database.query(ProfileAccessRequest).count() == 1
+    assert database.query(UserTrackedProfile).count() == 0
+
+
+def test_primary_identity_fulfillment_is_not_blocked_by_optional_tracking_limit(
+    database,
+    monkeypatch,
+):
+    monkeypatch.setenv("SPYBOXD_MAX_TRACKED_PROFILES_PER_USER", "1")
+    optional = _profile(1, "Optional")
+    database.add(optional)
+    database.commit()
+    user = _user(letterboxd_username="Primary")
+
+    assert provision_app_user_identity(database, user)["primary_profile_status"] == "pending"
+    track_profile_by_id(database, user, optional.id)
+
+    primary = _profile(2, "Primary")
+    database.add(primary)
+    database.commit()
+
+    assert fulfill_pending_requests(database, primary) == 1
+    assert {
+        profile.username for profile in tracked_profiles(database, user)
+    } == {"Optional", "Primary"}
+
+
+def test_primary_identity_failure_rolls_back_the_new_user_and_access_mapping(
+    database,
+    monkeypatch,
+):
+    database.add(_profile(1, "Alpha"))
+    database.commit()
+
+    def fail_tracking(*_args, **_kwargs):
+        raise RuntimeError("synthetic tracking failure")
+
+    monkeypatch.setattr(profile_access_service, "_add_tracking", fail_tracking)
+
+    with pytest.raises(RuntimeError, match="synthetic tracking failure"):
+        provision_app_user_identity(
+            database,
+            _user(letterboxd_username="Alpha"),
+        )
+
+    assert database.query(AppUser).count() == 0
+    assert database.query(UserTrackedProfile).count() == 0
+    assert database.query(ProfileAccessRequest).count() == 0
+
+
+def test_primary_identity_is_unique_case_insensitively(database):
+    provision_app_user_identity(
+        database,
+        _user("first_user", letterboxd_username="FilmFan"),
+    )
+
+    with pytest.raises(HTTPException) as raised:
+        provision_app_user_identity(
+            database,
+            _user("second_user", letterboxd_username="filmfan"),
+        )
+
+    assert raised.value.status_code == 409
+    assert database.query(AppUser).count() == 1
+    assert database.query(ProfileAccessRequest).count() == 1
+
+
+def test_legacy_admin_and_ingestion_service_do_not_require_the_new_claim(database):
+    legacy = provision_app_user_identity(database, _user("admin", admin=True))
+    ingestion = provision_app_user_identity(
+        database,
+        ClerkUser(user_id="ingestion-token", session_id=None, is_admin=True),
+    )
+
+    assert legacy == {
+        "letterboxd_username": None,
+        "primary_profile_status": "unconfigured",
+    }
+    assert ingestion == legacy
+    assert [user.clerk_user_id for user in database.query(AppUser).all()] == [
+        "admin"
+    ]
+    assert database.query(AppUser).one().primary_profile_required is False
+
+
+def test_new_non_admin_fails_closed_without_the_signed_username_claim(database):
+    user = _user("missing_identity")
+
+    with pytest.raises(HTTPException) as direct:
+        provision_app_user_identity(database, user)
+    with pytest.raises(HTTPException) as first_route:
+        list_profile_catalog(database, user)
+
+    assert direct.value.status_code == 409
+    assert first_route.value.status_code == 409
+    assert database.query(AppUser).count() == 0
+    assert database.query(ProfileAccessRequest).count() == 0
+
+
+def test_grandfathered_admin_claim_does_not_create_a_profile_request(database):
+    database.add(
+        AppUser(
+            clerk_user_id="admin",
+            primary_profile_required=False,
+        )
+    )
+    database.commit()
+
+    identity = provision_app_user_identity(
+        database,
+        _user("admin", admin=True, letterboxd_username="admin"),
+    )
+
+    assert identity == {
+        "letterboxd_username": "admin",
+        "primary_profile_status": "unlinked",
+    }
+    assert database.query(AppUser).one().letterboxd_username == "admin"
+    assert database.query(ProfileAccessRequest).count() == 0
+    assert database.query(UserTrackedProfile).count() == 0
+
+
+def test_stored_primary_identity_is_not_silently_retargeted(database):
+    database.add(
+        AppUser(
+            clerk_user_id="user_one",
+            letterboxd_username="Alpha",
+        )
+    )
+    database.commit()
+
+    with pytest.raises(HTTPException) as raised:
+        provision_app_user_identity(
+            database,
+            _user(letterboxd_username="Beta"),
+        )
+
+    assert raised.value.status_code == 409
+    assert database.query(AppUser).one().letterboxd_username == "Alpha"
+    assert database.query(ProfileAccessRequest).count() == 0
+
+
+def test_primary_profile_cannot_be_untracked(database):
+    alpha = _profile(1, "Alpha")
+    beta = _profile(2, "Beta")
+    database.add_all([alpha, beta])
+    database.commit()
+    user = _user(letterboxd_username="Alpha")
+    provision_app_user_identity(database, user)
+    track_profile_by_id(database, user, beta.id)
+
+    with pytest.raises(HTTPException) as raised:
+        untrack_profile(database, user, "alpha")
+
+    assert raised.value.status_code == 409
+    assert untrack_profile(database, user, "Beta") is True
+    assert [profile.username for profile in tracked_profiles(database, user)] == [
+        "Alpha"
+    ]
+
+
+def test_me_returns_canonical_identity_and_primary_profile_status(database):
+    backend_main.app.dependency_overrides[backend_main.get_db] = lambda: database
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: _user(
+        "new_user",
+        letterboxd_username="FilmFan",
+    )
+    client = TestClient(backend_main.app)
+    try:
+        response = client.get("/api/me")
+    finally:
+        backend_main.app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": "new_user",
+        "is_admin": False,
+        "letterboxd_username": "FilmFan",
+        "primary_profile_status": "pending",
+    }
+
+
 def test_existing_completed_profile_is_tracked_case_insensitively_and_idempotently(database):
     database.add_all([_profile(1, "Alpha"), _profile(2, "Beta")])
     database.commit()
+    user = _legacy_user(database)
 
-    first = track_or_request_profile(database, _user(), "aLpHa")
-    second = track_or_request_profile(database, _user(), "ALPHA")
+    first = track_or_request_profile(database, user, "aLpHa")
+    second = track_or_request_profile(database, user, "ALPHA")
 
     assert first["status"] == "tracked"
     assert first["profile"]["username"] == "Alpha"
     assert second["status"] == "tracked"
     assert database.query(UserTrackedProfile).count() == 1
-    assert authorize_profile_usernames(database, _user(), None) == ["Alpha"]
+    assert authorize_profile_usernames(database, user, None) == ["Alpha"]
     with pytest.raises(HTTPException) as raised:
-        authorize_profile_usernames(database, _user(), ["Beta"])
+        authorize_profile_usernames(database, user, ["Beta"])
     assert raised.value.status_code == 403
 
 
@@ -136,8 +427,9 @@ def test_signed_in_catalog_lists_only_selectable_profiles_and_tracks_by_id(datab
         )
     )
     database.commit()
+    user = _legacy_user(database)
 
-    initial = list_profile_catalog(database, _user())
+    initial = list_profile_catalog(database, user)
     assert initial["total"] == 1
     assert initial["profiles"] == [
         {
@@ -150,23 +442,25 @@ def test_signed_in_catalog_lists_only_selectable_profiles_and_tracks_by_id(datab
         }
     ]
 
-    tracked = track_profile_by_id(database, _user(), selectable.id)
+    tracked = track_profile_by_id(database, user, selectable.id)
     assert tracked["status"] == "tracked"
-    assert list_profile_catalog(database, _user())["profiles"][0]["is_tracked"] is True
+    assert list_profile_catalog(database, user)["profiles"][0]["is_tracked"] is True
 
     with pytest.raises(HTTPException) as unavailable:
-        track_profile_by_id(database, _user(), pending.id)
+        track_profile_by_id(database, user, pending.id)
     assert unavailable.value.status_code == 404
 
 
 def test_profile_catalog_tracking_is_isolated_per_user(database):
     database.add(_profile(1, "Alpha"))
     database.commit()
+    first_user = _legacy_user(database, "first")
+    second_user = _legacy_user(database, "second")
 
-    track_profile_by_id(database, _user("first"), 1)
+    track_profile_by_id(database, first_user, 1)
 
-    assert list_profile_catalog(database, _user("first"))["profiles"][0]["is_tracked"] is True
-    assert list_profile_catalog(database, _user("second"))["profiles"][0]["is_tracked"] is False
+    assert list_profile_catalog(database, first_user)["profiles"][0]["is_tracked"] is True
+    assert list_profile_catalog(database, second_user)["profiles"][0]["is_tracked"] is False
 
 
 def test_admin_personal_monitoring_is_separate_from_global_library_access(database):
@@ -183,12 +477,13 @@ def test_admin_personal_monitoring_is_separate_from_global_library_access(databa
 
 
 def test_non_admin_cannot_request_global_dashboard_scope(database):
+    user = _legacy_user(database)
     with pytest.raises(HTTPException) as forbidden:
         asyncio.run(
             backend_main.get_consolidated_dashboard_analytics(
                 scope="global",
                 db=database,
-                user=_user(),
+                user=user,
             )
         )
     assert forbidden.value.status_code == 403
@@ -224,13 +519,14 @@ def test_omitted_dashboard_scope_defaults_non_admin_to_tracked_profiles(database
         ]
     )
     database.commit()
-    track_profile_by_id(database, _user(), alpha.id)
+    user = _legacy_user(database)
+    track_profile_by_id(database, user, alpha.id)
 
     result = asyncio.run(
         backend_main.get_consolidated_dashboard_analytics(
             scope=None,
             db=database,
-            user=_user(),
+            user=user,
         )
     )
 
@@ -267,8 +563,9 @@ def test_explicit_tracked_dashboard_scope_limits_admin_to_personal_set(database)
 
 
 def test_unknown_request_is_casefolded_idempotent_and_fulfills_only_after_sync(database):
-    first = track_or_request_profile(database, _user(), "New_User")
-    second = track_or_request_profile(database, _user(), "new_user")
+    user = _legacy_user(database)
+    first = track_or_request_profile(database, user, "New_User")
+    second = track_or_request_profile(database, user, "new_user")
 
     assert first["status"] == second["status"] == "pending"
     assert database.query(ProfileAccessRequest).count() == 1
@@ -293,8 +590,9 @@ def test_pending_placeholder_stays_a_request_without_access(database):
     profile = _profile(1, "awaiting", completed=False)
     database.add(profile)
     database.commit()
+    user = _legacy_user(database)
 
-    result = track_or_request_profile(database, _user(), "AWAITING")
+    result = track_or_request_profile(database, user, "AWAITING")
 
     assert result["status"] == "pending"
     assert result["profile"]["scraping_status"] == "pending"
@@ -304,23 +602,28 @@ def test_pending_placeholder_stays_a_request_without_access(database):
 
 def test_per_user_request_and_tracking_limits_are_enforced(database, monkeypatch):
     monkeypatch.setenv("SPYBOXD_MAX_PENDING_PROFILE_REQUESTS_PER_USER", "1")
-    track_or_request_profile(database, _user(), "first_unknown")
+    user = _legacy_user(database)
+    track_or_request_profile(database, user, "first_unknown")
     with pytest.raises(HTTPException) as pending_limit:
-        track_or_request_profile(database, _user(), "second_unknown")
+        track_or_request_profile(database, user, "second_unknown")
     assert pending_limit.value.status_code == 429
 
     monkeypatch.setenv("SPYBOXD_MAX_TRACKED_PROFILES_PER_USER", "1")
     database.add_all([_profile(10, "First"), _profile(11, "Second")])
     database.commit()
-    track_or_request_profile(database, _user("another"), "First")
+    another = _legacy_user(database, "another")
+    track_or_request_profile(database, another, "First")
     with pytest.raises(HTTPException) as tracked_limit:
-        track_or_request_profile(database, _user("another"), "Second")
+        track_or_request_profile(database, another, "Second")
     assert tracked_limit.value.status_code == 429
 
 
 def test_untracking_removes_fulfilled_request_and_prevents_silent_regrant(database):
     profile = _profile(1, "Alpha")
-    app_user = AppUser(clerk_user_id="user_one")
+    app_user = AppUser(
+        clerk_user_id="user_one",
+        primary_profile_required=False,
+    )
     database.add_all([profile, app_user])
     database.flush()
     database.add_all(
@@ -340,6 +643,23 @@ def test_untracking_removes_fulfilled_request_and_prevents_silent_regrant(databa
     assert untrack_profile(database, _user(), "alpha") is True
     assert database.query(UserTrackedProfile).count() == 0
     assert database.query(ProfileAccessRequest).count() == 0
+
+
+def test_untracking_preserves_access_to_legacy_profile_usernames(database):
+    profile = _profile(1, "legacy-name")
+    app_user = AppUser(
+        clerk_user_id="user_one",
+        primary_profile_required=False,
+    )
+    database.add_all([profile, app_user])
+    database.flush()
+    database.add(
+        UserTrackedProfile(user_id=app_user.id, profile_id=profile.id)
+    )
+    database.commit()
+
+    assert untrack_profile(database, _user(), "@LEGACY-NAME") is True
+    assert database.query(UserTrackedProfile).count() == 0
 
 
 def test_deleted_profile_requests_reopen_as_approved(database):
@@ -537,15 +857,19 @@ def test_different_pending_usernames_share_the_per_user_lock(database, monkeypat
         lambda _db, app_user_id: locked_user_ids.append(app_user_id),
     )
 
-    track_or_request_profile(database, _user(), "first_unknown")
-    track_or_request_profile(database, _user(), "second_unknown")
+    user = _legacy_user(database)
+    track_or_request_profile(database, user, "first_unknown")
+    track_or_request_profile(database, user, "second_unknown")
 
     app_user = database.query(AppUser).filter_by(clerk_user_id="user_one").one()
     assert locked_user_ids == [app_user.id, app_user.id]
 
 
 def test_non_admin_request_payload_omits_internal_identity_and_notes(database):
-    requester = AppUser(clerk_user_id="requester")
+    requester = AppUser(
+        clerk_user_id="requester",
+        primary_profile_required=False,
+    )
     admin = AppUser(clerk_user_id="admin")
     database.add_all([requester, admin])
     database.flush()
@@ -588,7 +912,10 @@ def test_profile_id_scope_prevents_case_variant_tenant_confusion(database):
     database.execute(text('DROP INDEX "uq_profiles_username_lower"'))
     tracked = _profile(1, "Alpha")
     hidden = _profile(2, "alpha")
-    app_user = AppUser(clerk_user_id="user_one")
+    app_user = AppUser(
+        clerk_user_id="user_one",
+        primary_profile_required=False,
+    )
     database.add_all([tracked, hidden, app_user])
     database.flush()
     database.add(

--- a/backend/tests/test_scraped_directory_cleanup.py
+++ b/backend/tests/test_scraped_directory_cleanup.py
@@ -85,6 +85,7 @@ def test_clear_endpoint_rejects_unsafe_profile_before_database_clear(tmp_path: P
     with (
         patch("backend.main.SCRAPED_DATA_DIR", str(scrape_root)),
         patch("backend.main.ProfileRepository", return_value=repository),
+        patch("backend.main.ensure_app_user"),
         pytest.raises(HTTPException) as raised,
     ):
         asyncio.run(

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -10,6 +10,7 @@ async function expectPublicAuthControl(page: Page, authenticated: boolean) {
     await expect(page.getByRole('button', { name: 'Open user menu' })).toBeVisible();
     return;
   }
+  await expect(page.getByRole('link', { name: 'Create account' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
 }
 
@@ -33,6 +34,8 @@ test('the aggregate dashboard is the anonymous landing page', async ({ page }) =
   await expect(page.getByTestId('public-dashboard')).toBeVisible();
   await expect(page.getByRole('heading', { name: /without exposing anyone's profile/i })).toBeVisible();
   const signInLink = page.getByRole('link', { name: 'Sign in to monitor profiles' });
+  const createAccountLink = page.getByRole('link', { name: 'Create account' });
+  await expect(createAccountLink).toHaveAttribute('href', '/sign-up');
   await expect(signInLink).toBeVisible();
   await expect(signInLink).toHaveAttribute('href', '/sign-in?redirect_url=%2Fprofiles');
   await expect(page.getByRole('link', { name: 'Sign in for private tools' }))
@@ -47,6 +50,25 @@ test('the aggregate dashboard is the anonymous landing page', async ({ page }) =
   await expect(page.getByRole('heading', { name: 'Sign in', exact: true })).toBeVisible();
   await expect.poll(() => page.evaluate(() => getComputedStyle(document.documentElement).colorScheme))
     .toContain('dark');
+});
+
+test('sign-up uses one required Letterboxd username as the Spyboxd identity', async ({ page }) => {
+  await installApiMocks(page, { authenticated: false });
+
+  await page.goto('/sign-up');
+
+  await expect(page.getByRole('heading', {
+    level: 1,
+    name: 'Your Letterboxd username is your Spyboxd username.',
+  })).toBeVisible();
+  await expect(page.getByText(/automatically monitor it if it is already synced/i)).toBeVisible();
+  const usernameInput = page.getByRole('textbox', { name: 'Letterboxd username' });
+  await expect(usernameInput).toBeVisible();
+  await expect(usernameInput).toHaveAttribute('required', '');
+  await expect(usernameInput).toHaveAttribute('minlength', '2');
+  await expect(usernameInput).toHaveAttribute('maxlength', '15');
+  await expect(usernameInput).toHaveAttribute('pattern', '[A-Za-z0-9_]{2,15}');
+  await expect(page.locator('[data-force-redirect-url="/profiles?onboarding=1"]')).toBeAttached();
 });
 
 for (const authenticated of [false, true]) {

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -297,6 +297,12 @@ function json(route: Route, body: unknown) {
 
 interface ApiFixtureState {
   profiles: typeof profiles;
+  currentUser: {
+    user_id: string;
+    is_admin: boolean;
+    letterboxd_username: string | null;
+    primary_profile_status: 'tracked' | 'pending' | 'approved' | 'rejected' | 'available' | 'unlinked' | 'unconfigured';
+  };
   requests: Array<{
     id: number;
     requester_user_id: string;
@@ -328,7 +334,7 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     });
   }
 
-  if (path === '/api/me') return json(route, { user_id: 'user_e2e', is_admin: isAdmin });
+  if (path === '/api/me') return json(route, state.currentUser);
   if (path === '/profiles' && method === 'GET') return json(route, { profiles: state.profiles });
   if (path === '/profiles/tracked' && method === 'GET') return json(route, { profiles: state.profiles });
   const analysisMatch = path.match(/^\/profiles\/([^/]+)\/analysis$/);
@@ -491,10 +497,19 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
 
 export async function installApiMocks(
   page: Page,
-  options: { authenticated?: boolean; isAdmin?: boolean; profileCount?: number } = {},
+  options: {
+    authenticated?: boolean;
+    isAdmin?: boolean;
+    profileCount?: number;
+    letterboxdUsername?: string | null;
+    primaryProfileStatus?: ApiFixtureState['currentUser']['primary_profile_status'];
+  } = {},
 ) {
   const authenticated = options.authenticated ?? true;
   const isAdmin = options.isAdmin ?? false;
+  const letterboxdUsername = options.letterboxdUsername === undefined
+    ? 'letterboxd_user'
+    : options.letterboxdUsername;
 
   if (authenticated) {
     await page.context().addCookies([{
@@ -505,7 +520,7 @@ export async function installApiMocks(
     }]);
   }
 
-  await page.addInitScript(({ signedIn }) => {
+  await page.addInitScript(({ signedIn, username }) => {
     const effectiveSignedIn = signedIn && document.cookie.split(';').some((cookie) => (
       cookie.trim() === 'spyboxd-e2e-auth=1'
     ));
@@ -514,7 +529,7 @@ export async function installApiMocks(
       firstName: 'E2E',
       lastName: 'User',
       fullName: 'E2E User',
-      username: 'e2e-user',
+      username,
       imageUrl: '',
       hasImage: false,
       organizationMemberships: [],
@@ -525,7 +540,7 @@ export async function installApiMocks(
       user,
       factorVerificationAge: null,
       actor: null,
-      lastActiveToken: { jwt: { claims: { sub: 'user_e2e', sid: 'sess_e2e' } } },
+      lastActiveToken: { jwt: { claims: { sub: 'user_e2e', sid: 'sess_e2e', letterboxd_username: username } } },
       getToken: async () => 'e2e-token',
     } : null;
     const resources = {
@@ -592,12 +607,43 @@ export async function installApiMocks(
       unmountSignIn(node: HTMLElement) {
         node.replaceChildren();
       },
+      mountSignUp(node: HTMLElement, mountProps?: { forceRedirectUrl?: string }) {
+        if (mountProps?.forceRedirectUrl) {
+          node.dataset.forceRedirectUrl = mountProps.forceRedirectUrl;
+        }
+        const wrapper = document.createElement('div');
+        const heading = document.createElement('h2');
+        heading.textContent = 'Create your account';
+        const label = document.createElement('label');
+        label.textContent = 'Letterboxd username';
+        const input = document.createElement('input');
+        input.name = 'username';
+        input.required = true;
+        input.minLength = 2;
+        input.maxLength = 15;
+        input.pattern = '[A-Za-z0-9_]{2,15}';
+        label.append(input);
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'Continue';
+        wrapper.append(heading, label, button);
+        node.replaceChildren(wrapper);
+      },
+      unmountSignUp(node: HTMLElement) {
+        node.replaceChildren();
+      },
     };
     Object.assign(globalThis, { Clerk: clerk });
-  }, { signedIn: authenticated });
+  }, { signedIn: authenticated, username: letterboxdUsername ?? 'legacy_user' });
 
   const state: ApiFixtureState = {
     profiles: profiles.slice(0, options.profileCount ?? profiles.length).map((profile) => ({ ...profile })),
+    currentUser: {
+      user_id: 'user_e2e',
+      is_admin: isAdmin,
+      letterboxd_username: letterboxdUsername,
+      primary_profile_status: options.primaryProfileStatus ?? (letterboxdUsername ? 'pending' : 'unconfigured'),
+    },
     requests: [{
       id: 1,
       requester_user_id: 'user_e2e',

--- a/frontend/e2e/onboarding.spec.ts
+++ b/frontend/e2e/onboarding.spec.ts
@@ -19,3 +19,48 @@ test('one tracked profile explains how to unlock pair features', async ({ page }
   await expect(page.getByRole('heading', { name: 'Add one more profile for Spy Signals' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Add or request a profile' })).toBeVisible();
 });
+
+test('a synced signup profile is identified and cannot be removed', async ({ page }) => {
+  await installApiMocks(page, {
+    profileCount: 1,
+    letterboxdUsername: 'alpha',
+    primaryProfileStatus: 'tracked',
+  });
+
+  await page.goto('/profiles?onboarding=1');
+
+  const identity = page.getByTestId('primary-profile-status');
+  await expect(identity.getByText('@alpha', { exact: true })).toBeVisible();
+  await expect(identity.getByText(/synced and included/i)).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Your Letterboxd profile alpha' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Remove alpha from My Profiles' })).toHaveCount(0);
+  await expect(page.getByTestId('tracked-profile-grid').getByText('Your profile', { exact: true })).toBeVisible();
+});
+
+test('a missing signup profile explains its automatic sync request', async ({ page }) => {
+  await installApiMocks(page, {
+    profileCount: 0,
+    letterboxdUsername: 'new_viewer',
+    primaryProfileStatus: 'pending',
+  });
+
+  await page.goto('/profiles?onboarding=1');
+
+  const identity = page.getByTestId('primary-profile-status');
+  await expect(identity.getByText('@new_viewer', { exact: true })).toBeVisible();
+  await expect(identity.getByText(/automatically requested this profile/i)).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Request another profile' })).toBeVisible();
+});
+
+test('a legacy account without a canonical username receives a repair message', async ({ page }) => {
+  await installApiMocks(page, {
+    profileCount: 0,
+    letterboxdUsername: null,
+    primaryProfileStatus: 'unconfigured',
+  });
+
+  await page.goto('/profiles?onboarding=1');
+
+  await expect(page.getByRole('heading', { name: 'Letterboxd username not linked' })).toBeVisible();
+  await expect(page.getByText(/pre-existing account has no Letterboxd username linked/i)).toBeVisible();
+});

--- a/frontend/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/frontend/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -2,25 +2,39 @@ import { SignUp } from '@clerk/nextjs';
 
 export default function SignUpPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <SignUp
-        fallbackRedirectUrl="/dashboard"
-        appearance={{
-          elements: {
-            rootBox: 'mx-auto',
-            card: 'bg-black/30 backdrop-blur-xl border border-white/10 shadow-2xl',
-            headerTitle: 'text-white',
-            headerSubtitle: 'text-white/60',
-            socialButtonsBlockButton: 'border-white/20 text-white hover:bg-white/10',
-            dividerLine: 'bg-white/10',
-            dividerText: 'text-white/40',
-            formFieldLabel: 'text-white/70',
-            formFieldInput: 'bg-white/5 border-white/20 text-white placeholder:text-white/30 focus:border-cinema-400',
-            formButtonPrimary: 'bg-cinema-500 hover:bg-cinema-600',
-            footerActionLink: 'text-cinema-400 hover:text-cinema-300',
-          },
-        }}
-      />
+    <div className="min-h-screen px-4 py-10 sm:px-6">
+      <div className="mx-auto grid min-h-[calc(100vh-5rem)] max-w-5xl items-center gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(24rem,28rem)]">
+        <section className="max-w-xl" aria-labelledby="signup-introduction-title">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cinema-300">Create your account</p>
+          <h1 id="signup-introduction-title" className="mt-3 text-4xl font-bold leading-tight text-white sm:text-5xl">
+            Your Letterboxd username is your Spyboxd username.
+          </h1>
+          <p className="mt-5 text-base leading-7 text-white/60">
+            Use the exact username from your Letterboxd profile. After sign-up, Spyboxd will automatically monitor it if it is already synced, or request it for the next residential data refresh.
+          </p>
+          <p className="mt-4 text-sm leading-6 text-white/45">
+            Letterboxd usernames are 2–15 characters and use only letters, numbers, or underscores. Entering a username links the public profile data; it does not verify ownership of the Letterboxd account.
+          </p>
+        </section>
+        <SignUp
+          forceRedirectUrl="/profiles?onboarding=1"
+          appearance={{
+            elements: {
+              rootBox: 'mx-auto w-full',
+              card: 'bg-black/30 backdrop-blur-xl border border-white/10 shadow-2xl',
+              headerTitle: 'text-white',
+              headerSubtitle: 'text-white/60',
+              socialButtonsBlockButton: 'border-white/20 text-white hover:bg-white/10',
+              dividerLine: 'bg-white/10',
+              dividerText: 'text-white/40',
+              formFieldLabel: 'text-white/70',
+              formFieldInput: 'bg-white/5 border-white/20 text-white placeholder:text-white/30 focus:border-cinema-400',
+              formButtonPrimary: 'bg-cinema-500 hover:bg-cinema-600',
+              footerActionLink: 'text-cinema-400 hover:text-cinema-300',
+            },
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -10,7 +10,15 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <ClerkProvider afterSignOutUrl="/">
+    <ClerkProvider
+      afterSignOutUrl="/"
+      localization={{
+        formFieldLabel__username: 'Letterboxd username',
+        formFieldInputPlaceholder__username: 'e.g. yash03x',
+        formFieldLabel__emailAddress_username: 'Email or Letterboxd username',
+        formFieldInputPlaceholder__emailAddress_username: 'Enter email or Letterboxd username',
+      }}
+    >
       <html lang="en">
         <body>
           <Providers>{children}</Providers>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -20,6 +20,7 @@ import {
   ScaleIcon as ScaleIconSolid,
 } from '@heroicons/react/24/solid';
 import { LogOut, Menu, UsersRound, X } from 'lucide-react';
+import { useCurrentUser } from '../hooks/useCurrentUser';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -73,6 +74,7 @@ const NAVIGATION_ITEMS = [
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const pathname = usePathname();
   const { isSignedIn } = useAuth();
+  const currentUserQuery = useCurrentUser(Boolean(isSignedIn));
   const [isLoaded, setIsLoaded] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
@@ -86,6 +88,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const activeItem = NAVIGATION_ITEMS.find((item) => isActive(item.path));
   const isInsightWorkspace = isActive('/compare') || isActive('/watch-together');
   const signInHref = `/sign-in?redirect_url=${encodeURIComponent(pathname)}`;
+  const accountLabel = currentUserQuery.data?.letterboxd_username
+    ? `@${currentUserQuery.data.letterboxd_username}`
+    : 'Account';
 
   return (
     <motion.div 
@@ -258,7 +263,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               <div className="mt-5 hidden items-center justify-between gap-3 border-t border-white/10 pt-4 text-sm text-white/60 lg:flex">
                 {isSignedIn ? (
                   <>
-                    <div className="flex items-center gap-3"><UserButton /> Account</div>
+                    <div className="flex min-w-0 items-center gap-3">
+                      <UserButton />
+                      <span className="truncate" title={accountLabel}>{accountLabel}</span>
+                    </div>
                     <SignOutButton redirectUrl="/">
                       <button
                         type="button"
@@ -277,7 +285,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
             <div className="mt-5 border-t border-white/10 pt-4 lg:hidden">
               {isSignedIn ? (
-                <div className="flex items-center gap-3 text-sm text-white/60"><UserButton /> Account</div>
+                <div className="flex min-w-0 items-center gap-3 text-sm text-white/60">
+                  <UserButton />
+                  <span className="truncate" title={accountLabel}>{accountLabel}</span>
+                </div>
               ) : (
                 <Link href={signInHref} className="text-sm font-semibold text-cinema-300 hover:text-cinema-200">Sign in</Link>
               )}
@@ -318,6 +329,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               isSignedIn ? (
                 <div className="flex items-center gap-3">
                   <UserButton />
+                  <span className="max-w-44 truncate text-sm font-semibold text-white/65" title={accountLabel}>
+                    {accountLabel}
+                  </span>
                   <SignOutButton redirectUrl="/">
                     <button
                       type="button"

--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -4,10 +4,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { authApi } from '../services/api';
 
-export function useCurrentUser() {
+export function useCurrentUser(enabled = true) {
   return useQuery({
     queryKey: ['current-user'],
     queryFn: authApi.getCurrentUser,
+    enabled,
     staleTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -72,6 +72,8 @@ export interface ProfileInfo {
 export interface CurrentUser {
   user_id: string;
   is_admin: boolean;
+  letterboxd_username: string | null;
+  primary_profile_status: 'tracked' | 'pending' | 'approved' | 'rejected' | 'available' | 'unlinked' | 'unconfigured';
 }
 
 export type ProfileRequestStatus = 'pending' | 'approved' | 'rejected' | 'fulfilled';

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -93,6 +93,7 @@ const ProfileManager: React.FC = () => {
   const { data: profiles, isLoading, error } = useQuery({
     queryKey: ['profiles'],
     queryFn: profileApi.getProfiles,
+    enabled: currentUserQuery.isSuccess,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -100,7 +101,7 @@ const ProfileManager: React.FC = () => {
   const adminTrackedProfilesQuery = useQuery({
     queryKey: ['profiles', 'tracked', 'profile-manager'],
     queryFn: profileApi.getTrackedProfiles,
-    enabled: isAdmin,
+    enabled: currentUserQuery.isSuccess && isAdmin,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -108,6 +109,7 @@ const ProfileManager: React.FC = () => {
   const profileRequestsQuery = useQuery({
     queryKey: ['profile-requests'],
     queryFn: profileApi.getRequests,
+    enabled: currentUserQuery.isSuccess,
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -118,6 +120,7 @@ const ProfileManager: React.FC = () => {
       debouncedCatalogSearchTerm,
       PROFILE_CATALOG_RESULT_LIMIT,
     ),
+    enabled: currentUserQuery.isSuccess,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -125,7 +128,7 @@ const ProfileManager: React.FC = () => {
   const adminRequestsQuery = useQuery({
     queryKey: ['admin-profile-requests'],
     queryFn: () => adminProfileRequestApi.getRequests(),
-    enabled: isAdmin,
+    enabled: currentUserQuery.isSuccess && isAdmin,
     staleTime: 30 * 1000,
     refetchOnWindowFocus: false,
   });
@@ -269,6 +272,11 @@ const ProfileManager: React.FC = () => {
     ? adminTrackedProfilesQuery.data?.length
     : profilesArray.length;
   const normalizedRequestedUsername = requestedUsername.trim().replace(/^@/, '');
+  const primaryUsername = currentUserQuery.data?.letterboxd_username ?? null;
+  const primaryProfileStatus = currentUserQuery.data?.primary_profile_status ?? 'unconfigured';
+  const isPrimaryUsername = (username: string) => (
+    primaryUsername !== null && username.toLowerCase() === primaryUsername.toLowerCase()
+  );
   const filteredProfiles = profilesArray.filter((profile) => {
     const matchesSearch = profile.username.toLowerCase().includes(searchTerm.toLowerCase());
     const matchesFilter =
@@ -343,6 +351,38 @@ const ProfileManager: React.FC = () => {
         )}
       </motion.div>
 
+      {(primaryUsername || searchParams.get('onboarding') === '1') && (
+        <motion.section
+          className="rounded-2xl border border-cinema-400/25 bg-cinema-500/10 p-5"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.22 }}
+          aria-labelledby="primary-profile-status-title"
+          data-testid="primary-profile-status"
+        >
+          <div className="flex items-start gap-4">
+            <span className="grid h-11 w-11 shrink-0 place-items-center rounded-xl border border-cinema-400/30 bg-black/15 text-cinema-200">
+              <ShieldCheck className="h-5 w-5" />
+            </span>
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-cinema-300">Your Spyboxd identity</p>
+              <h2 id="primary-profile-status-title" className="mt-1 text-xl font-bold text-white">
+                {primaryUsername ? `@${primaryUsername}` : 'Letterboxd username not linked'}
+              </h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
+                {primaryProfileStatus === 'tracked' && 'Your Letterboxd profile is synced and included in your monitored profiles.'}
+                {primaryProfileStatus === 'pending' && 'We automatically requested this profile. It is awaiting review before a residential full sync.'}
+                {primaryProfileStatus === 'approved' && 'Your profile request is approved and queued for the next residential full sync.'}
+                {primaryProfileStatus === 'rejected' && 'This profile request was not approved. Contact the administrator if this is the correct Letterboxd username.'}
+                {primaryProfileStatus === 'available' && 'This profile is already synced and can be added from the profile list below.'}
+                {primaryProfileStatus === 'unlinked' && 'This username is linked to your account, but its Letterboxd profile has not been requested yet.'}
+                {primaryProfileStatus === 'unconfigured' && 'This pre-existing account has no Letterboxd username linked. Contact the administrator to repair the account identity.'}
+              </p>
+            </div>
+          </div>
+        </motion.section>
+      )}
+
       <motion.section
         className="card-cinema"
         initial={{ opacity: 0, y: 20 }}
@@ -404,16 +444,20 @@ const ProfileManager: React.FC = () => {
             <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
               {catalogProfiles.map((profile) => {
                 const isBusy = trackingProfileId === profile.id || untrackingProfile === profile.username;
+                const isPrimaryProfile = isPrimaryUsername(profile.username);
                 return (
                   <article key={profile.id} className="flex min-w-0 items-center gap-3 rounded-xl border border-white/10 bg-black/15 p-3">
                     <ProfileAvatar profile={profile} size="lg" />
                     <div className="min-w-0 flex-1">
                       <p className="truncate font-semibold text-white">{profile.display_name || profile.username}</p>
-                      <p className="truncate text-xs text-white/45">@{profile.username} · {profile.total_films.toLocaleString()} films</p>
+                      <p className="truncate text-xs text-white/45">
+                        @{profile.username} · {profile.total_films.toLocaleString()} films
+                        {isPrimaryProfile ? ' · Your profile' : ''}
+                      </p>
                     </div>
                     <button
                       type="button"
-                      disabled={isBusy}
+                      disabled={isBusy || (isPrimaryProfile && profile.is_tracked)}
                       onClick={() => {
                         if (profile.is_tracked) {
                           untrackProfileMutation.mutate(profile.username);
@@ -421,12 +465,14 @@ const ProfileManager: React.FC = () => {
                           trackCatalogProfileMutation.mutate(profile.id);
                         }
                       }}
-                      aria-label={`${profile.is_tracked ? 'Stop monitoring' : 'Monitor'} ${profile.username}`}
+                      aria-label={isPrimaryProfile && profile.is_tracked
+                        ? `Your Letterboxd profile ${profile.username}`
+                        : `${profile.is_tracked ? 'Stop monitoring' : 'Monitor'} ${profile.username}`}
                       className={profile.is_tracked
                         ? 'rounded-lg border border-emerald-400/25 bg-emerald-400/10 px-3 py-2 text-xs font-semibold text-emerald-200 transition-colors hover:bg-emerald-400/20 disabled:opacity-50'
                         : 'rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-3 py-2 text-xs font-semibold text-cinema-200 transition-colors hover:bg-cinema-500/20 disabled:opacity-50'}
                     >
-                      {isBusy ? 'Saving…' : profile.is_tracked ? 'Monitoring' : 'Monitor'}
+                      {isBusy ? 'Saving…' : isPrimaryProfile && profile.is_tracked ? 'Your profile' : profile.is_tracked ? 'Monitoring' : 'Monitor'}
                     </button>
                   </article>
                 );
@@ -449,7 +495,7 @@ const ProfileManager: React.FC = () => {
                 <UserPlus className="h-5 w-5" />
               </span>
               <div>
-                <h2 className="text-xl font-bold text-white">Request a profile that is not listed</h2>
+                <h2 className="text-xl font-bold text-white">Request another profile</h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-white/60">
                   Enter a Letterboxd username that Spyboxd does not have yet. It will be sent for review and, once accepted, queued for the next residential full sync.
                 </p>
@@ -472,6 +518,9 @@ const ProfileManager: React.FC = () => {
                 onChange={(event) => setRequestedUsername(event.target.value)}
                 className="input-field w-full"
                 autoComplete="off"
+                maxLength={16}
+                pattern="@?[A-Za-z0-9_]{2,15}"
+                title="Use 2–15 letters, numbers, or underscores."
               />
             </label>
             <button
@@ -803,6 +852,7 @@ const ProfileManager: React.FC = () => {
             <motion.div data-testid="tracked-profile-grid" className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6" layout>
               {filteredProfiles.map((profile) => {
                 const badge = getStatusBadge(profile.scraping_status);
+                const isPrimaryProfile = isPrimaryUsername(profile.username);
                 const coverageSummary =
                   profile.data_coverage?.summary ||
                   'Run the local full sync workflow to populate this profile.';
@@ -839,6 +889,14 @@ const ProfileManager: React.FC = () => {
                         >
                           <TrashIcon className={`w-4 h-4 text-red-400 ${deletingProfile === profile.username ? 'animate-pulse' : ''}`} />
                         </button>
+                      ) : isPrimaryProfile ? (
+                        <span
+                          className="inline-flex items-center gap-2 rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-3 py-2 text-xs font-semibold text-cinema-200"
+                          title="Your Letterboxd profile is your Spyboxd identity"
+                        >
+                          <ShieldCheck className="h-4 w-4" />
+                          Your profile
+                        </span>
                       ) : (
                         <button
                           onClick={() => {

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -124,7 +124,10 @@ function PublicHeader({ isSignedIn }: { isSignedIn: boolean | undefined }) {
             <UserButton />
           </>
         ) : (
-          <Link href="/sign-in?redirect_url=%2Fprofiles" className="btn-primary whitespace-nowrap">Sign in to monitor profiles</Link>
+          <>
+            <Link href="/sign-up" className="btn-primary whitespace-nowrap">Create account</Link>
+            <Link href="/sign-in?redirect_url=%2Fprofiles" className="btn-secondary whitespace-nowrap">Sign in to monitor profiles</Link>
+          </>
         )}
       </div>
     </header>


### PR DESCRIPTION
## Summary
- make Clerk username the canonical Letterboxd and Spyboxd handle
- require signed username provisioning for new users while grandfathering existing/admin identities
- automatically track an existing completed profile or create one pending residential-sync request
- prevent removing the mandatory primary profile and preserve untracking for legacy stored usernames
- add the public create-account path, signup explanation, identity status, and private navigation handle
- add an additive migration with case-insensitive username uniqueness

## Validation
- `.venv/bin/python -m pytest backend/tests -q` (232 passed, 1 PostgreSQL check skipped locally, 19 subtests passed)
- `npm run lint -- --max-warnings=0`
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e -- --workers=1` (72 passed across desktop and mobile)
- rendered real Clerk development signup verified in-browser

## Clerk configuration applied
- production and development require 2–15 character usernames, letters/numbers/underscore, including numeric-only handles
- signed `letterboxd_username` session claim added without removing `public_metadata`
- self-service username changes and account deletion disabled; deletion policy applied to existing users

Entering a Letterboxd handle links public profile data but is not proof of ownership; the signup UI says this explicitly.