### PR TITLE
Fix Dependabot Compose monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,7 +45,7 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
 
-  - package-ecosystem: docker
+  - package-ecosystem: docker-compose
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
## Summary
- use the supported `docker-compose` ecosystem for the root `docker-compose.yml`
- retain `docker` monitoring for the backend and frontend Dockerfiles

## Verification
- parsed the updated YAML
- confirmed the root Docker update failure was `dependency_file_not_found`
- GitHub documents `docker-compose` as the supported ecosystem for Compose v2/v3: https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories