### PR TITLE
Preserve optional Clerk deploy argument

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,8 @@ jobs:
           grep -Fq 'REPOSITORY_URL: https://github.com/' .github/workflows/deploy.yml
           grep -Fq 'github.repository' .github/workflows/deploy.yml
           grep -Fq 'repository_git remote set-url origin "${REPOSITORY_URL}"' .github/workflows/deploy.yml
+          grep -Fq '"${REPOSITORY_URL}" "${CLERK_BRIDGE_EDGE}" <<' .github/workflows/deploy.yml
+          grep -Fq 'CLERK_BRIDGE_EDGE="${5:-}"' .github/workflows/deploy.yml
           if grep -n -F 'appleboy/' \
               .github/workflows/deploy.yml \
               .github/workflows/rollback.yml \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,13 +189,13 @@ jobs:
           timeout --signal=TERM --kill-after=2m 30m \
             deploy/production-ssh.sh run sh -s -- \
               "${RELEASE_SHA}" "${REMOTE_BUNDLE}" "${REMOTE_CHECKSUM}" \
-              "${CLERK_BRIDGE_EDGE}" "${REPOSITORY_URL}" <<'REMOTE'
+              "${REPOSITORY_URL}" "${CLERK_BRIDGE_EDGE}" <<'REMOTE'
             set -eu
             RELEASE_SHA="$1"
             REMOTE_BUNDLE="$2"
             REMOTE_CHECKSUM="$3"
-            CLERK_BRIDGE_EDGE="${4:-}"
-            REPOSITORY_URL="$5"
+            REPOSITORY_URL="$4"
+            CLERK_BRIDGE_EDGE="${5:-}"
 
             case "${RELEASE_SHA}" in
               *[!0-9a-f]*|'')

--- a/deploy/test_validate_clerk_production.py
+++ b/deploy/test_validate_clerk_production.py
@@ -517,7 +517,8 @@ class ClerkProductionValidatorTests(unittest.TestCase):
         self.assertIn('old_release=""', release_script)
         self.assertIn("vars.PRODUCTION_CLERK_BRIDGE_EDGE", workflow)
         self.assertIn('"${previous_target}:${RELEASE_SHA}"', workflow)
-        self.assertIn('CLERK_BRIDGE_EDGE="${4:-}"', workflow)
+        self.assertIn('"${REPOSITORY_URL}" "${CLERK_BRIDGE_EDGE}"', workflow)
+        self.assertIn('CLERK_BRIDGE_EDGE="${5:-}"', workflow)
         self.assertIn('SPYBOXD_CLERK_BRIDGE_EDGE="${CLERK_BRIDGE_EDGE}"', workflow)
         self.assertIn(
             "Stopped the failed Clerk bridge without activating the incompatible development artifact.",


### PR DESCRIPTION
## Summary

- place the required canonical repository URL before the optional Clerk bridge argument
- preserve the established behavior where an empty trailing bridge value may be omitted by SSH
- add static CI guards for the required argument order

## Incident behavior

The first renamed-repository deploy failed before activation with `sh: 6: 5: parameter not set`. The retained production release remained active and the reconciliation step completed.

## Verification

- workflow YAML parse
- production asset assertions
- deployment script syntax
- `git diff --check`