### PR TITLE
Close production pipeline and canary gaps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,4 +12,5 @@ __pycache__
 *.pyo
 *.pyd
 .DS_Store
-.env
+**/.env
+**/.env.*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,8 +56,9 @@ updates:
       default-days: 7
     open-pull-requests-limit: 3
     groups:
-      docker-images:
+      compose-images-minor-and-patch:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: docker
     directory: /backend
@@ -69,6 +70,10 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 2
+    groups:
+      backend-base-images-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: docker
     directory: /frontend
@@ -80,3 +85,7 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 2
+    groups:
+      frontend-base-images-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,15 @@ on:
   workflow_dispatch: {}
 
 permissions:
+  actions: read
+  attestations: read
   contents: read
 
 concurrency:
   group: production-ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Supersede stale PR validation, but never interrupt a main run after its
+  # immutable release has entered the production deployment handoff.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   backend:
@@ -36,11 +40,13 @@ jobs:
     env:
       DATABASE_URL: postgresql+psycopg://spyboxd:spyboxd@127.0.0.1:5432/spyboxd_ci
       SPYBOXD_TEST_DATABASE_URL: postgresql+psycopg://spyboxd:spyboxd@127.0.0.1:5432/spyboxd_ci
+      SPYBOXD_PREVIOUS_APP_REVISION: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/backend
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
@@ -203,13 +209,23 @@ jobs:
 
   compose:
     name: Operations / Production assets
+    needs: frontend
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Download the already-built frontend artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: frontend-next-${{ github.sha }}-${{ github.run_attempt }}
+          path: frontend/.next
+
+      - name: Verify the reused frontend build
+        run: test -f frontend/.next/BUILD_ID
 
       - name: Install production configuration validators
         run: |
@@ -234,6 +250,7 @@ jobs:
           [[ "$("${runtime_dir}/node" --version)" == v24.18.1 ]]
           [[ -s "${runtime_dir}/LICENSE.nodejs" ]]
           "${runtime_dir}/node" --check frontend/scripts/runtime-proof.cjs
+          "${runtime_dir}/node" --test frontend/scripts/run-production-auth-canary.test.mjs
 
       - name: Test production Clerk configuration guard
         run: python3 -m unittest -v deploy/test_validate_clerk_production.py
@@ -245,8 +262,12 @@ jobs:
             deploy/test_frontend_runtime_proof.py \
             deploy/test_postgres_restore_drill.py \
             deploy/test_production_canary.py \
+            deploy/test_reconcile_interrupted_deployment.py \
             deploy/test_runtime_launcher.py \
             deploy/test_rollback_state_machine.py
+
+      - name: Test workflow hardening contracts
+        run: python3 -m unittest -v deploy/test_workflow_controls.py
 
       - name: Validate systemd units
         run: |
@@ -330,6 +351,7 @@ jobs:
           grep -Fq 'sudo -n nginx -t' deploy/release.sh
           grep -Fq 'validate-clerk-production.py' deploy/release.sh
           grep -Fq 'SPYBOXD_CLERK_VALIDATOR' deploy/rollback.sh
+          grep -Fq 'reconcile-interrupted-deployment.sh' .github/workflows/deploy.yml
           if grep -R -n -F 'SPYBOXD_E2E_AUTH_BYPASS=' deploy/env; then
             echo 'Deployment environment examples must never enable the browser-test auth bypass.' >&2
             exit 1
@@ -337,7 +359,7 @@ jobs:
           grep -Fq 'SPYBOXD_NGINX_VALIDATE = /usr/sbin/nginx -t' deploy/sudoers/spyboxd-deploy
           # This assertion intentionally matches a literal shell expression.
           # shellcheck disable=SC2016
-          grep -Fq 'runner_path="${current_link}/deploy/run-tmdb-enrichment.sh"' .github/workflows/tmdb-enrichment.yml
+          grep -Fq 'runner_path="${active_release}/deploy/run-tmdb-enrichment.sh"' .github/workflows/tmdb-enrichment.yml
           grep -Fq 'AddressFamily inet' deploy/production-ssh.sh
           grep -Fq 'ControlMaster auto' deploy/production-ssh.sh
           grep -Fq 'ssh-keyscan -4' deploy/production-ssh.sh
@@ -358,7 +380,15 @@ jobs:
           grep -Fq 'proxy_pass http://127.0.0.1:8000;' deploy/nginx/spyboxd.conf
 
       - name: Validate Docker Compose configuration
-        run: docker compose config --quiet
+        run: |
+          docker compose config --quiet
+          docker compose \
+            -f docker-compose.yml \
+            -f deploy/docker-compose.ci.yml \
+            config --quiet
+
+      - name: Package and startup-smoke the Compose stack
+        run: bash deploy/run-compose-smoke.sh
 
   release_gate:
     # Branch protection requires this display name on pull requests.
@@ -404,6 +434,11 @@ jobs:
       NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL: /
       NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL: /
     steps:
+      - name: Monitor runner file and network activity
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -487,3 +522,12 @@ jobs:
           compression-level: 0
           overwrite: false
           retention-days: 1
+
+  deploy_production:
+    name: Deploy / Production handoff
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: release_bundle
+    uses: ./.github/workflows/deploy.yml
+    with:
+      release_sha: ${{ github.sha }}
+      ci_run_id: ${{ github.run_id }}

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,8 +17,12 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
     steps:
+      - name: Monitor runner file and network activity
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -27,6 +31,5 @@ jobs:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          comment-summary-in-pr: always
           fail-on-severity: moderate
           license-check: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,16 @@
 name: Deploy Production
 
-on: # zizmor: ignore[dangerous-triggers] Only trusted main push artifacts pass repository, SHA, and provenance checks before secrets load.
-  workflow_run:
-    workflows: [Production CI]
-    branches: [main]
-    types: [completed]
+on:
+  workflow_call:
+    inputs:
+      release_sha:
+        description: Exact trusted main commit packaged by the caller
+        required: true
+        type: string
+      ci_run_id:
+        description: Exact Production CI run containing the attested bundle
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -20,19 +26,19 @@ jobs:
   deploy:
     name: Exact-SHA release
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.release_sha == github.sha
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     environment:
       name: production
       url: https://spyboxd.com
     env:
-      RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
-      REMOTE_BUNDLE: /tmp/spyboxd-release-${{ github.event.workflow_run.head_sha }}.tar.gz
-      REMOTE_CHECKSUM: /tmp/spyboxd-release-${{ github.event.workflow_run.head_sha }}.tar.gz.sha256
+      RELEASE_SHA: ${{ inputs.release_sha }}
+      CI_RUN_ID: ${{ inputs.ci_run_id }}
+      REMOTE_BUNDLE: /tmp/spyboxd-release-${{ inputs.release_sha }}.tar.gz
+      REMOTE_CHECKSUM: /tmp/spyboxd-release-${{ inputs.release_sha }}.tar.gz.sha256
       REPOSITORY_URL: https://github.com/${{ github.repository }}.git
       CLERK_BRIDGE_EDGE: ${{ vars.PRODUCTION_CLERK_BRIDGE_EDGE }}
 
@@ -48,6 +54,9 @@ jobs:
         run: |
           set -Eeuo pipefail
           [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${CI_RUN_ID}" =~ ^[1-9][0-9]{0,19}$ ]]
+          [[ "${CI_RUN_ID}" == "${GITHUB_RUN_ID}" ]]
+          [[ "${RELEASE_SHA}" == "${GITHUB_SHA}" ]]
 
           current_main_sha="$(
             curl --silent --show-error --fail --connect-timeout 10 --max-time 30 \
@@ -66,7 +75,7 @@ jobs:
       - name: Check out exact deployment helpers
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ inputs.release_sha }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -77,7 +86,7 @@ jobs:
           path: ${{ runner.temp }}/spyboxd-transfer
           github-token: ${{ github.token }}
           repository: ${{ github.repository }}
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.ci_run_id }}
 
       - name: Verify exact release artifact
         run: |
@@ -348,6 +357,49 @@ jobs:
             [ "${#previous_target}" -eq 40 ] || exit 64
           fi
           case "${clerk_bridge_mode}" in true|false) ;; *) exit 64 ;; esac
+
+          # Standard immutable-release recovery is executable and failure-injected
+          # in CI. The inline state machine below remains only as a compatibility
+          # fallback for the one-time legacy/Clerk bridge paths and for a failure
+          # that happened before the exact helper commit reached the VPS repository.
+          if [ "${clerk_bridge_mode}" = false ] && [ "${previous_target}" != legacy ]; then
+            reconcile_runner="$(mktemp /tmp/spyboxd-reconcile-state.XXXXXX)"
+            cleanup_reconcile_runner() {
+              rm -f -- "${reconcile_runner}"
+            }
+            trap cleanup_reconcile_runner EXIT HUP INT TERM
+            helper_available=false
+            if git --git-dir="${app_root}/repository" rev-parse --is-bare-repository >/dev/null 2>&1; then
+              if git --git-dir="${app_root}/repository" show \
+                  "${release_sha}:deploy/reconcile-interrupted-deployment.sh" \
+                  >"${reconcile_runner}" 2>/dev/null; then
+                helper_available=true
+              fi
+            elif git -C "${app_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              if git -C "${app_root}" show \
+                  "${release_sha}:deploy/reconcile-interrupted-deployment.sh" \
+                  >"${reconcile_runner}" 2>/dev/null; then
+                helper_available=true
+              fi
+            fi
+            if [ "${helper_available}" = true ]; then
+              chmod 0700 "${reconcile_runner}"
+              if "${reconcile_runner}" \
+                  "${release_sha}" "${previous_target}" "${clerk_bridge_mode}"; then
+                reconcile_status=0
+              else
+                reconcile_status=$?
+              fi
+              rm -f -- "${reconcile_runner}"
+              reconcile_runner=''
+              trap - EXIT HUP INT TERM
+              exit "${reconcile_status}"
+            fi
+            rm -f -- "${reconcile_runner}"
+            reconcile_runner=''
+            trap - EXIT HUP INT TERM
+            echo 'Exact reconciliation helper was unavailable; using the compatibility fallback.' >&2
+          fi
 
           for command_name in curl flock git id python3 readlink seq stat sudo timeout; do
             command -v "${command_name}" >/dev/null 2>&1 || {

--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -158,8 +158,8 @@ jobs:
             echo '### Authenticated isolation phase not enabled'
             echo
             echo 'The public, RSS, redirect, and anonymous API checks passed.'
-            echo 'To enable the hourly fail-closed two-user phase, enable Clerk Agent Tasks, provision two dedicated non-admin canary accounts that each track only their own profile, create `/etc/spyboxd/canary.env` from `deploy/env/canary.env.example` on the VPS, and set the repository Actions variable `PRODUCTION_AUTH_CANARY_ENABLED=true`.'
-            echo 'No Clerk, database, password, or session secret belongs in GitHub.'
+            echo 'To enable the hourly fail-closed two-user phase, enable Clerk Agent Tasks, create two dedicated non-admin Clerk accounts whose usernames match completed unclaimed Spyboxd profiles, store their four identity values as production environment secrets, and set the repository Actions variable `PRODUCTION_AUTH_CANARY_ENABLED=true`.'
+            echo 'The workflow stages those non-password identity values only for a single run. Clerk, database, password, and session secrets remain on the VPS.'
           } >>"${GITHUB_STEP_SUMMARY}"
 
       - name: Require exact release alignment for authenticated isolation
@@ -236,13 +236,28 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
         run: deploy/production-ssh.sh open
 
-      - name: Allocate a private remote canary script path
+      - name: Allocate private remote canary paths
         id: remote_canary
         run: |
           set -Eeuo pipefail
+          remote_path=''
+          remote_env_path=''
+          cleanup_allocations() {
+            if [[ "${remote_env_path}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]; then
+              deploy/production-ssh.sh run rm -f -- "${remote_env_path}" >/dev/null 2>&1 || true
+            fi
+            if [[ "${remote_path}" =~ ^/tmp/spyboxd-auth-canary\.[A-Za-z0-9]{6}$ ]]; then
+              deploy/production-ssh.sh run rm -f -- "${remote_path}" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_allocations ERR INT TERM
           remote_path="$(deploy/production-ssh.sh run mktemp /tmp/spyboxd-auth-canary.XXXXXX)"
           [[ "${remote_path}" =~ ^/tmp/spyboxd-auth-canary\.[A-Za-z0-9]{6}$ ]]
+          remote_env_path="$(deploy/production-ssh.sh run mktemp /tmp/spyboxd-auth-canary-env.XXXXXX)"
+          [[ "${remote_env_path}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]
           printf 'path=%s\n' "${remote_path}" >>"${GITHUB_OUTPUT}"
+          printf 'env_path=%s\n' "${remote_env_path}" >>"${GITHUB_OUTPUT}"
+          trap - ERR INT TERM
 
       - name: Install the exact remote Clerk task helper
         env:
@@ -273,8 +288,60 @@ jobs:
           chmod 0700 "${canary_path}"
           REMOTE
 
+      - name: Stage the private one-run canary identity configuration
+        env:
+          REMOTE_CANARY_ENV_PATH: ${{ steps.remote_canary.outputs.env_path }}
+          SPYBOXD_CANARY_PROFILE_A: ${{ secrets.SPYBOXD_CANARY_PROFILE_A }}
+          SPYBOXD_CANARY_PROFILE_B: ${{ secrets.SPYBOXD_CANARY_PROFILE_B }}
+          SPYBOXD_CANARY_USER_A_ID: ${{ secrets.SPYBOXD_CANARY_USER_A_ID }}
+          SPYBOXD_CANARY_USER_B_ID: ${{ secrets.SPYBOXD_CANARY_USER_B_ID }}
+        run: |
+          set -Eeuo pipefail
+          local_env="${RUNNER_TEMP}/spyboxd-auth-canary.env"
+          [[ "${REMOTE_CANARY_ENV_PATH}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]
+          [[ "${SPYBOXD_CANARY_USER_A_ID}" =~ ^user_[A-Za-z0-9]+$ ]]
+          [[ "${SPYBOXD_CANARY_USER_B_ID}" =~ ^user_[A-Za-z0-9]+$ ]]
+          [[ "${SPYBOXD_CANARY_PROFILE_A}" =~ ^[A-Za-z0-9_]{2,15}$ ]]
+          [[ "${SPYBOXD_CANARY_PROFILE_B}" =~ ^[A-Za-z0-9_]{2,15}$ ]]
+          [[ "${SPYBOXD_CANARY_USER_A_ID}" != "${SPYBOXD_CANARY_USER_B_ID}" ]]
+          [[ "${SPYBOXD_CANARY_PROFILE_A,,}" != "${SPYBOXD_CANARY_PROFILE_B,,}" ]]
+          [[ ! -e "${local_env}" && ! -L "${local_env}" ]]
+          umask 077
+          {
+            printf 'SPYBOXD_CANARY_USER_A_ID=%s\n' "${SPYBOXD_CANARY_USER_A_ID}"
+            printf 'SPYBOXD_CANARY_PROFILE_A=%s\n' "${SPYBOXD_CANARY_PROFILE_A}"
+            printf 'SPYBOXD_CANARY_USER_B_ID=%s\n' "${SPYBOXD_CANARY_USER_B_ID}"
+            printf 'SPYBOXD_CANARY_PROFILE_B=%s\n' "${SPYBOXD_CANARY_PROFILE_B}"
+          } >"${local_env}"
+          chmod 0600 "${local_env}"
+          [[ -s "${local_env}" && "$(wc -c <"${local_env}")" -le 1024 ]]
+          expected_hash="$(sha256sum "${local_env}" | awk '{print $1}')"
+          [[ "${expected_hash}" =~ ^[0-9a-f]{64}$ ]]
+          deploy/production-ssh.sh copy \
+            "${local_env}" \
+            "spyboxd-production:${REMOTE_CANARY_ENV_PATH}"
+          deploy/production-ssh.sh run sh -s -- \
+            "${REMOTE_CANARY_ENV_PATH}" "${expected_hash}" <<'REMOTE'
+          set -eu
+          canary_env_path="$1"
+          expected_hash="$2"
+          case "${canary_env_path}" in
+            /tmp/spyboxd-auth-canary-env.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;;
+            *) exit 64 ;;
+          esac
+          case "${expected_hash}" in
+            *[!0-9a-f]*|'') exit 64 ;;
+          esac
+          [ "${#expected_hash}" -eq 64 ]
+          [ -f "${canary_env_path}" ] && [ ! -L "${canary_env_path}" ]
+          [ "$(sha256sum "${canary_env_path}" | awk '{print $1}')" = "${expected_hash}" ]
+          chmod 0600 "${canary_env_path}"
+          [ "$(stat -c '%u:%a' "${canary_env_path}")" = "$(id -u):600" ]
+          REMOTE
+
       - name: Prove browser-backed isolation under a fail-safe VPS guardian
         env:
+          REMOTE_CANARY_ENV_PATH: ${{ steps.remote_canary.outputs.env_path }}
           REMOTE_CANARY_PATH: ${{ steps.remote_canary.outputs.path }}
         run: |
           set -Eeuo pipefail
@@ -285,6 +352,7 @@ jobs:
           [[ ! -e "${task_file}" && ! -L "${task_file}" ]]
           [[ "${lease_id}" =~ ^gha-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$ ]]
           [[ "${REMOTE_CANARY_PATH}" =~ ^/tmp/spyboxd-auth-canary\.[A-Za-z0-9]{6}$ ]]
+          [[ "${REMOTE_CANARY_ENV_PATH}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]
 
           guardian_started=0
           signal_guardian() {
@@ -299,12 +367,17 @@ jobs:
           trap 'signal_guardian; exit 130' INT TERM
 
           deploy/production-ssh.sh run sh -s -- \
-            "${REMOTE_CANARY_PATH}" "${lease_id}" <<'REMOTE'
+            "${REMOTE_CANARY_PATH}" "${REMOTE_CANARY_ENV_PATH}" "${lease_id}" <<'REMOTE'
           set -eu
           canary_path="$1"
-          lease_id="$2"
+          canary_env_path="$2"
+          lease_id="$3"
           case "${canary_path}" in
             /tmp/spyboxd-auth-canary.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;;
+            *) exit 64 ;;
+          esac
+          case "${canary_env_path}" in
+            /tmp/spyboxd-auth-canary-env.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;;
             *) exit 64 ;;
           esac
           case "${lease_id}" in
@@ -323,12 +396,15 @@ jobs:
           current_link=/opt/spyboxd/current
           python_path="${current_link}/.venv/bin/python"
           [ -L "${current_link}" ] && [ -x "${python_path}" ]
+          [ -f "${canary_env_path}" ] && [ ! -L "${canary_env_path}" ]
+          [ "$(stat -c '%u:%a' "${canary_env_path}")" = "$(id -u):600" ]
           command -v nohup >/dev/null
           command -v setsid >/dev/null
           umask 077
           nohup setsid "${python_path}" "${canary_path}" guard \
             --lease-id "${lease_id}" \
             --max-wait-seconds 600 \
+            --canary-env "${canary_env_path}" \
             </dev/null >/dev/null 2>&1 &
           guardian_pid=$!
           sleep 2
@@ -434,30 +510,47 @@ jobs:
             deploy/production-ssh.sh run \
               "${REMOTE_CANARY_PATH}" cleanup --lease-id "${lease_id}"
 
-      - name: Remove the remote canary helper
-        if: always() && steps.remote_canary.outputs.path != ''
+      - name: Securely remove remote one-run canary material
+        if: always() && (steps.remote_canary.outputs.path != '' || steps.remote_canary.outputs.env_path != '')
         env:
+          REMOTE_CANARY_ENV_PATH: ${{ steps.remote_canary.outputs.env_path }}
           REMOTE_CANARY_PATH: ${{ steps.remote_canary.outputs.path }}
         run: |
           set -Eeuo pipefail
+          if [[ ! -f "${RUNNER_TEMP}/spyboxd-production-ssh.config" ]]; then
+            exit 0
+          fi
           [[ "${REMOTE_CANARY_PATH}" =~ ^/tmp/spyboxd-auth-canary\.[A-Za-z0-9]{6}$ ]]
-          deploy/production-ssh.sh run sh -s -- "${REMOTE_CANARY_PATH}" <<'REMOTE'
+          [[ "${REMOTE_CANARY_ENV_PATH}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]
+          deploy/production-ssh.sh run sh -s -- \
+            "${REMOTE_CANARY_PATH}" "${REMOTE_CANARY_ENV_PATH}" <<'REMOTE'
           set -eu
           canary_path="$1"
+          canary_env_path="$2"
           case "${canary_path}" in
             /tmp/spyboxd-auth-canary.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;;
             *) exit 64 ;;
           esac
-          if [ -L "${canary_path}" ]; then
-            echo 'Refusing to remove a remote canary symlink.' >&2
-            exit 1
-          fi
-          if [ -f "${canary_path}" ]; then
-            rm -f -- "${canary_path}"
-          elif [ -e "${canary_path}" ]; then
-            echo 'Refusing to remove a non-file remote canary path.' >&2
-            exit 1
-          fi
+          case "${canary_env_path}" in
+            /tmp/spyboxd-auth-canary-env.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;;
+            *) exit 64 ;;
+          esac
+          for path in "${canary_env_path}" "${canary_path}"; do
+            if [ -L "${path}" ]; then
+              echo 'Refusing to remove a remote canary symlink.' >&2
+              exit 1
+            elif [ -f "${path}" ]; then
+              chmod 0600 "${path}"
+              if command -v shred >/dev/null 2>&1; then
+                shred --force --iterations=1 --zero --remove -- "${path}"
+              else
+                rm -f -- "${path}"
+              fi
+            elif [ -e "${path}" ]; then
+              echo 'Refusing to remove a non-file remote canary path.' >&2
+              exit 1
+            fi
+          done
           REMOTE
 
       - name: Close production SSH and securely remove local key material
@@ -471,6 +564,7 @@ jobs:
         if: always()
         run: |
           for path in \
+            "${RUNNER_TEMP}/spyboxd-auth-canary.env" \
             "${RUNNER_TEMP}/spyboxd-auth-tasks.json"
           do
             if [[ -L "${path}" ]]; then
@@ -496,5 +590,6 @@ jobs:
             echo "- Release: \`${PRODUCTION_REVISION}\`"
             echo '- Two short-lived browser-established non-admin Clerk sessions proved per-user profile isolation'
             echo '- Global/admin access remained denied and the VPS re-listed both users to prove no canary session remained live'
-            echo '- Clerk and database secrets remained on the VPS'
+            echo '- The two dedicated identities either passed strict existing-state checks or were safely provisioned from completed unclaimed profiles during their first browser run'
+            echo '- The ephemeral identity configuration was securely removed locally and remotely; Clerk and database secrets remained on the VPS'
           } >>"${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/tmdb-enrichment.yml
+++ b/.github/workflows/tmdb-enrichment.yml
@@ -9,7 +9,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: spyboxd-production-deploy
+  # Enrichment only updates resumable TMDB cache rows. Keep it out of the
+  # deploy/rollback lane so an emergency rollback never waits for this job.
+  group: spyboxd-production-tmdb-enrichment
   queue: max
   cancel-in-progress: false
 
@@ -51,10 +53,34 @@ jobs:
 
           current_link=/opt/spyboxd/current
           env_file=/etc/spyboxd/api.env
-          python_path="${current_link}/.venv/bin/python"
-          runner_path="${current_link}/deploy/run-tmdb-enrichment.sh"
 
           [ -L "${current_link}" ]
+          active_release="$(readlink -f -- "${current_link}")"
+          case "${active_release}" in
+            /opt/spyboxd/releases/*)
+              ;;
+            *)
+              echo 'The active release link resolves outside the release directory.' >&2
+              exit 1
+              ;;
+          esac
+          active_revision="${active_release##*/}"
+          case "${active_revision}" in
+            *[!0-9a-f]*|'')
+              echo 'The active release directory is not a lowercase Git revision.' >&2
+              exit 1
+              ;;
+          esac
+          [ "${#active_revision}" -eq 40 ]
+          [ "${active_release}" = "/opt/spyboxd/releases/${active_revision}" ]
+          [ -f "${active_release}/REVISION" ]
+          [ "$(tr -d '\r\n' <"${active_release}/REVISION")" = "${active_revision}" ]
+
+          # Pin every executable path to one release. A concurrent rollback may
+          # switch /opt/spyboxd/current, but this bounded cache run stays
+          # internally consistent and cannot execute a mixed release.
+          python_path="${active_release}/.venv/bin/python"
+          runner_path="${active_release}/deploy/run-tmdb-enrichment.sh"
           [ -f "${env_file}" ] && [ ! -L "${env_file}" ] && [ -r "${env_file}" ]
           [ -x "${python_path}" ] && [ -x "${runner_path}" ]
           if systemctl is-enabled --quiet spyboxd-tmdb-enrichment.timer 2>/dev/null \
@@ -64,7 +90,7 @@ jobs:
             exit 1
           fi
 
-          exec "${python_path}" - "${env_file}" "${runner_path}" <<'PY'
+          exec "${python_path}" - "${env_file}" "${runner_path}" "${active_release}" <<'PY'
           import os
           from pathlib import Path
           import sys
@@ -73,6 +99,7 @@ jobs:
 
           env_path = Path(sys.argv[1])
           runner_path = Path(sys.argv[2])
+          active_release = Path(sys.argv[3])
           values = {
               key: value
               for key, value in dotenv_values(env_path).items()
@@ -94,9 +121,9 @@ jobs:
 
           environment = os.environ.copy()
           environment.update(values)
-          # Each committed batch is resumable. Keeping this run small caps the
-          # time it can occupy the shared production deployment queue while
-          # still processing roughly the prior daily volume across four runs.
+          environment["SPYBOXD_CURRENT_LINK"] = str(active_release)
+          # Each committed batch is cache-aware and resumable. Keeping this run
+          # small bounds its overlap with a deployment or emergency rollback.
           environment["TMDB_ENRICHMENT_LIMIT"] = "50"
           environment["TMDB_ENRICHMENT_BATCH_SIZE"] = "10"
           os.execve(runner_path, [str(runner_path)], environment)

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
+import sys
+import tarfile
+import tempfile
 import unittest
 import uuid
 from pathlib import Path
@@ -924,6 +928,120 @@ class AdditiveMigrationPostgresTests(unittest.TestCase):
                     )
             finally:
                 transaction.rollback()
+
+    def test_previous_application_revision_serves_upgraded_seeded_schema(self) -> None:
+        """Run the actual prior backend checkout against the migrated fixture."""
+
+        previous_revision = os.getenv("SPYBOXD_PREVIOUS_APP_REVISION", "").strip()
+        if not previous_revision:
+            self.skipTest("SPYBOXD_PREVIOUS_APP_REVISION is not configured")
+        if not re.fullmatch(r"[0-9a-f]{40}", previous_revision):
+            self.fail("SPYBOXD_PREVIOUS_APP_REVISION must be a full Git commit")
+
+        subprocess.run(
+            ["git", "cat-file", "-e", f"{previous_revision}^{{commit}}"],
+            cwd=REPO_ROOT,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        ancestor = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", previous_revision, "HEAD"],
+            cwd=REPO_ROOT,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.assertEqual(
+            ancestor.returncode,
+            0,
+            "the compatibility revision must be an ancestor of the tested checkout",
+        )
+
+        with tempfile.TemporaryDirectory(
+            prefix="spyboxd-previous-app-compatibility-"
+        ) as temporary_directory:
+            temporary = Path(temporary_directory)
+            archive_path = temporary / "previous-backend.tar"
+            source_root = temporary / "source"
+            source_root.mkdir(mode=0o700)
+            subprocess.run(
+                [
+                    "git",
+                    "archive",
+                    "--format=tar",
+                    f"--output={archive_path}",
+                    previous_revision,
+                    "backend",
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            with tarfile.open(archive_path, mode="r:") as archive:
+                archive.extractall(source_root, filter="data")
+
+            previous_backend = source_root / "backend"
+            self.assertTrue((previous_backend / "main.py").is_file())
+            probe = temporary / "probe.py"
+            probe.write_text(
+                """
+import json
+from fastapi.testclient import TestClient
+from main import app
+
+with TestClient(app) as client:
+    response = client.get("/api/public/dashboard")
+    if response.status_code != 200:
+        raise SystemExit(f"previous dashboard returned HTTP {response.status_code}")
+    payload = response.json()
+required = {
+    "activity_data",
+    "data_health",
+    "rating_distribution",
+    "signal_counts",
+    "system_stats",
+    "timestamp",
+}
+if not isinstance(payload, dict) or not required.issubset(payload):
+    raise SystemExit("previous dashboard returned an invalid contract")
+stats = payload.get("system_stats")
+if (
+    not isinstance(stats, dict)
+    or stats.get("total_profiles", 0) < 2
+    or stats.get("total_movies_tracked", 0) < 1
+):
+    raise SystemExit("previous dashboard did not read the seeded database")
+print("SPYBOXD_PREVIOUS_APP_PROBE=" + json.dumps(stats, sort_keys=True))
+""".lstrip(),
+                encoding="utf-8",
+            )
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "DATABASE_URL": self.database_url.render_as_string(
+                        hide_password=False
+                    ),
+                    "PGOPTIONS": f"-csearch_path={self.schema_name}",
+                    "PYTHONPATH": str(previous_backend),
+                    "SPYBOXD_APP_REVISION": previous_revision,
+                }
+            )
+            completed = subprocess.run(
+                [sys.executable, str(probe)],
+                cwd=previous_backend,
+                env=environment,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=60,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stdout)
+            self.assertIn("SPYBOXD_PREVIOUS_APP_PROBE=", completed.stdout)
 
 
 if __name__ == "__main__":

--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -1,0 +1,22 @@
+services:
+  postgres:
+    container_name: !reset null
+    restart: "no"
+    ports: !reset []
+
+  api:
+    container_name: !reset null
+    restart: "no"
+    ports: !reset []
+
+  rss-poller:
+    container_name: !reset null
+    restart: "no"
+
+  frontend:
+    container_name: !reset null
+    restart: "no"
+    ports: !reset []
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.prebuilt

--- a/deploy/env/canary.env.example
+++ b/deploy/env/canary.env.example
@@ -1,8 +1,9 @@
-# Optional authenticated production canary. Do not put Clerk or database secrets here.
-# Use two pre-existing, dedicated, ordinary Clerk users already provisioned in
-# Spyboxd. Each must track its own distinct profile and not the other profile.
-# The Clerk production instance must support Agent Tasks; each run creates a
-# two-minute session through that official flow and revokes it after validation.
+# GitHub production-environment secret names used by the optional authenticated
+# canary. This file is only a naming template; do not deploy or populate it.
+# The first run may safely provision two new dedicated Clerk identities when
+# both matching profiles are completed and unclaimed. Later runs require each
+# identity to track exactly its own profile. Never put Clerk, database, password,
+# or session secrets in this file or in GitHub.
 SPYBOXD_CANARY_USER_A_ID=user_REPLACE_WITH_DEDICATED_CANARY_A
 SPYBOXD_CANARY_PROFILE_A=REPLACE_WITH_CANARY_A_LETTERBOXD_USERNAME
 SPYBOXD_CANARY_USER_B_ID=user_REPLACE_WITH_DEDICATED_CANARY_B

--- a/deploy/reconcile-interrupted-deployment.sh
+++ b/deploy/reconcile-interrupted-deployment.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly APP_ROOT="${SPYBOXD_APP_ROOT:-/opt/spyboxd}"
+readonly REPOSITORY_DIR="${SPYBOXD_REPOSITORY_DIR:-${APP_ROOT}/repository}"
+readonly RELEASES_DIR="${SPYBOXD_RELEASES_DIR:-${APP_ROOT}/releases}"
+readonly SHARED_DIR="${SPYBOXD_SHARED_DIR:-${APP_ROOT}/shared}"
+readonly RELEASE_STATE_DIR="${SPYBOXD_RELEASE_STATE_DIR:-${SHARED_DIR}/release-state}"
+readonly CURRENT_LINK="${SPYBOXD_CURRENT_LINK:-${APP_ROOT}/current}"
+readonly DEPLOY_REF="${SPYBOXD_DEPLOY_REF:-refs/remotes/origin/main}"
+readonly SERVICES=(spyboxd-api.service spyboxd-rss.service spyboxd-frontend.service)
+
+TEMPORARY_LINK=""
+
+log() {
+    printf '[spyboxd-reconcile] %s\n' "$*"
+}
+
+fail() {
+    printf '[spyboxd-reconcile] ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    local exit_status=$?
+    trap - EXIT
+    if [[ -n "${TEMPORARY_LINK}" && -L "${TEMPORARY_LINK}" ]]; then
+        rm -f -- "${TEMPORARY_LINK}"
+    fi
+    exit "${exit_status}"
+}
+trap cleanup EXIT
+
+usage() {
+    printf 'Usage: %s <release-sha> <previous-sha|none> false\n' "$0" >&2
+    exit 64
+}
+
+[[ $# -eq 3 ]] || usage
+readonly RELEASE_SHA="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+readonly PREVIOUS_TARGET="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+readonly CLERK_BRIDGE_MODE="$3"
+readonly EXPECTED_RELEASE="${RELEASES_DIR}/${RELEASE_SHA}"
+
+[[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || usage
+if [[ "${PREVIOUS_TARGET}" != none ]]; then
+    [[ "${PREVIOUS_TARGET}" =~ ^[0-9a-f]{40}$ ]] || usage
+fi
+[[ "${CLERK_BRIDGE_MODE}" == false ]] || usage
+
+for command_name in basename chmod curl flock git id ln mv python3 readlink rm seq sleep stat sudo timeout touch tr; do
+    command -v "${command_name}" >/dev/null 2>&1 \
+        || fail "required recovery command is missing: ${command_name}"
+done
+
+exec 9>"${APP_ROOT}/.release.lock"
+flock -w 180 9 || fail "the interrupted release did not relinquish the deployment lock"
+
+validate_state_dir() {
+    [[ -d "${RELEASE_STATE_DIR}" && ! -L "${RELEASE_STATE_DIR}" ]] \
+        || fail "trusted release state is unavailable"
+    [[ "$(stat -c '%u' "${RELEASE_STATE_DIR}")" == "$(id -u)" ]] \
+        && [[ "$(stat -c '%a' "${RELEASE_STATE_DIR}")" == 750 ]] \
+        || fail "trusted release state has unsafe ownership or permissions"
+}
+
+read_state_revision() {
+    local marker_path revision
+    marker_path="${RELEASE_STATE_DIR}/$1"
+    [[ -f "${marker_path}" && ! -L "${marker_path}" ]] || return 1
+    revision="$(<"${marker_path}")"
+    [[ "${revision}" =~ ^[0-9a-f]{40}$ ]] || return 1
+    printf '%s\n' "${revision}"
+}
+
+write_state_revision() {
+    local name="$1" revision="$2" temporary
+    [[ "${name}" == active || "${name}" == previous ]] \
+        || fail "invalid release-state marker name"
+    [[ "${revision}" =~ ^[0-9a-f]{40}$ ]] \
+        || fail "invalid release-state revision"
+    temporary="${RELEASE_STATE_DIR}/.${name}.$$"
+    printf '%s\n' "${revision}" >"${temporary}"
+    chmod 0640 "${temporary}"
+    mv -f -- "${temporary}" "${RELEASE_STATE_DIR}/${name}"
+}
+
+clear_state_marker() {
+    local marker_path
+    marker_path="${RELEASE_STATE_DIR}/$1"
+    if [[ -e "${marker_path}" || -L "${marker_path}" ]]; then
+        [[ -f "${marker_path}" && ! -L "${marker_path}" ]] \
+            || fail "refusing to remove an unsafe release-state marker"
+        rm -f -- "${marker_path}"
+    fi
+}
+
+active_target=""
+if [[ -e "${CURRENT_LINK}" || -L "${CURRENT_LINK}" ]]; then
+    [[ -L "${CURRENT_LINK}" ]] || fail "current release path is not a symlink"
+    active_target="$(readlink -f "${CURRENT_LINK}" || true)"
+    [[ -n "${active_target}" ]] || fail "current release symlink cannot be resolved"
+fi
+
+stop_services() {
+    timeout --signal=TERM --kill-after=15s 4m \
+        sudo -n systemctl stop "${SERVICES[@]}"
+}
+
+restart_services() {
+    timeout --signal=TERM --kill-after=15s 4m \
+        sudo -n systemctl restart "${SERVICES[@]}"
+}
+
+activate_release() {
+    local release_path="$1"
+    TEMPORARY_LINK="${APP_ROOT}/.current-reconcile.$$"
+    [[ ! -e "${TEMPORARY_LINK}" && ! -L "${TEMPORARY_LINK}" ]] \
+        || fail "temporary activation path already exists"
+    ln -s "${release_path}" "${TEMPORARY_LINK}"
+    mv -Tf -- "${TEMPORARY_LINK}" "${CURRENT_LINK}"
+    TEMPORARY_LINK=""
+    [[ "$(readlink -f "${CURRENT_LINK}" || true)" == "${release_path}" ]] \
+        || fail "reconciled activation did not resolve to the expected release"
+}
+
+validate_runtime_release() {
+    local release_path="$1" revision="$2" require_runtime="$3"
+    [[ -d "${release_path}" && ! -L "${release_path}" ]] \
+        || fail "recovery release is unavailable: ${revision}"
+    [[ -f "${release_path}/REVISION" && ! -L "${release_path}/REVISION" ]] \
+        && [[ "$(<"${release_path}/REVISION")" == "${revision}" ]] \
+        || fail "recovery release has an invalid revision marker: ${revision}"
+    [[ -f "${release_path}/.revision-health-v1" \
+        && ! -L "${release_path}/.revision-health-v1" ]] \
+        || fail "recovery release predates strict readiness: ${revision}"
+    [[ -x "${release_path}/.venv/bin/uvicorn" ]] \
+        && [[ -f "${release_path}/frontend/.next/BUILD_ID" ]] \
+        && [[ -f "${release_path}/frontend/node_modules/next/dist/bin/next" ]] \
+        || fail "recovery release is incomplete: ${revision}"
+    if [[ "${require_runtime}" == true ]]; then
+        [[ -x "${release_path}/frontend/.runtime/node" \
+            && ! -L "${release_path}/frontend/.runtime/node" ]] \
+            && [[ -f "${release_path}/frontend/.runtime/LICENSE.nodejs" \
+                && ! -L "${release_path}/frontend/.runtime/LICENSE.nodejs" ]] \
+            || fail "attempted release is missing its bundled Node runtime"
+    fi
+}
+
+if [[ "${PREVIOUS_TARGET}" == none ]]; then
+    case "${active_target}" in
+        ""|"${EXPECTED_RELEASE}") ;;
+        *) fail "first-release recovery found an unexpected active target" ;;
+    esac
+    if [[ -e "${RELEASE_STATE_DIR}" || -L "${RELEASE_STATE_DIR}" ]]; then
+        validate_state_dir
+        if [[ -e "${RELEASE_STATE_DIR}/active" || -L "${RELEASE_STATE_DIR}/active" ]]; then
+            [[ "$(read_state_revision active)" == "${RELEASE_SHA}" ]] \
+                || fail "first-release recovery found an unexpected active state marker"
+        fi
+        [[ ! -e "${RELEASE_STATE_DIR}/previous" \
+            && ! -L "${RELEASE_STATE_DIR}/previous" ]] \
+            || fail "first-release recovery found an impossible previous state marker"
+    fi
+    stop_services || fail "failed to stop services during first-release recovery"
+    rm -f -- "${CURRENT_LINK}"
+    if [[ -e "${RELEASE_STATE_DIR}" || -L "${RELEASE_STATE_DIR}" ]]; then
+        validate_state_dir
+        clear_state_marker active
+        clear_state_marker previous
+    fi
+    log "Stopped the first failed activation because no prior release existed."
+    exit 0
+fi
+
+readonly PREVIOUS_RELEASE="${RELEASES_DIR}/${PREVIOUS_TARGET}"
+case "${active_target}" in
+    ""|"${EXPECTED_RELEASE}"|"${PREVIOUS_RELEASE}") ;;
+    *) fail "revision recovery found an unexpected active target" ;;
+esac
+
+validate_state_dir
+active_marker="$(read_state_revision active)" \
+    || fail "the active release-state marker is invalid"
+if [[ "${active_marker}" != "${PREVIOUS_TARGET}" \
+    && "${active_marker}" != "${RELEASE_SHA}" ]]; then
+    fail "release-state marker does not identify either recovery revision"
+fi
+
+previous_marker=""
+if [[ -e "${RELEASE_STATE_DIR}/previous" \
+    || -L "${RELEASE_STATE_DIR}/previous" ]]; then
+    previous_marker="$(read_state_revision previous)" \
+        || fail "the previous release-state marker is invalid"
+fi
+if [[ "${active_marker}" == "${RELEASE_SHA}" ]]; then
+    [[ "${previous_marker}" == "${PREVIOUS_TARGET}" ]] \
+        || fail "the successful activation has no trustworthy previous marker"
+elif [[ -n "${previous_marker}" \
+    && "${previous_marker}" != "${PREVIOUS_TARGET}" \
+    && "${previous_marker}" != "${RELEASE_SHA}" ]]; then
+    fail "the previous release-state marker does not identify a recovery revision"
+fi
+
+validate_runtime_release "${PREVIOUS_RELEASE}" "${PREVIOUS_TARGET}" false
+if [[ "${active_marker}" == "${RELEASE_SHA}" ]]; then
+    validate_runtime_release "${EXPECTED_RELEASE}" "${RELEASE_SHA}" true
+fi
+
+if git --git-dir="${REPOSITORY_DIR}" rev-parse --is-bare-repository >/dev/null 2>&1; then
+    repository_git() {
+        git --git-dir="${REPOSITORY_DIR}" "$@"
+    }
+    repository_fetch() {
+        timeout --signal=TERM --kill-after=15s 2m \
+            git --git-dir="${REPOSITORY_DIR}" fetch "$@"
+    }
+elif git -C "${APP_ROOT}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    repository_git() {
+        git -C "${APP_ROOT}" "$@"
+    }
+    repository_fetch() {
+        timeout --signal=TERM --kill-after=15s 2m \
+            git -C "${APP_ROOT}" fetch "$@"
+    }
+else
+    fail "no trusted repository is available for reconciliation"
+fi
+
+repository_fetch --quiet --force --prune origin \
+    '+refs/heads/main:refs/remotes/origin/main'
+[[ "$(repository_git rev-parse --verify "${RELEASE_SHA}^{commit}")" == "${RELEASE_SHA}" ]] \
+    || fail "attempted release is not a known repository commit"
+repository_git merge-base --is-ancestor "${RELEASE_SHA}" "${DEPLOY_REF}" \
+    || fail "attempted release is not reachable from the deployment ref"
+[[ "$(repository_git rev-parse --verify "${PREVIOUS_TARGET}^{commit}")" == "${PREVIOUS_TARGET}" ]] \
+    || fail "previous release is not a known repository commit"
+repository_git merge-base --is-ancestor "${PREVIOUS_TARGET}" "${DEPLOY_REF}" \
+    || fail "previous release is not reachable from the deployment ref"
+
+health_validator="${SPYBOXD_HEALTH_VALIDATOR:-}"
+if [[ -z "${health_validator}" ]]; then
+    if [[ -f "${PREVIOUS_RELEASE}/deploy/check-runtime-health.py" \
+        && ! -L "${PREVIOUS_RELEASE}/deploy/check-runtime-health.py" ]]; then
+        health_validator="${PREVIOUS_RELEASE}/deploy/check-runtime-health.py"
+    elif [[ -f "${EXPECTED_RELEASE}/deploy/check-runtime-health.py" \
+        && ! -L "${EXPECTED_RELEASE}/deploy/check-runtime-health.py" ]]; then
+        health_validator="${EXPECTED_RELEASE}/deploy/check-runtime-health.py"
+    fi
+fi
+[[ -n "${health_validator}" && -f "${health_validator}" \
+    && ! -L "${health_validator}" ]] \
+    || fail "trusted runtime health validator is unavailable"
+readonly health_validator
+
+wait_for_http() {
+    local name="$1" url="$2" expected_status="${3:-}" expected_revision="${4:-}" response attempt
+    for attempt in $(seq 1 12); do
+        if response="$(curl --silent --show-error --fail --max-time 5 "${url}" 2>/dev/null)"; then
+            if [[ -z "${expected_status}" && -z "${expected_revision}" ]] \
+                || python3 -c '
+import json
+import sys
+
+expected_status, expected_revision = sys.argv[1:]
+try:
+    payload = json.load(sys.stdin)
+except (TypeError, ValueError):
+    raise SystemExit(1)
+if expected_status and payload.get("status") != expected_status:
+    raise SystemExit(1)
+if expected_revision and payload.get("revision") != expected_revision:
+    raise SystemExit(1)
+' "${expected_status}" "${expected_revision}" <<<"${response}"; then
+                log "${name} is ready"
+                return 0
+            fi
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+wait_for_validated_json() {
+    local name="$1" url="$2" kind="$3" expected_revision="${4:-}" response attempt
+    local -a validator_args=("${kind}")
+    if [[ -n "${expected_revision}" ]]; then
+        validator_args+=(--revision "${expected_revision}")
+    fi
+    for attempt in $(seq 1 12); do
+        if response="$(curl --silent --show-error --fail --max-time 5 "${url}" 2>/dev/null)" \
+            && printf '%s' "${response}" \
+                | python3 "${health_validator}" "${validator_args[@]}" >/dev/null; then
+            log "${name} is ready"
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+check_release_readiness() {
+    local revision="$1"
+    wait_for_validated_json "reconciled API revision ${revision}" \
+        "http://127.0.0.1:8000/ready" ready "${revision}" \
+        && wait_for_validated_json "reconciled database-backed dashboard" \
+            "http://127.0.0.1:8000/api/public/dashboard" dashboard \
+        && wait_for_http "reconciled frontend" "http://127.0.0.1:3000/sign-in" \
+        && wait_for_validated_json "public reconciled API revision ${revision}" \
+            "https://api.spyboxd.com/ready" ready "${revision}" \
+        && wait_for_validated_json "public reconciled database-backed dashboard" \
+            "https://api.spyboxd.com/api/public/dashboard" dashboard \
+        && wait_for_http "public reconciled frontend" "https://spyboxd.com/sign-in"
+}
+
+check_release_compatibility() {
+    local revision="$1"
+    wait_for_http "rollback-compatible API revision ${revision}" \
+        "http://127.0.0.1:8000/health" ok "${revision}" \
+        && wait_for_validated_json "rollback-compatible database-backed dashboard" \
+            "http://127.0.0.1:8000/api/public/dashboard" dashboard \
+        && wait_for_http "rollback-compatible frontend" "http://127.0.0.1:3000/sign-in" \
+        && wait_for_http "public rollback-compatible API revision ${revision}" \
+            "https://api.spyboxd.com/health" ok "${revision}" \
+        && wait_for_validated_json "public rollback-compatible database-backed dashboard" \
+            "https://api.spyboxd.com/api/public/dashboard" dashboard \
+        && wait_for_http "public rollback-compatible frontend" "https://spyboxd.com/sign-in"
+}
+
+if [[ "${PREVIOUS_TARGET}" == "${RELEASE_SHA}" ]]; then
+    [[ "${active_target}" == "${EXPECTED_RELEASE}" \
+        && "${active_marker}" == "${RELEASE_SHA}" ]] \
+        || fail "repeated-release recovery found inconsistent active state"
+    check_release_readiness "${RELEASE_SHA}" \
+        || fail "repeated release is not ready"
+    log "The requested release was already active and healthy."
+    exit 0
+fi
+
+activate_release "${PREVIOUS_RELEASE}"
+previous_restarted=true
+restart_services || previous_restarted=false
+
+if [[ "${previous_restarted}" == true ]] \
+    && check_release_compatibility "${PREVIOUS_TARGET}"; then
+    touch "${PREVIOUS_RELEASE}/.activated-at"
+    if [[ "${active_marker}" == "${RELEASE_SHA}" ]]; then
+        write_state_revision previous "${RELEASE_SHA}"
+        write_state_revision active "${PREVIOUS_TARGET}"
+    elif [[ "${previous_marker}" == "${PREVIOUS_TARGET}" ]]; then
+        clear_state_marker previous
+    fi
+    [[ "$(read_state_revision active)" == "${PREVIOUS_TARGET}" ]] \
+        || fail "reconciled release state does not identify the previous release"
+    log "Restored healthy previous release ${PREVIOUS_TARGET} after interrupted activation."
+    exit 0
+fi
+
+if [[ "${active_marker}" == "${RELEASE_SHA}" ]]; then
+    activate_release "${EXPECTED_RELEASE}"
+    if restart_services && check_release_readiness "${RELEASE_SHA}"; then
+        log "Previous-release recovery failed; restored the healthy attempted release."
+    else
+        log "Previous-release recovery and attempted-release restoration are unhealthy."
+    fi
+fi
+fail "the directly restored previous release did not become healthy"

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -989,9 +989,12 @@ require_bundled_frontend_process() {
 
 check_rollback_liveness() {
     if [[ -f "${old_release}/.revision-health-v1" ]]; then
-        wait_for_http "rolled-back API" "http://127.0.0.1:8000/health" ok "${old_revision}" \
+        wait_for_http "rolled-back API revision ${old_revision}" "http://127.0.0.1:8000/health" ok "${old_revision}" \
             && wait_for_validated_json "rolled-back database-backed dashboard" "http://127.0.0.1:8000/api/public/dashboard" dashboard \
-            && wait_for_http "rolled-back frontend" "http://127.0.0.1:3000/sign-in"
+            && wait_for_http "rolled-back frontend" "http://127.0.0.1:3000/sign-in" \
+            && wait_for_http "public rolled-back API revision ${old_revision}" "https://api.spyboxd.com/health" ok "${old_revision}" \
+            && wait_for_validated_json "public rolled-back database-backed dashboard" "https://api.spyboxd.com/api/public/dashboard" dashboard \
+            && wait_for_http "public rolled-back frontend" "https://spyboxd.com/sign-in"
         return
     fi
 

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -203,11 +203,15 @@ if expected_revision and payload.get("revision") != expected_revision:
 }
 
 wait_for_validated_json() {
-    local name="$1" url="$2" kind="$3" response attempt
+    local name="$1" url="$2" kind="$3" expected_revision="${4:-}" response attempt
+    local -a validator_args=("${kind}")
+    if [[ -n "${expected_revision}" ]]; then
+        validator_args+=(--revision "${expected_revision}")
+    fi
     for attempt in $(seq 1 12); do
         if response="$(curl --silent --show-error --fail --max-time 5 "${url}" 2>/dev/null)" \
             && printf '%s' "${response}" \
-                | python3 "${health_validator}" "${kind}" >/dev/null; then
+                | python3 "${health_validator}" "${validator_args[@]}" >/dev/null; then
             log "${name} is ready"
             return 0
         fi

--- a/deploy/run-compose-smoke.sh
+++ b/deploy/run-compose-smoke.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Exercise Compose packaging, dependency ordering, API migration, and container
+# health without publishing host ports or recompiling the Next.js artifact.
+# Browser-to-API behavior is covered separately by the required Playwright job.
+readonly project_name="spyboxdci-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}-${PPID}"
+if [[ ! "${project_name}" =~ ^[a-z0-9][a-z0-9_-]{1,62}$ ]]; then
+    printf 'Unsafe Compose project name: %s\n' "${project_name}" >&2
+    exit 64
+fi
+
+umask 077
+env_file="$(mktemp "${RUNNER_TEMP:-/tmp}/spyboxd-compose-smoke.XXXXXX.env")"
+readonly env_file
+declare -ar compose=(
+    docker compose
+    --project-name "${project_name}"
+    --env-file "${env_file}"
+    -f docker-compose.yml
+    -f deploy/docker-compose.ci.yml
+)
+
+cleanup() {
+    local status="$?"
+    trap - EXIT
+
+    if (( status != 0 )); then
+        printf '%s\n' 'Compose smoke failed; collecting bounded container diagnostics.' >&2
+        timeout --signal=TERM --kill-after=5s 20s \
+            "${compose[@]}" ps --all >&2 || true
+        timeout --signal=TERM --kill-after=5s 30s \
+            "${compose[@]}" logs --no-color --tail 200 postgres api frontend >&2 || true
+    fi
+
+    timeout --signal=TERM --kill-after=10s 90s \
+        "${compose[@]}" down --volumes --remove-orphans --timeout 10 >&2 || true
+    rm -f -- "${env_file}"
+    exit "${status}"
+}
+trap cleanup EXIT
+
+{
+    printf 'POSTGRES_PASSWORD=ci-%s-%s-%s\n' \
+        "${GITHUB_RUN_ID:-local}" "${GITHUB_RUN_ATTEMPT:-1}" "${RANDOM}"
+    printf '%s\n' \
+        'FRONTEND_URL=http://frontend:3000' \
+        'CORS_ALLOWED_ORIGINS=http://frontend:3000' \
+        'NEXT_PUBLIC_API_BASE_URL=http://api:8000' \
+        'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsuZXhhbXBsZS50ZXN0JA=='
+    # Deliberately non-secret build sentinel, split to avoid resembling a credential.
+    printf 'CLERK_SECRET_KEY=sk_%s_%s\n' \
+        live 'Y2xlcmsuZXhhbXBsZS50ZXN0JA=='
+    printf '%s\n' \
+        'NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in' \
+        'NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up' \
+        'NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/' \
+        'NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/'
+} >"${env_file}"
+
+expected_frontend_build_id="$(<frontend/.next/BUILD_ID)"
+[[ -n "${expected_frontend_build_id}" && "${expected_frontend_build_id}" != *$'\n'* ]]
+
+# Keep the normal developer Compose Dockerfile valid even though this CI smoke
+# packages the already-built artifact through the prebuilt runtime Dockerfile.
+timeout --signal=TERM --kill-after=5s 30s \
+    docker build --check -f frontend/Dockerfile .
+
+timeout --signal=TERM --kill-after=30s 12m \
+    "${compose[@]}" build --pull api frontend
+
+timeout --signal=TERM --kill-after=30s 5m \
+    "${compose[@]}" up --detach --wait --wait-timeout 180 postgres api frontend
+
+# The RSS worker intentionally stays out of this smoke: contacting Letterboxd
+# is not needed to validate the production container graph.
+if "${compose[@]}" ps --all --services | grep -Fqx 'rss-poller'; then
+    printf '%s\n' 'The Compose smoke unexpectedly started rss-poller.' >&2
+    exit 1
+fi
+
+timeout --signal=TERM --kill-after=5s 30s \
+    "${compose[@]}" exec -T api python - <<'PY'
+import json
+import urllib.request
+
+with urllib.request.urlopen("http://localhost:8000/ready", timeout=5) as response:
+    report = json.load(response)
+
+assert report["status"] == "ready", report
+assert report["checks"] == {"database": "ok", "schema": "current"}, report
+assert report["schema"]["current_revisions"], report
+PY
+
+expected_heads="$({
+    timeout --signal=TERM --kill-after=5s 30s \
+        "${compose[@]}" exec -T api python - <<'PY'
+from services.operational_health import repository_schema_heads
+
+print("\n".join(sorted(repository_schema_heads())))
+PY
+} | tr -d '\r')"
+current_heads="$({
+    timeout --signal=TERM --kill-after=5s 30s \
+        "${compose[@]}" exec -T postgres \
+        psql --username spyboxd --dbname spyboxd --tuples-only --no-align \
+        --command 'SELECT version_num FROM alembic_version ORDER BY version_num'
+} | tr -d '\r')"
+
+[[ -n "${expected_heads}" && "${current_heads}" == "${expected_heads}" ]]
+[[ "$(timeout --signal=TERM --kill-after=5s 30s \
+    "${compose[@]}" exec -T postgres \
+    psql --username spyboxd --dbname spyboxd --tuples-only --no-align \
+    --command "SELECT to_regclass('public.profiles') IS NOT NULL" | tr -d '[:space:]')" == t ]]
+
+timeout --signal=TERM --kill-after=5s 30s \
+    "${compose[@]}" exec -T frontend \
+    wget --quiet --output-document=/dev/null http://localhost:3000/
+
+container_frontend_build_id="$({
+    timeout --signal=TERM --kill-after=5s 30s \
+        "${compose[@]}" exec -T frontend \
+        sh -c 'cat /app/.next/BUILD_ID'
+} | tr -d '\r\n')"
+[[ "${container_frontend_build_id}" == "${expected_frontend_build_id}" ]]
+
+printf '%s\n' 'Compose startup smoke passed: artifact packaged, services healthy, and migrations reached head.'

--- a/deploy/run-production-auth-canary.py
+++ b/deploy/run-production-auth-canary.py
@@ -42,6 +42,13 @@ LOCK_NAME = ".auth-canary.lock"
 LIVE_SESSION_STATUSES = ("active",)
 SESSION_MAX_DURATION_SECONDS = 120
 SESSION_EXPIRY_GRACE_SECONDS = 5
+BROWSER_PLAN_VERSION = 2
+BROWSER_CLOSURE_BY_LABEL = {
+    "A": "sign_out",
+    "B": "session_expiry",
+}
+DATABASE_STATE_BOOTSTRAP = "bootstrap"
+DATABASE_STATE_PROVISIONED = "provisioned"
 
 
 class AuthCanaryError(RuntimeError):
@@ -50,6 +57,16 @@ class AuthCanaryError(RuntimeError):
 
 class GuardianInterrupted(AuthCanaryError):
     pass
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(
+        self, request, file_pointer, code, message, headers, new_url  # noqa: ANN001
+    ):
+        return None
+
+
+_CLERK_OPENER = urllib.request.build_opener(_NoRedirect)
 
 
 @dataclass(frozen=True)
@@ -167,14 +184,56 @@ def _validate_database_rows(
     identity_rows: Iterable[Mapping[str, Any]],
     tracked_rows: Iterable[Mapping[str, Any]],
     configured_admin_ids: set[str],
-) -> None:
+    profile_rows: Iterable[Mapping[str, Any]] = (),
+    claimed_rows: Iterable[Mapping[str, Any]] = (),
+) -> str:
     expected_ids = {identity.user_id for identity in identities}
     if expected_ids & configured_admin_ids:
         raise AuthCanaryError("a configured canary identity is an administrator")
-    by_user = {str(row["clerk_user_id"]): row for row in identity_rows}
+
+    identity_row_list = list(identity_rows)
+    by_user = {str(row["clerk_user_id"]): row for row in identity_row_list}
+    if len(identity_row_list) != len(by_user):
+        raise AuthCanaryError("the canary identity database state is ambiguous")
+    if not by_user:
+        expected_profiles = {identity.profile.casefold() for identity in identities}
+        profile_row_list = list(profile_rows)
+        by_profile: dict[str, Mapping[str, Any]] = {}
+        for row in profile_row_list:
+            username = row.get("username")
+            if not isinstance(username, str):
+                raise AuthCanaryError("a bootstrap canary profile is invalid")
+            normalized = username.casefold()
+            if normalized in by_profile:
+                raise AuthCanaryError("the bootstrap canary profile state is ambiguous")
+            by_profile[normalized] = row
+        if set(by_profile) != expected_profiles:
+            raise AuthCanaryError(
+                "both bootstrap canary profiles must already exist in Spyboxd"
+            )
+        for identity in identities:
+            row = by_profile[identity.profile.casefold()]
+            if (
+                row.get("is_active") is not True
+                or row.get("scraping_status") != "completed"
+            ):
+                raise AuthCanaryError(
+                    f"bootstrap canary profile {identity.label} is not completed "
+                    "and active"
+                )
+        if list(claimed_rows):
+            raise AuthCanaryError(
+                "a bootstrap canary profile is already claimed by another "
+                "Spyboxd identity"
+            )
+        if list(tracked_rows):
+            raise AuthCanaryError("the bootstrap canary identity state is inconsistent")
+        return DATABASE_STATE_BOOTSTRAP
+
     if set(by_user) != expected_ids:
         raise AuthCanaryError(
-            "both canary identities must already be provisioned in Spyboxd"
+            "canary identities must be either both absent or both provisioned "
+            "in Spyboxd"
         )
 
     tracked: dict[str, set[str]] = {identity.user_id: set() for identity in identities}
@@ -199,13 +258,14 @@ def _validate_database_rows(
             raise AuthCanaryError(
                 f"canary identity {identity.label} must track exactly its own profile"
             )
+    return DATABASE_STATE_PROVISIONED
 
 
 def _database_preflight(
     database_url: str,
     identities: tuple[CanaryIdentity, CanaryIdentity],
     configured_admin_ids: set[str],
-) -> None:
+) -> str:
     try:
         from sqlalchemy import create_engine, text
     except ImportError as exc:
@@ -247,13 +307,52 @@ def _database_preflight(
                 .mappings()
                 .all()
             )
+            profile_rows = (
+                connection.execute(
+                    text(
+                        """
+                    SELECT username, is_active, scraping_status
+                    FROM profiles
+                    WHERE lower(username) IN (:profile_a, :profile_b)
+                    """
+                    ),
+                    {
+                        "profile_a": identities[0].profile.casefold(),
+                        "profile_b": identities[1].profile.casefold(),
+                    },
+                )
+                .mappings()
+                .all()
+            )
+            claimed_rows = (
+                connection.execute(
+                    text(
+                        """
+                    SELECT clerk_user_id, letterboxd_username
+                    FROM app_users
+                    WHERE lower(letterboxd_username) IN (:profile_a, :profile_b)
+                    """
+                    ),
+                    {
+                        "profile_a": identities[0].profile.casefold(),
+                        "profile_b": identities[1].profile.casefold(),
+                    },
+                )
+                .mappings()
+                .all()
+            )
     except Exception as exc:
         raise AuthCanaryError("the canary database preflight failed") from exc
     finally:
         if engine is not None:
             engine.dispose()
-    _validate_database_rows(
-        identities, identity_rows, tracked_rows, configured_admin_ids
+    return _validate_database_rows(
+        identities,
+        identity_rows,
+        tracked_rows,
+        configured_admin_ids,
+        profile_rows,
+        claimed_rows,
     )
 
 
@@ -302,9 +401,12 @@ def _request(
     request = urllib.request.Request(url, data=body, headers=headers, method=method)
     try:
         # Safe because the parsed HTTPS origin is pinned to api.clerk.com above.
-        opened = urllib.request.urlopen(request, timeout=10)  # nosec B310
+        opened = _CLERK_OPENER.open(request, timeout=10)
     except urllib.error.HTTPError as exc:
-        return HttpResponse(exc.code, _bounded_body(exc), exc.headers)
+        try:
+            return HttpResponse(exc.code, _bounded_body(exc), exc.headers)
+        finally:
+            exc.close()
     except (OSError, urllib.error.URLError) as exc:
         raise AuthCanaryError(
             "an authenticated canary dependency could not be reached"
@@ -320,6 +422,42 @@ def _json(response: HttpResponse, label: str, expected_status: int) -> Any:
         return json.loads(response.body)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise AuthCanaryError(f"{label} returned invalid JSON") from exc
+
+
+def _verify_bootstrap_clerk_usernames(
+    secret_key: str,
+    identities: tuple[CanaryIdentity, CanaryIdentity],
+) -> None:
+    for identity in identities:
+        payload = _json(
+            _request(
+                "https://api.clerk.com/v1/users/"
+                + urllib.parse.quote(identity.user_id, safe=""),
+                bearer=secret_key,
+                clerk_backend=True,
+            ),
+            f"Clerk user lookup for bootstrap canary {identity.label}",
+            200,
+        )
+        username = payload.get("username") if isinstance(payload, dict) else None
+        if (
+            not isinstance(payload, dict)
+            or payload.get("id") != identity.user_id
+            or not isinstance(username, str)
+            or username.casefold() != identity.profile.casefold()
+        ):
+            raise AuthCanaryError(
+                f"bootstrap canary {identity.label} Clerk username does not "
+                "match its configured profile"
+            )
+
+
+def _require_post_browser_provisioning(database_state: str) -> None:
+    if database_state != DATABASE_STATE_PROVISIONED:
+        raise AuthCanaryError(
+            "the browser flow did not provision both canary identities with "
+            "one-profile tracking"
+        )
 
 
 def _origin(value: str, label: str) -> str:
@@ -448,11 +586,60 @@ def _create_agent_task(
     }
 
 
+def _build_browser_plan(
+    *,
+    api_base: str,
+    app_origin: str,
+    task_origin: str,
+    tasks: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    if len(tasks) != len(BROWSER_CLOSURE_BY_LABEL):
+        raise AuthCanaryError("authenticated browser plan requires exactly two tasks")
+
+    planned_tasks: list[dict[str, Any]] = []
+    seen_labels: set[str] = set()
+    for task in tasks:
+        label = task.get("label")
+        if not isinstance(label, str):
+            raise AuthCanaryError("authenticated browser plan has invalid task labels")
+        closure = BROWSER_CLOSURE_BY_LABEL.get(label)
+        if closure is None or label in seen_labels:
+            raise AuthCanaryError("authenticated browser plan has invalid task labels")
+        if task.get("task_origin") != task_origin:
+            raise AuthCanaryError(
+                "authenticated browser plan has inconsistent task origins"
+            )
+        seen_labels.add(label)
+        planned_tasks.append(
+            {
+                **{key: value for key, value in task.items() if key != "task_origin"},
+                "closure": closure,
+            }
+        )
+
+    if seen_labels != set(BROWSER_CLOSURE_BY_LABEL):
+        raise AuthCanaryError("authenticated browser plan is missing a task label")
+    return {
+        "version": BROWSER_PLAN_VERSION,
+        "api_base": api_base,
+        "app_origin": app_origin,
+        "task_origin": task_origin,
+        "session_max_duration_seconds": SESSION_MAX_DURATION_SECONDS,
+        "tasks": planned_tasks,
+    }
+
+
 def _list_sessions(
     secret_key: str, user_id: str, status_filter: str
 ) -> list[dict[str, Any]]:
+    limit = 100
     query = urllib.parse.urlencode(
-        {"user_id": user_id, "status": status_filter, "limit": 100}
+        {
+            "user_id": user_id,
+            "status": status_filter,
+            "limit": limit,
+            "paginated": "true",
+        }
     )
     payload = _json(
         _request(
@@ -463,12 +650,23 @@ def _list_sessions(
         "Clerk canary session listing",
         200,
     )
-    if not isinstance(payload, list):
+    if not isinstance(payload, dict):
         raise AuthCanaryError("Clerk returned an invalid session list")
-    if len(payload) >= 100:
+    raw_sessions = payload.get("data")
+    total_count = payload.get("total_count")
+    if (
+        not isinstance(raw_sessions, list)
+        or isinstance(total_count, bool)
+        or not isinstance(total_count, int)
+        or total_count < 0
+    ):
+        raise AuthCanaryError("Clerk returned an invalid session list")
+    if total_count != len(raw_sessions):
+        raise AuthCanaryError("Clerk returned an ambiguous paginated session list")
+    if total_count >= limit:
         raise AuthCanaryError("a dedicated canary user has too many sessions")
     sessions: list[dict[str, Any]] = []
-    for item in payload:
+    for item in raw_sessions:
         if not isinstance(item, dict):
             raise AuthCanaryError("Clerk returned an invalid session entry")
         session_id = item.get("id")
@@ -951,7 +1149,11 @@ def run_guardian(
                 signal_number, _signal_handler
             )
         try:
-            _database_preflight(database_url, identities, configured_admin_ids)
+            database_state = _database_preflight(
+                database_url, identities, configured_admin_ids
+            )
+            if database_state == DATABASE_STATE_BOOTSTRAP:
+                _verify_bootstrap_clerk_usernames(secret_key, identities)
             _require_zero_live_sessions(secret_key, identities)
             state["session_baseline_proven_zero"] = True
             state["phase"] = "creating_tasks"
@@ -971,16 +1173,15 @@ def run_guardian(
                 )
                 for identity in identities
             ]
-            task_origins = {task.pop("task_origin") for task in tasks}
+            task_origins = {task.get("task_origin") for task in tasks}
             if len(task_origins) != 1:
                 raise AuthCanaryError("Clerk returned inconsistent task origins")
-            plan = {
-                "version": 1,
-                "api_base": api_base,
-                "app_origin": APP_ORIGIN,
-                "task_origin": next(iter(task_origins)),
-                "tasks": tasks,
-            }
+            plan = _build_browser_plan(
+                api_base=api_base,
+                app_origin=APP_ORIGIN,
+                task_origin=next(iter(task_origins)),
+                tasks=tasks,
+            )
             state["phase"] = "waiting_for_browser"
             _write_private_json(state_path, state)
             _write_private_json(lease_dir / PLAN_NAME, plan)
@@ -992,6 +1193,11 @@ def run_guardian(
                         "authenticated browser canary did not finish before its deadline"
                     )
                 time.sleep(0.5)
+            state["phase"] = "verifying_database_provisioning"
+            _write_private_json(state_path, state)
+            _require_post_browser_provisioning(
+                _database_preflight(database_url, identities, configured_admin_ids)
+            )
         except BaseException as exc:  # noqa: BLE001 - signals must enter the cleanup path
             primary_error = exc
         finally:

--- a/deploy/test_check_runtime_health.py
+++ b/deploy/test_check_runtime_health.py
@@ -75,23 +75,22 @@ class RuntimeHealthValidationTests(unittest.TestCase):
                     health.validate_dashboard(payload)
 
     def test_ready_requires_matching_revision_and_database_schema(self) -> None:
-        health.validate_ready(
-            {
-                "status": "ready",
-                "revision": "a" * 40,
-                "checks": {"database": "ok", "schema": "current"},
-            },
-            "a" * 40,
+        healthy = {
+            "status": "ready",
+            "revision": "a" * 40,
+            "checks": {"database": "ok", "schema": "current"},
+        }
+        health.validate_ready(healthy, "a" * 40)
+
+        invalid = (
+            {**healthy, "revision": "b" * 40},
+            {**healthy, "checks": {"database": "unavailable", "schema": "current"}},
+            {**healthy, "checks": {"database": "ok", "schema": "pending"}},
         )
-        with self.assertRaises(health.HealthValidationError):
-            health.validate_ready(
-                {
-                    "status": "ready",
-                    "revision": "b" * 40,
-                    "checks": {"database": "ok", "schema": "current"},
-                },
-                "a" * 40,
-            )
+        for payload in invalid:
+            with self.subTest(payload=payload):
+                with self.assertRaises(health.HealthValidationError):
+                    health.validate_ready(payload, "a" * 40)
 
     def test_rss_rejects_degraded_http_200_payload(self) -> None:
         healthy = {

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import stat
@@ -242,26 +243,178 @@ class ProductionCanaryTests(unittest.TestCase):
             auth_canary.CanaryIdentity("A", "user_A123", "alpha"),
             auth_canary.CanaryIdentity("B", "user_B123", "beta"),
         )
-        auth_canary._validate_database_rows(
-            identities,
-            [
-                {
-                    "clerk_user_id": "user_A123",
-                    "letterboxd_username": "Alpha",
-                    "is_active": True,
-                },
-                {
-                    "clerk_user_id": "user_B123",
-                    "letterboxd_username": "Beta",
-                    "is_active": True,
-                },
-            ],
-            [
-                {"clerk_user_id": "user_A123", "username": "Alpha"},
-                {"clerk_user_id": "user_B123", "username": "Beta"},
-            ],
-            set(),
+        self.assertEqual(
+            auth_canary._validate_database_rows(
+                identities,
+                [
+                    {
+                        "clerk_user_id": "user_A123",
+                        "letterboxd_username": "Alpha",
+                        "is_active": True,
+                    },
+                    {
+                        "clerk_user_id": "user_B123",
+                        "letterboxd_username": "Beta",
+                        "is_active": True,
+                    },
+                ],
+                [
+                    {"clerk_user_id": "user_A123", "username": "Alpha"},
+                    {"clerk_user_id": "user_B123", "username": "Beta"},
+                ],
+                set(),
+            ),
+            auth_canary.DATABASE_STATE_PROVISIONED,
         )
+
+    def test_auth_canary_first_run_accepts_two_completed_unclaimed_profiles(self):
+        identities = (
+            auth_canary.CanaryIdentity("A", "user_A123", "alpha"),
+            auth_canary.CanaryIdentity("B", "user_B123", "beta"),
+        )
+        self.assertEqual(
+            auth_canary._validate_database_rows(
+                identities,
+                [],
+                [],
+                set(),
+                [
+                    {
+                        "username": "Alpha",
+                        "is_active": True,
+                        "scraping_status": "completed",
+                    },
+                    {
+                        "username": "Beta",
+                        "is_active": True,
+                        "scraping_status": "completed",
+                    },
+                ],
+                [],
+            ),
+            auth_canary.DATABASE_STATE_BOOTSTRAP,
+        )
+
+    def test_auth_canary_first_run_rejects_partial_incomplete_or_claimed_state(self):
+        identities = (
+            auth_canary.CanaryIdentity("A", "user_A123", "alpha"),
+            auth_canary.CanaryIdentity("B", "user_B123", "beta"),
+        )
+        completed_profiles = [
+            {
+                "username": "alpha",
+                "is_active": True,
+                "scraping_status": "completed",
+            },
+            {
+                "username": "beta",
+                "is_active": True,
+                "scraping_status": "completed",
+            },
+        ]
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "both absent"):
+            auth_canary._validate_database_rows(
+                identities,
+                [
+                    {
+                        "clerk_user_id": "user_A123",
+                        "letterboxd_username": "alpha",
+                        "is_active": True,
+                    }
+                ],
+                [{"clerk_user_id": "user_A123", "username": "alpha"}],
+                set(),
+                completed_profiles,
+                [],
+            )
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "not completed"):
+            auth_canary._validate_database_rows(
+                identities,
+                [],
+                [],
+                set(),
+                [
+                    {**completed_profiles[0], "scraping_status": "pending"},
+                    completed_profiles[1],
+                ],
+                [],
+            )
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "already claimed"):
+            auth_canary._validate_database_rows(
+                identities,
+                [],
+                [],
+                set(),
+                completed_profiles,
+                [
+                    {
+                        "clerk_user_id": "user_someone_else",
+                        "letterboxd_username": "alpha",
+                    }
+                ],
+            )
+
+    def test_auth_canary_bootstrap_verifies_clerk_usernames(self):
+        identities = (
+            auth_canary.CanaryIdentity("A", "user_A123", "alpha"),
+            auth_canary.CanaryIdentity("B", "user_B123", "beta"),
+        )
+        responses = [
+            auth_canary.HttpResponse(
+                200,
+                json.dumps({"id": "user_A123", "username": "Alpha"}).encode(),
+                {},
+            ),
+            auth_canary.HttpResponse(
+                200,
+                json.dumps({"id": "user_B123", "username": "Beta"}).encode(),
+                {},
+            ),
+        ]
+        with mock.patch.object(
+            auth_canary, "_request", side_effect=responses
+        ) as request:
+            auth_canary._verify_bootstrap_clerk_usernames("sk_live_test", identities)
+        self.assertEqual(request.call_count, 2)
+        self.assertTrue(
+            all(call.kwargs["clerk_backend"] for call in request.call_args_list)
+        )
+
+        responses[1] = auth_canary.HttpResponse(
+            200,
+            json.dumps({"id": "user_B123", "username": "someone_else"}).encode(),
+            {},
+        )
+        with (
+            mock.patch.object(auth_canary, "_request", side_effect=responses),
+            self.assertRaisesRegex(auth_canary.AuthCanaryError, "does not match"),
+        ):
+            auth_canary._verify_bootstrap_clerk_usernames("sk_live_test", identities)
+
+    def test_auth_canary_requires_provisioned_database_state_after_browser(self):
+        auth_canary._require_post_browser_provisioning(
+            auth_canary.DATABASE_STATE_PROVISIONED
+        )
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "did not provision"):
+            auth_canary._require_post_browser_provisioning(
+                auth_canary.DATABASE_STATE_BOOTSTRAP
+            )
+
+    def test_authenticated_workflow_stages_and_deletes_ephemeral_identity_config(self):
+        workflow = (
+            DEPLOY_DIR.parent / ".github" / "workflows" / "production-canary.yml"
+        ).read_text(encoding="utf-8")
+        for name in (
+            "SPYBOXD_CANARY_USER_A_ID",
+            "SPYBOXD_CANARY_PROFILE_A",
+            "SPYBOXD_CANARY_USER_B_ID",
+            "SPYBOXD_CANARY_PROFILE_B",
+        ):
+            self.assertIn(f"secrets.{name}", workflow)
+        self.assertIn('local_env="${RUNNER_TEMP}/spyboxd-auth-canary.env"', workflow)
+        self.assertIn('--canary-env "${canary_env_path}"', workflow)
+        self.assertIn("shred --force --iterations=1 --zero --remove", workflow)
+        self.assertNotIn("/etc/spyboxd/canary.env", workflow)
 
     def test_authenticated_canary_pins_the_documented_clerk_api_version_header(self):
         class Opened:
@@ -280,8 +433,8 @@ class ProductionCanaryTests(unittest.TestCase):
                 return False
 
         with mock.patch.object(
-            auth_canary.urllib.request, "urlopen", return_value=Opened()
-        ) as urlopen:
+            auth_canary._CLERK_OPENER, "open", return_value=Opened()
+        ) as open_request:
             auth_canary._request(
                 "https://api.clerk.com/v1/agents/tasks",
                 method="POST",
@@ -289,10 +442,72 @@ class ProductionCanaryTests(unittest.TestCase):
                 payload={"permissions": "*"},
                 clerk_backend=True,
             )
-        request = urlopen.call_args.args[0]
+        request = open_request.call_args.args[0]
         headers = {name.lower(): value for name, value in request.header_items()}
         self.assertEqual(headers["clerk-api-version"], "2026-05-12")
         self.assertNotIn("clerk-version", headers)
+
+    def test_authenticated_canary_never_follows_clerk_redirects(self):
+        redirect = auth_canary.urllib.error.HTTPError(
+            "https://api.clerk.com/v1/sessions",
+            302,
+            "Found",
+            {"Location": "https://evil.example/collect"},
+            io.BytesIO(b""),
+        )
+        with mock.patch.object(
+            auth_canary._CLERK_OPENER, "open", side_effect=redirect
+        ) as open_request:
+            response = auth_canary._request(
+                "https://api.clerk.com/v1/sessions",
+                bearer="sk_live_test",
+                clerk_backend=True,
+            )
+        self.assertEqual(response.status, 302)
+        self.assertEqual(open_request.call_count, 1)
+        self.assertEqual(
+            open_request.call_args.args[0].full_url,
+            "https://api.clerk.com/v1/sessions",
+        )
+
+    def test_authenticated_canary_requires_explicit_complete_session_pagination(self):
+        session = {
+            "id": "sess_A123456",
+            "user_id": "user_A123",
+            "status": "active",
+        }
+        response = auth_canary.HttpResponse(
+            200,
+            json.dumps({"data": [session], "total_count": 1}).encode(),
+            {},
+        )
+        with mock.patch.object(auth_canary, "_request", return_value=response) as request:
+            self.assertEqual(
+                auth_canary._list_sessions(
+                    "sk_live_test", "user_A123", "active"
+                ),
+                [session],
+            )
+        self.assertIn("paginated=true", request.call_args.args[0])
+
+        invalid_payloads = (
+            [session],
+            {"data": [session], "total_count": 2},
+            {"data": [session], "total_count": True},
+            {"data": [session] * 100, "total_count": 100},
+        )
+        for payload in invalid_payloads:
+            with self.subTest(payload_type=type(payload).__name__):
+                response = auth_canary.HttpResponse(
+                    200, json.dumps(payload).encode(), {}
+                )
+                with (
+                    mock.patch.object(auth_canary, "_request", return_value=response),
+                    self.assertRaises(auth_canary.AuthCanaryError),
+                ):
+                    auth_canary._list_sessions(
+                        "sk_live_test", "user_A123", "active"
+                    )
 
     def test_authenticated_canary_records_task_id_before_url_validation(self):
         identity = auth_canary.CanaryIdentity("A", "user_A123", "alpha")
@@ -329,6 +544,73 @@ class ProductionCanaryTests(unittest.TestCase):
             request.call_args.kwargs["payload"]["redirect_url"],
             "https://spyboxd.com/profiles",
         )
+
+    def test_authenticated_browser_plan_assigns_sign_out_and_expiry_proofs(self):
+        tasks = [
+            {
+                "label": "A",
+                "user_id": "user_A123",
+                "profile": "alpha",
+                "task_url": "https://clerk.spyboxd.com/task-a",
+                "task_origin": "https://clerk.spyboxd.com",
+            },
+            {
+                "label": "B",
+                "user_id": "user_B123",
+                "profile": "beta",
+                "task_url": "https://clerk.spyboxd.com/task-b",
+                "task_origin": "https://clerk.spyboxd.com",
+            },
+        ]
+        plan = auth_canary._build_browser_plan(
+            api_base="https://api.spyboxd.com",
+            app_origin="https://spyboxd.com",
+            task_origin="https://clerk.spyboxd.com",
+            tasks=tasks,
+        )
+        self.assertEqual(plan["version"], auth_canary.BROWSER_PLAN_VERSION)
+        self.assertEqual(
+            plan["session_max_duration_seconds"],
+            auth_canary.SESSION_MAX_DURATION_SECONDS,
+        )
+        self.assertEqual(
+            [task["closure"] for task in plan["tasks"]],
+            ["sign_out", "session_expiry"],
+        )
+        self.assertNotIn("closure", tasks[0])
+        self.assertNotIn("closure", tasks[1])
+
+    def test_authenticated_browser_plan_rejects_duplicate_or_inconsistent_tasks(self):
+        base = {
+            "label": "A",
+            "user_id": "user_A123",
+            "profile": "alpha",
+            "task_url": "https://clerk.spyboxd.com/task-a",
+            "task_origin": "https://clerk.spyboxd.com",
+        }
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "task labels"):
+            auth_canary._build_browser_plan(
+                api_base="https://api.spyboxd.com",
+                app_origin="https://spyboxd.com",
+                task_origin="https://clerk.spyboxd.com",
+                tasks=[base, {**base, "user_id": "user_B123", "profile": "beta"}],
+            )
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "task origins"):
+            auth_canary._build_browser_plan(
+                api_base="https://api.spyboxd.com",
+                app_origin="https://spyboxd.com",
+                task_origin="https://clerk.spyboxd.com",
+                tasks=[
+                    base,
+                    {
+                        "label": "B",
+                        "user_id": "user_B123",
+                        "profile": "beta",
+                        "task_url": "https://clerk.spyboxd.com/task-b",
+                        "task_origin": "https://other.example",
+                    },
+                ],
+            )
 
     def test_authenticated_canary_refuses_users_with_preexisting_sessions(self):
         identities = (

--- a/deploy/test_reconcile_interrupted_deployment.py
+++ b/deploy/test_reconcile_interrupted_deployment.py
@@ -1,0 +1,400 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+RECONCILE_SCRIPT = REPOSITORY_ROOT / "deploy/reconcile-interrupted-deployment.sh"
+HEALTH_VALIDATOR = REPOSITORY_ROOT / "deploy/check-runtime-health.py"
+DEPLOY_WORKFLOW = REPOSITORY_ROOT / ".github/workflows/deploy.yml"
+
+
+class InterruptedDeploymentReconciliationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="spyboxd-reconcile-test-")
+        self.root = Path(self.temporary.name).resolve()
+        self.app_root = self.root / "app"
+        self.releases = self.app_root / "releases"
+        self.shared = self.app_root / "shared"
+        self.state = self.shared / "release-state"
+        self.repository = self.app_root / "repository"
+        self.bin_dir = self.root / "bin"
+        for directory in (self.releases, self.state, self.bin_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+        self.state.chmod(0o750)
+
+        self.source_repository = self.root / "source"
+        subprocess.run(
+            ["git", "init", "--quiet", "--initial-branch=main", self.source_repository],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", self.source_repository, "config", "user.name", "Spyboxd CI"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                self.source_repository,
+                "config",
+                "user.email",
+                "ci@spyboxd.invalid",
+            ],
+            check=True,
+        )
+        marker = self.source_repository / "marker"
+        marker.write_text("previous\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", self.source_repository, "add", "marker"], check=True
+        )
+        subprocess.run(
+            ["git", "-C", self.source_repository, "commit", "--quiet", "-m", "previous"],
+            check=True,
+        )
+        self.previous_revision = self._git(self.source_repository, "rev-parse", "HEAD")
+        marker.write_text("attempted\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", self.source_repository, "commit", "--quiet", "-am", "attempted"],
+            check=True,
+        )
+        self.attempted_revision = self._git(self.source_repository, "rev-parse", "HEAD")
+        subprocess.run(
+            ["git", "clone", "--quiet", "--bare", self.source_repository, self.repository],
+            check=True,
+        )
+
+        self.previous_release = self._release(self.previous_revision)
+        self.attempted_release = self._release(self.attempted_revision)
+        self.current_link = self.app_root / "current"
+        self.current_link.symlink_to(self.attempted_release)
+        self._write_state(self.previous_revision, self.previous_revision)
+
+        self.curl_trace = self.root / "curl-trace.log"
+        self.service_trace = self.root / "service-trace.log"
+        self.curl_trace.touch()
+        self.service_trace.touch()
+        self._install_command_fakes()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    @staticmethod
+    def _git(repository: Path, *arguments: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", repository, *arguments], text=True
+        ).strip()
+
+    def _release(self, revision: str) -> Path:
+        release = self.releases / revision
+        (release / ".venv/bin").mkdir(parents=True)
+        (release / "frontend/.next").mkdir(parents=True)
+        (release / "frontend/node_modules/next/dist/bin").mkdir(parents=True)
+        (release / "frontend/.runtime").mkdir(parents=True)
+        (release / "deploy").mkdir(parents=True)
+        (release / "REVISION").write_text(f"{revision}\n", encoding="utf-8")
+        (release / ".revision-health-v1").touch()
+        (release / "frontend/.next/BUILD_ID").write_text("test\n", encoding="utf-8")
+        (release / "frontend/node_modules/next/dist/bin/next").touch()
+        (release / "frontend/.runtime/LICENSE.nodejs").write_text(
+            "test license\n", encoding="utf-8"
+        )
+        for executable in (
+            release / ".venv/bin/uvicorn",
+            release / "frontend/.runtime/node",
+        ):
+            executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+        shutil.copyfile(
+            HEALTH_VALIDATOR, release / "deploy/check-runtime-health.py"
+        )
+        return release
+
+    def _write_state(self, active: str, previous: str | None) -> None:
+        for name, value in (("active", active), ("previous", previous)):
+            marker = self.state / name
+            if value is None:
+                marker.unlink(missing_ok=True)
+                continue
+            marker.write_text(f"{value}\n", encoding="utf-8")
+            marker.chmod(0o640)
+
+    def _executable(self, name: str, contents: str) -> None:
+        path = self.bin_dir / name
+        path.write_text(textwrap.dedent(contents).lstrip(), encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def _install_command_fakes(self) -> None:
+        self._executable(
+            "flock",
+            """
+            #!/usr/bin/env bash
+            if [[ "${SPYBOXD_TEST_FAIL_LOCK:-0}" == 1 && "${1:-}" == -w ]]; then
+              exit 1
+            fi
+            exit 0
+            """,
+        )
+        self._executable(
+            "timeout",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            while [[ "${1:-}" == --* ]]; do shift; done
+            shift
+            exec "$@"
+            """,
+        )
+        self._executable(
+            "sudo",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            printf '%s\n' "$*" >>"${SPYBOXD_TEST_SERVICE_TRACE}"
+            if [[ " $* " == *" stop "* && "${SPYBOXD_TEST_FAIL_STOP:-0}" == 1 ]]; then
+              exit 1
+            fi
+            if [[ " $* " == *" restart "* && "${SPYBOXD_TEST_FAIL_RESTART:-0}" == 1 ]]; then
+              exit 1
+            fi
+            exit 0
+            """,
+        )
+        self._executable(
+            "sleep",
+            """
+            #!/usr/bin/env bash
+            exit 0
+            """,
+        )
+        self._executable(
+            "readlink",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            if [[ "${1:-}" == -f ]]; then
+              python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$2"
+            else
+              /usr/bin/readlink "$@"
+            fi
+            """,
+        )
+        self._executable(
+            "stat",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            [[ "$1" == -c ]]
+            case "$2" in
+              %u) python3 -c 'import os,sys; print(os.stat(sys.argv[1], follow_symlinks=False).st_uid)' "$3" ;;
+              %a) python3 -c 'import os,stat,sys; print(oct(stat.S_IMODE(os.stat(sys.argv[1], follow_symlinks=False).st_mode))[2:])' "$3" ;;
+              *) exit 64 ;;
+            esac
+            """,
+        )
+        self._executable(
+            "mv",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            if [[ "${1:-}" == -Tf ]]; then
+              shift
+              [[ "${1:-}" == -- ]] && shift
+              [[ "$#" == 2 ]]
+              source_path="$1"
+              destination_path="$2"
+              /bin/rm -f -- "${destination_path}"
+              exec /bin/mv -f -- "${source_path}" "${destination_path}"
+            fi
+            exec /bin/mv "$@"
+            """,
+        )
+        self._executable(
+            "curl",
+            """
+            #!/usr/bin/env bash
+            set -Eeuo pipefail
+            url="${!#}"
+            printf '%s\n' "${url}" >>"${SPYBOXD_TEST_CURL_TRACE}"
+            current_release="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "${SPYBOXD_CURRENT_LINK}")"
+            revision="$(basename "${current_release}")"
+            case "${url}" in
+              */ready)
+                database=ok
+                schema=current
+                if [[ "${revision}" == "${SPYBOXD_TEST_PREVIOUS_REVISION}" ]]; then
+                  schema=pending
+                fi
+                printf '{"status":"ready","revision":"%s","checks":{"database":"%s","schema":"%s"}}\n' \
+                  "${revision}" "${database}" "${schema}"
+                ;;
+              */health)
+                printf '{"status":"ok","revision":"%s"}\n' "${revision}"
+                ;;
+              */api/public/dashboard)
+                if [[ "${revision}" == "${SPYBOXD_TEST_PREVIOUS_REVISION}" \
+                    && "${SPYBOXD_TEST_FAIL_PREVIOUS_DASHBOARD:-0}" == 1 ]]; then
+                  printf '%s\n' '{"activity_data":"invalid"}'
+                else
+                  printf '%s\n' '{"activity_data":[],"data_health":{"active_profiles":2,"completed_profiles":2,"last_synced_at":"2026-07-31T00:00:00Z"},"rating_distribution":{},"signal_counts":{"one_day_gap_events":0,"one_day_gap_pair_hits":0,"profiles_analyzed":2,"profiles_with_diary_dates":2,"same_day_events":0,"same_day_pair_hits":0,"shared_titles":1},"system_stats":{"global_avg_rating":3.5,"total_movies_tracked":2,"total_profiles":2,"total_reviews":1},"timestamp":"2026-07-31T00:00:00Z"}'
+                fi
+                ;;
+              *) printf '%s\n' ok ;;
+            esac
+            """,
+        )
+
+    def _run(
+        self,
+        previous_target: str | None = None,
+        *,
+        fail_lock: bool = False,
+        fail_stop: bool = False,
+        fail_restart: bool = False,
+        fail_previous_dashboard: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{self.bin_dir}:{environment['PATH']}",
+                "SPYBOXD_APP_ROOT": str(self.app_root),
+                "SPYBOXD_REPOSITORY_DIR": str(self.repository),
+                "SPYBOXD_RELEASES_DIR": str(self.releases),
+                "SPYBOXD_SHARED_DIR": str(self.shared),
+                "SPYBOXD_RELEASE_STATE_DIR": str(self.state),
+                "SPYBOXD_CURRENT_LINK": str(self.current_link),
+                "SPYBOXD_TEST_CURL_TRACE": str(self.curl_trace),
+                "SPYBOXD_TEST_SERVICE_TRACE": str(self.service_trace),
+                "SPYBOXD_TEST_PREVIOUS_REVISION": self.previous_revision,
+                "SPYBOXD_TEST_FAIL_LOCK": "1" if fail_lock else "0",
+                "SPYBOXD_TEST_FAIL_STOP": "1" if fail_stop else "0",
+                "SPYBOXD_TEST_FAIL_RESTART": "1" if fail_restart else "0",
+                "SPYBOXD_TEST_FAIL_PREVIOUS_DASHBOARD": "1"
+                if fail_previous_dashboard
+                else "0",
+            }
+        )
+        return subprocess.run(
+            [
+                "bash",
+                RECONCILE_SCRIPT,
+                self.attempted_revision,
+                previous_target or self.previous_revision,
+                "false",
+            ],
+            cwd=REPOSITORY_ROOT,
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=30,
+        )
+
+    def test_interrupted_healthy_candidate_is_conservatively_rolled_back(self) -> None:
+        self._write_state(self.attempted_revision, self.previous_revision)
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.previous_release)
+        self.assertEqual(
+            (self.state / "active").read_text().strip(), self.previous_revision
+        )
+        self.assertEqual(
+            (self.state / "previous").read_text().strip(), self.attempted_revision
+        )
+        requested = self.curl_trace.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(any(url.endswith("/health") for url in requested))
+        self.assertTrue(
+            any(url.endswith("/api/public/dashboard") for url in requested)
+        )
+        self.assertFalse(any(url.endswith("/ready") for url in requested))
+
+    def test_failed_candidate_restores_prior_release(self) -> None:
+        self._write_state(self.previous_revision, self.previous_revision)
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.previous_release)
+        self.assertEqual(
+            (self.state / "active").read_text().strip(), self.previous_revision
+        )
+        self.assertFalse((self.state / "previous").exists())
+
+    def test_first_activation_stops_services_and_clears_current_state(self) -> None:
+        self._write_state(self.attempted_revision, None)
+        result = self._run("none")
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.current_link.exists())
+        self.assertFalse(self.current_link.is_symlink())
+        self.assertFalse((self.state / "active").exists())
+        self.assertFalse((self.state / "previous").exists())
+        self.assertIn(" systemctl stop ", f" {self.service_trace.read_text()} ")
+
+    def test_first_activation_stop_failure_preserves_current_and_state(self) -> None:
+        self._write_state(self.attempted_revision, None)
+        result = self._run("none", fail_stop=True)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("failed to stop services", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+        self.assertEqual(
+            (self.state / "active").read_text().strip(), self.attempted_revision
+        )
+
+    def test_busy_lock_and_corrupt_state_fail_without_switching_release(self) -> None:
+        result = self._run(fail_lock=True)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("did not relinquish", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+
+        self.state.chmod(0o700)
+        result = self._run()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("unsafe ownership or permissions", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+
+        self.state.chmod(0o750)
+        (self.state / "previous").write_text("corrupt\n", encoding="utf-8")
+        result = self._run()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("previous release-state marker is invalid", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+
+        self._write_state(self.attempted_revision, None)
+        result = self._run()
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("no trustworthy previous marker", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+
+    def test_service_restart_failure_restores_attempted_link_and_fails(self) -> None:
+        self._write_state(self.attempted_revision, self.previous_revision)
+        result = self._run(fail_restart=True)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("directly restored previous release", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+        service_calls = self.service_trace.read_text(encoding="utf-8")
+        self.assertGreaterEqual(service_calls.count("systemctl restart"), 2)
+
+    def test_database_incompatible_previous_restores_healthy_attempted_release(self) -> None:
+        self._write_state(self.attempted_revision, self.previous_revision)
+        result = self._run(fail_previous_dashboard=True)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("restored the healthy attempted release", result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.attempted_release)
+
+    def test_workflow_invokes_the_exact_repository_native_helper(self) -> None:
+        workflow = DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            '"${release_sha}:deploy/reconcile-interrupted-deployment.sh"', workflow
+        )
+        self.assertIn(
+            '"${release_sha}" "${previous_target}" "${clerk_bridge_mode}"', workflow
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/test_rollback_state_machine.py
+++ b/deploy/test_rollback_state_machine.py
@@ -97,6 +97,8 @@ class RollbackStateMachineTests(unittest.TestCase):
         self.clerk_validator = self.root / "validate-clerk.py"
         self.clerk_validator.write_text("raise SystemExit(0)\n", encoding="utf-8")
         self.clerk_validator.chmod(0o600)
+        self.curl_trace = self.root / "curl-trace.log"
+        self.curl_trace.touch()
 
         self._executable(
             "sudo",
@@ -121,7 +123,13 @@ class RollbackStateMachineTests(unittest.TestCase):
             url="${!#}"
             current_release="$(readlink -f "${SPYBOXD_APP_ROOT}/current")"
             revision="$(basename "${current_release}")"
+            printf '%s\n' "${url}" >>"${SPYBOXD_TEST_CURL_TRACE}"
             case "${url}" in
+              */ready)
+                printf '{"status":"not_ready","revision":"%s","checks":{"database":"ok","schema":"pending"}}\n' \
+                  "${revision}"
+                exit 22
+                ;;
               */api/public/dashboard)
                 if [[ "${SPYBOXD_TEST_FAIL_TARGET_DASHBOARD:-0}" == 1 \
                     && "${revision}" == "${SPYBOXD_TEST_TARGET_REVISION}" ]]; then
@@ -131,7 +139,12 @@ class RollbackStateMachineTests(unittest.TestCase):
                 fi
                 ;;
               */health)
-                printf '{"status":"ok","revision":"%s"}\n' "${revision}"
+                response_revision="${revision}"
+                if [[ "${revision}" == "${SPYBOXD_TEST_TARGET_REVISION}" \
+                    && "${SPYBOXD_TEST_FAIL_TARGET_HEALTH:-0}" == 1 ]]; then
+                  response_revision="${SPYBOXD_TEST_CURRENT_REVISION}"
+                fi
+                printf '{"status":"ok","revision":"%s"}\n' "${response_revision}"
                 ;;
               *)
                 printf '%s\n' 'ok'
@@ -180,7 +193,10 @@ class RollbackStateMachineTests(unittest.TestCase):
         path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
     def _run(
-        self, *, fail_target_dashboard: bool = False
+        self,
+        *,
+        fail_target_dashboard: bool = False,
+        fail_target_health: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         environment = os.environ.copy()
         environment.update(
@@ -197,8 +213,13 @@ class RollbackStateMachineTests(unittest.TestCase):
                 "SPYBOXD_CLERK_VALIDATOR": str(self.clerk_validator),
                 "SPYBOXD_HEALTH_VALIDATOR": str(HEALTH_VALIDATOR),
                 "SPYBOXD_TEST_TARGET_REVISION": self.previous_revision,
+                "SPYBOXD_TEST_CURRENT_REVISION": self.current_revision,
+                "SPYBOXD_TEST_CURL_TRACE": str(self.curl_trace),
                 "SPYBOXD_TEST_FAIL_TARGET_DASHBOARD": "1"
                 if fail_target_dashboard
+                else "0",
+                "SPYBOXD_TEST_FAIL_TARGET_HEALTH": "1"
+                if fail_target_health
                 else "0",
             }
         )
@@ -222,6 +243,12 @@ class RollbackStateMachineTests(unittest.TestCase):
         self.assertEqual(
             (self.state / "previous").read_text().strip(), self.current_revision
         )
+        requested_urls = self.curl_trace.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(any(url.endswith("/health") for url in requested_urls))
+        self.assertTrue(
+            any(url.endswith("/api/public/dashboard") for url in requested_urls)
+        )
+        self.assertFalse(any(url.endswith("/ready") for url in requested_urls))
 
     def test_database_contract_failure_restores_original_release(self) -> None:
         result = self._run(fail_target_dashboard=True)
@@ -235,6 +262,19 @@ class RollbackStateMachineTests(unittest.TestCase):
         self.assertEqual(
             (self.state / "previous").read_text().strip(), self.previous_revision
         )
+
+    def test_health_revision_failure_restores_original_release(self) -> None:
+        result = self._run(fail_target_health=True)
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("Rollback health verification failed", result.stdout)
+        self.assertIn("Original release", result.stdout)
+        self.assertEqual((self.app_root / "current").resolve(), self.current_release)
+        self.assertEqual(
+            (self.state / "active").read_text().strip(), self.current_revision
+        )
+        requested_urls = self.curl_trace.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(any(url.endswith("/health") for url in requested_urls))
+        self.assertFalse(any(url.endswith("/ready") for url in requested_urls))
 
     def test_runtime_aware_target_without_bundled_node_is_rejected(self) -> None:
         (self.previous_release / ".spyboxd-release-manifest.json").write_text(

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HARDEN_RUNNER = (
+    "step-security/harden-runner@"
+    "bf7454d06d71f1098171f2acdf0cd4708d7b5920"
+)
+
+
+def read_repo_file(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def workflow_concurrency_group(relative_path: str) -> str:
+    contents = read_repo_file(relative_path)
+    match = re.search(r"(?m)^concurrency:\n(?:^[ ]{2}.*\n)*?^[ ]{2}group: ([^\n]+)$", contents)
+    if match is None:
+        raise AssertionError(f"No top-level concurrency group in {relative_path}")
+    return match.group(1).strip()
+
+
+def dependabot_block(ecosystem: str, directory: str) -> str:
+    contents = read_repo_file(".github/dependabot.yml")
+    blocks = re.split(r"(?m)^  - package-ecosystem: ", contents)[1:]
+    for block in blocks:
+        lines = block.splitlines()
+        if lines[0].strip() != ecosystem:
+            continue
+        if f"    directory: {directory}" in block:
+            return block
+    raise AssertionError(f"Missing Dependabot block for {ecosystem} {directory}")
+
+
+class WorkflowControlsTests(unittest.TestCase):
+    def test_compose_smoke_is_bounded_disposable_and_semantic(self) -> None:
+        ci = read_repo_file(".github/workflows/ci.yml")
+        smoke = read_repo_file("deploy/run-compose-smoke.sh")
+        override = read_repo_file("deploy/docker-compose.ci.yml")
+        dockerignore = read_repo_file(".dockerignore")
+
+        self.assertIn("timeout-minutes: 30", ci)
+        self.assertIn("needs: frontend", ci)
+        self.assertIn("Download the already-built frontend artifact", ci)
+        self.assertIn("path: frontend/.next", ci)
+        self.assertIn("bash deploy/run-compose-smoke.sh", ci)
+        self.assertIn("deploy/docker-compose.ci.yml", ci)
+        self.assertIn(
+            '"${runtime_dir}/node" --test '
+            "frontend/scripts/run-production-auth-canary.test.mjs",
+            ci,
+        )
+        self.assertIn("--project-name", smoke)
+        self.assertIn("build --pull api frontend", smoke)
+        self.assertIn("docker build --check -f frontend/Dockerfile .", smoke)
+        self.assertIn(
+            "up --detach --wait --wait-timeout 180 postgres api frontend",
+            smoke,
+        )
+        self.assertIn("down --volumes --remove-orphans", smoke)
+        self.assertIn('report["status"] == "ready"', smoke)
+        self.assertIn('"schema": "current"', smoke)
+        self.assertIn("SELECT version_num FROM alembic_version", smoke)
+        self.assertIn("to_regclass('public.profiles')", smoke)
+        self.assertIn("container_frontend_build_id", smoke)
+        self.assertIn("unexpectedly started rss-poller", smoke)
+        self.assertGreaterEqual(smoke.count("timeout --signal=TERM"), 8)
+        self.assertEqual(override.count("container_name: !reset null"), 4)
+        self.assertEqual(override.count("ports: !reset []"), 3)
+        self.assertIn("dockerfile: Dockerfile.prebuilt", override)
+        self.assertIn("**/.env", dockerignore)
+        self.assertIn("**/.env.*", dockerignore)
+
+    def test_rollback_does_not_queue_behind_tmdb_enrichment(self) -> None:
+        tmdb_group = workflow_concurrency_group(".github/workflows/tmdb-enrichment.yml")
+        rollback_group = workflow_concurrency_group(".github/workflows/rollback.yml")
+        deploy_group = workflow_concurrency_group(".github/workflows/deploy.yml")
+        self.assertEqual(rollback_group, deploy_group)
+        self.assertNotEqual(tmdb_group, rollback_group)
+
+        workflow = read_repo_file(".github/workflows/tmdb-enrichment.yml")
+        self.assertIn('active_release="$(readlink -f -- "${current_link}")"', workflow)
+        self.assertIn(
+            'runner_path="${active_release}/deploy/run-tmdb-enrichment.sh"',
+            workflow,
+        )
+        self.assertIn(
+            '[ "${active_release}" = "/opt/spyboxd/releases/${active_revision}" ]',
+            workflow,
+        )
+        self.assertIn('environment["SPYBOXD_CURRENT_LINK"] = str(active_release)', workflow)
+        self.assertIn('environment["TMDB_ENRICHMENT_LIMIT"] = "50"', workflow)
+        self.assertIn('environment["TMDB_ENRICHMENT_BATCH_SIZE"] = "10"', workflow)
+        self.assertIn("--kill-after=15s 8m", workflow)
+
+    def test_privileged_jobs_start_with_pinned_harden_runner(self) -> None:
+        ci = read_repo_file(".github/workflows/ci.yml")
+        release_bundle = ci.split("\n  release_bundle:\n", maxsplit=1)[1]
+        dependency_review = read_repo_file(".github/workflows/dependency-review.yml")
+
+        for workflow_job in (release_bundle, dependency_review):
+            self.assertIn(HARDEN_RUNNER, workflow_job)
+            self.assertIn("egress-policy: audit", workflow_job)
+            self.assertLess(
+                workflow_job.index(HARDEN_RUNNER),
+                workflow_job.index("actions/checkout@"),
+            )
+        self.assertNotIn("pull-requests: write", dependency_review)
+        self.assertNotIn("comment-summary-in-pr", dependency_review)
+
+    def test_deployment_is_an_exact_main_ci_handoff_without_pr_workflow_runs(self) -> None:
+        ci = read_repo_file(".github/workflows/ci.yml")
+        deployment = read_repo_file(".github/workflows/deploy.yml")
+
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            ci,
+        )
+        self.assertIn("deploy_production:", ci)
+        self.assertIn("needs: release_bundle", ci)
+        self.assertIn("uses: ./.github/workflows/deploy.yml", ci)
+        self.assertIn("release_sha: ${{ github.sha }}", ci)
+        self.assertIn("ci_run_id: ${{ github.run_id }}", ci)
+        self.assertNotIn("secrets: inherit", ci)
+        self.assertIn("workflow_call:", deployment)
+        self.assertNotIn("workflow_run:", deployment)
+        self.assertIn("environment:\n      name: production", deployment)
+        self.assertIn('[[ "${CI_RUN_ID}" == "${GITHUB_RUN_ID}" ]]', deployment)
+        self.assertIn('[[ "${RELEASE_SHA}" == "${GITHUB_SHA}" ]]', deployment)
+        self.assertIn("ref: ${{ inputs.release_sha }}", deployment)
+        self.assertIn("run-id: ${{ inputs.ci_run_id }}", deployment)
+
+    def test_dependabot_groups_nonmajor_updates_for_every_runtime_source(self) -> None:
+        cases = (
+            ("npm", "/frontend", "npm-minor-and-patch"),
+            ("pip", "/", "python-minor-and-patch"),
+            ("docker-compose", "/", "compose-images-minor-and-patch"),
+            ("docker", "/backend", "backend-base-images-minor-and-patch"),
+            ("docker", "/frontend", "frontend-base-images-minor-and-patch"),
+        )
+        for ecosystem, directory, group_name in cases:
+            with self.subTest(ecosystem=ecosystem, directory=directory):
+                block = dependabot_block(ecosystem, directory)
+                self.assertIn(f"      {group_name}:", block)
+                self.assertIn('update-types: ["minor", "patch"]', block)
+                self.assertNotIn('dependency-name: "*"', block)
+                self.assertNotIn('version-update:semver-major', block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/Dockerfile.prebuilt
+++ b/frontend/Dockerfile.prebuilt
@@ -1,0 +1,22 @@
+FROM node:24-alpine@sha256:f70403e87646dc51b45295f4b8b70cdad0b63d2297c4c9899119b03f7af7a6b3
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000
+
+# CI downloads the exact .next artifact already built, linted, and type-checked;
+# the required Playwright job exercises the same artifact. This packages that
+# output without compiling it again merely to test the Compose runtime graph.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY .next ./.next
+COPY public ./public
+COPY next.config.ts ./next.config.ts
+COPY scripts ./scripts
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/frontend/Dockerfile.prebuilt.dockerignore
+++ b/frontend/Dockerfile.prebuilt.dockerignore
@@ -1,0 +1,10 @@
+*
+!package.json
+!package-lock.json
+!.next
+!.next/**
+!public
+!public/**
+!next.config.ts
+!scripts
+!scripts/**

--- a/frontend/scripts/run-production-auth-canary.mjs
+++ b/frontend/scripts/run-production-auth-canary.mjs
@@ -2,12 +2,21 @@
 
 import { constants } from 'node:fs';
 import { open } from 'node:fs/promises';
-import { chromium } from 'playwright';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const MAX_FILE_BYTES = 64 * 1024;
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const USER_ID = /^user_[A-Za-z0-9]+$/;
+const SESSION_ID = /^sess_[A-Za-z0-9]+$/;
 const PROFILE = /^[A-Za-z0-9_]{2,15}$/;
+const BROWSER_PLAN_VERSION = 2;
+const EXPECTED_SESSION_MAX_DURATION_SECONDS = 120;
+const JWT_EXPIRY_GRACE_SECONDS = 5;
+const SESSION_EXPIRY_GRACE_SECONDS = 15;
+const MAX_EXPIRY_OVERHEAD_SECONDS = 30;
+const PRIVATE_PROOF_PATH = '/profiles';
+const CLOSURES = new Set(['sign_out', 'session_expiry']);
 
 class CanaryError extends Error {}
 
@@ -85,8 +94,13 @@ function bareHttpsOrigin(value, label) {
   return parsed.origin;
 }
 
-function validateTasks(payload) {
-  if (!payload || payload.version !== 1 || !Array.isArray(payload.tasks)) {
+export function validateTasks(payload) {
+  if (
+    !payload
+    || payload.version !== BROWSER_PLAN_VERSION
+    || payload.session_max_duration_seconds !== EXPECTED_SESSION_MAX_DURATION_SECONDS
+    || !Array.isArray(payload.tasks)
+  ) {
     fail('authenticated canary task contract is invalid');
   }
   const apiBase = bareHttpsOrigin(payload.api_base, 'API base');
@@ -101,6 +115,7 @@ function validateTasks(payload) {
   const labels = new Set();
   const userIds = new Set();
   const profiles = new Set();
+  const closures = new Set();
   for (const task of payload.tasks) {
     let taskUrl;
     try {
@@ -110,6 +125,7 @@ function validateTasks(payload) {
     }
     if (
       !['A', 'B'].includes(task?.label)
+      || !CLOSURES.has(task?.closure)
       || !USER_ID.test(task?.user_id ?? '')
       || !PROFILE.test(task?.profile ?? '')
       || taskUrl.protocol !== 'https:'
@@ -123,14 +139,25 @@ function validateTasks(payload) {
     labels.add(task.label);
     userIds.add(task.user_id);
     profiles.add(task.profile.toLowerCase());
+    closures.add(task.closure);
   }
-  if (labels.size !== 2 || userIds.size !== 2 || profiles.size !== 2) {
+  if (
+    labels.size !== 2
+    || userIds.size !== 2
+    || profiles.size !== 2
+    || closures.size !== 2
+  ) {
     fail('authenticated canary tasks are not isolated identities');
   }
-  return { apiBase, appOrigin, tasks: payload.tasks };
+  return {
+    apiBase,
+    appOrigin,
+    sessionMaxDurationSeconds: payload.session_max_duration_seconds,
+    tasks: payload.tasks,
+  };
 }
 
-function decodeSession(token) {
+export function decodeSession(token, nowSeconds = Math.floor(Date.now() / 1000)) {
   if (typeof token !== 'string' || token.length < 100 || token.split('.').length !== 3) {
     fail('Clerk did not establish a valid session token');
   }
@@ -140,10 +167,63 @@ function decodeSession(token) {
   } catch {
     fail('Clerk returned an invalid session token');
   }
-  if (!USER_ID.test(payload?.sub ?? '')) {
-    fail('Clerk session token omitted its user identity');
+  if (
+    !USER_ID.test(payload?.sub ?? '')
+    || !SESSION_ID.test(payload?.sid ?? '')
+    || !Number.isSafeInteger(payload?.exp)
+    || payload.exp <= nowSeconds
+  ) {
+    fail('Clerk session token omitted a valid identity or future expiry');
   }
-  return { userId: payload.sub };
+  return {
+    userId: payload.sub,
+    sessionId: payload.sid,
+    expiresAtSeconds: payload.exp,
+  };
+}
+
+export function expiryProofDeadlineMilliseconds(
+  sessionStartedAtMilliseconds,
+  tokenExpiresAtSeconds,
+  sessionMaxDurationSeconds,
+) {
+  if (
+    !Number.isSafeInteger(sessionStartedAtMilliseconds)
+    || sessionStartedAtMilliseconds <= 0
+    || !Number.isSafeInteger(tokenExpiresAtSeconds)
+    || !Number.isSafeInteger(sessionMaxDurationSeconds)
+    || sessionMaxDurationSeconds !== EXPECTED_SESSION_MAX_DURATION_SECONDS
+  ) {
+    fail('authenticated canary expiry inputs are invalid');
+  }
+  const tokenDeadline = (tokenExpiresAtSeconds + JWT_EXPIRY_GRACE_SECONDS) * 1000;
+  const sessionDeadline = sessionStartedAtMilliseconds
+    + ((sessionMaxDurationSeconds + SESSION_EXPIRY_GRACE_SECONDS) * 1000);
+  const proofDeadline = Math.max(tokenDeadline, sessionDeadline);
+  const maximumDeadline = sessionStartedAtMilliseconds
+    + ((sessionMaxDurationSeconds + MAX_EXPIRY_OVERHEAD_SECONDS) * 1000);
+  if (proofDeadline > maximumDeadline) {
+    fail('Clerk JWT expiry exceeds the bounded Agent Task session');
+  }
+  return proofDeadline;
+}
+
+export function isPrivateSignInRedirect(urlValue, appOrigin, privatePath = PRIVATE_PROOF_PATH) {
+  let parsed;
+  try {
+    parsed = new URL(urlValue);
+  } catch {
+    return false;
+  }
+  const redirectTargets = parsed.searchParams.getAll('redirect_url');
+  return parsed.origin === appOrigin
+    && !parsed.username
+    && !parsed.password
+    && parsed.pathname.replace(/\/+$/, '') === '/sign-in'
+    && !parsed.hash
+    && parsed.searchParams.size === 1
+    && redirectTargets.length === 1
+    && redirectTargets[0] === `${appOrigin}${privatePath}`;
 }
 
 async function sessionCookie(context, appOrigin, timeoutMilliseconds = 30_000) {
@@ -167,13 +247,16 @@ async function sessionCookie(context, appOrigin, timeoutMilliseconds = 30_000) {
 }
 
 async function responseJson(context, apiBase, path, token, expectedStatus, label) {
+  const headers = {
+    Accept: 'application/json',
+    'Cache-Control': 'no-cache',
+  };
+  if (typeof token === 'string') {
+    headers.Authorization = `Bearer ${token}`;
+  }
   const response = await context.request.get(`${apiBase}${path}`, {
     failOnStatusCode: false,
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${token}`,
-      'Cache-Control': 'no-cache',
-    },
+    headers,
     timeout: 15_000,
   });
   if (response.status() !== expectedStatus) {
@@ -292,10 +375,95 @@ async function validateIdentity(context, apiBase, task, other, token) {
   );
 }
 
+function requireDetail(payload, expected, label) {
+  if (!payload || payload.detail !== expected) {
+    fail(`${label} returned an unexpected authentication error`);
+  }
+}
+
+async function proveAnonymousPrivateBoundary(page, context, apiBase, appOrigin, label) {
+  const anonymousMe = await responseJson(
+    context,
+    apiBase,
+    '/api/me',
+    undefined,
+    401,
+    `${label} anonymous API boundary`,
+  );
+  requireDetail(anonymousMe, 'Missing authorization token', `${label} anonymous API boundary`);
+
+  await page.goto(`${appOrigin}${PRIVATE_PROOF_PATH}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 45_000,
+  });
+  await page.waitForURL(
+    (url) => isPrivateSignInRedirect(url.href, appOrigin),
+    { timeout: 45_000 },
+  );
+}
+
+export async function proveSignOutClosure(page, context, apiBase, appOrigin, label) {
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  await signOut.waitFor({ state: 'visible', timeout: 30_000 });
+  await signOut.click({ timeout: 30_000 });
+  await page.waitForURL(
+    (url) => url.origin === appOrigin && url.pathname === '/' && !url.search && !url.hash,
+    { timeout: 45_000 },
+  );
+  await page.getByRole('link', { name: 'Sign in to monitor profiles', exact: true }).waitFor({
+    state: 'visible',
+    timeout: 30_000,
+  });
+  await proveAnonymousPrivateBoundary(page, context, apiBase, appOrigin, label);
+}
+
+async function proveSessionExpiryClosure(
+  page,
+  context,
+  apiBase,
+  appOrigin,
+  label,
+  token,
+  sessionStartedAtMilliseconds,
+  tokenExpiresAtSeconds,
+  sessionMaxDurationSeconds,
+) {
+  // Clerk refreshes short-lived cookie JWTs while the browser session is live.
+  // Waiting past both the captured JWT exp and the Agent Task session ceiling
+  // proves the backend expiry check and the frontend's eventual signed-out state.
+  const proofDeadline = expiryProofDeadlineMilliseconds(
+    sessionStartedAtMilliseconds,
+    tokenExpiresAtSeconds,
+    sessionMaxDurationSeconds,
+  );
+  const remainingMilliseconds = proofDeadline - Date.now();
+  const maximumWaitMilliseconds = (
+    sessionMaxDurationSeconds + MAX_EXPIRY_OVERHEAD_SECONDS
+  ) * 1000;
+  if (remainingMilliseconds > maximumWaitMilliseconds) {
+    fail(`${label} expiry proof exceeded its bounded wait`);
+  }
+  if (remainingMilliseconds > 0) {
+    await page.waitForTimeout(remainingMilliseconds);
+  }
+
+  const expiredMe = await responseJson(
+    context,
+    apiBase,
+    '/api/me',
+    token,
+    401,
+    `${label} expired JWT boundary`,
+  );
+  requireDetail(expiredMe, 'Token has expired', `${label} expired JWT boundary`);
+  await proveAnonymousPrivateBoundary(page, context, apiBase, appOrigin, label);
+}
+
 async function main() {
   const { tasksPath } = argumentsFromCommandLine();
   const taskContract = validateTasks(await readBoundedJson(tasksPath, 'task file'));
 
+  const { chromium } = await import('playwright');
   let browser;
   try {
     browser = await chromium.launch({ headless: true });
@@ -309,6 +477,7 @@ async function main() {
       let token;
       try {
         const page = await context.newPage();
+        const sessionStartedAtMilliseconds = Date.now();
         await page.goto(task.task_url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
         await page.waitForURL(
           (url) => url.origin === taskContract.appOrigin
@@ -322,11 +491,30 @@ async function main() {
         if (session.userId !== task.user_id) {
           fail(`Clerk Agent Task resolved the wrong canary ${task.label} identity`);
         }
-        await page.getByRole('button', { name: 'Sign out', exact: true }).waitFor({
-          state: 'visible',
-          timeout: 30_000,
-        });
         await validateIdentity(context, taskContract.apiBase, task, other, token);
+        if (task.closure === 'sign_out') {
+          await proveSignOutClosure(
+            page,
+            context,
+            taskContract.apiBase,
+            taskContract.appOrigin,
+            `canary ${task.label}`,
+          );
+        } else if (task.closure === 'session_expiry') {
+          await proveSessionExpiryClosure(
+            page,
+            context,
+            taskContract.apiBase,
+            taskContract.appOrigin,
+            `canary ${task.label}`,
+            token,
+            sessionStartedAtMilliseconds,
+            session.expiresAtSeconds,
+            taskContract.sessionMaxDurationSeconds,
+          );
+        } else {
+          fail(`canary ${task.label} has an unsupported closure proof`);
+        }
       } finally {
         token = undefined;
         await context.clearCookies();
@@ -338,13 +526,18 @@ async function main() {
       await browser.close();
     }
   }
-  process.stdout.write('authenticated production canary passed: 2 browser sessions remained isolated\n');
+  process.stdout.write(
+    'authenticated production canary passed: two-user isolation, sign-out, and natural expiry proven\n',
+  );
 }
 
-main().catch((error) => {
-  const detail = error instanceof CanaryError
-    ? error.message
-    : 'browser-backed isolation check failed';
-  process.stderr.write(`authenticated production canary failed: ${detail}\n`);
-  process.exitCode = 1;
-});
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : '';
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    const detail = error instanceof CanaryError
+      ? error.message
+      : 'browser-backed isolation check failed';
+    process.stderr.write(`authenticated production canary failed: ${detail}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/frontend/scripts/run-production-auth-canary.test.mjs
+++ b/frontend/scripts/run-production-auth-canary.test.mjs
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  decodeSession,
+  expiryProofDeadlineMilliseconds,
+  isPrivateSignInRedirect,
+  proveSignOutClosure,
+  validateTasks,
+} from './run-production-auth-canary.mjs';
+
+const APP_ORIGIN = 'https://spyboxd.com';
+const TASK_ORIGIN = 'https://clerk.spyboxd.com';
+
+function task(label, closure, userId, profile) {
+  return {
+    label,
+    closure,
+    user_id: userId,
+    profile,
+    task_url: `${TASK_ORIGIN}/v1/agent-tasks/${label.toLowerCase()}-ticket`,
+  };
+}
+
+function plan() {
+  return {
+    version: 2,
+    api_base: 'https://api.spyboxd.com',
+    app_origin: APP_ORIGIN,
+    task_origin: TASK_ORIGIN,
+    session_max_duration_seconds: 120,
+    tasks: [
+      task('A', 'sign_out', 'user_A123', 'alpha'),
+      task('B', 'session_expiry', 'user_B123', 'beta'),
+    ],
+  };
+}
+
+function token(payload) {
+  const encodedHeader = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' }))
+    .toString('base64url');
+  const encodedPayload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${encodedHeader}.${encodedPayload}.${'s'.repeat(96)}`;
+}
+
+test('browser plan requires distinct sign-out and natural-expiry closures', () => {
+  const contract = validateTasks(plan());
+  assert.equal(contract.sessionMaxDurationSeconds, 120);
+  assert.deepEqual(contract.tasks.map((item) => item.closure), ['sign_out', 'session_expiry']);
+
+  const duplicated = plan();
+  duplicated.tasks[1].closure = 'sign_out';
+  assert.throws(() => validateTasks(duplicated), /not isolated identities/);
+
+  const wrongDuration = plan();
+  wrongDuration.session_max_duration_seconds = 1800;
+  assert.throws(() => validateTasks(wrongDuration), /task contract is invalid/);
+});
+
+test('session token contract requires a future expiry and session identity', () => {
+  const decoded = decodeSession(token({
+    sub: 'user_A123',
+    sid: 'sess_A123',
+    exp: 1_060,
+  }), 1_000);
+  assert.deepEqual(decoded, {
+    userId: 'user_A123',
+    sessionId: 'sess_A123',
+    expiresAtSeconds: 1_060,
+  });
+
+  assert.throws(
+    () => decodeSession(token({ sub: 'user_A123', sid: 'sess_A123', exp: 999 }), 1_000),
+    /future expiry/,
+  );
+  assert.throws(
+    () => decodeSession(token({ sub: 'user_A123', exp: 1_060 }), 1_000),
+    /valid identity/,
+  );
+});
+
+test('expiry proof deadline covers both JWT and Agent Task session expiry', () => {
+  const sessionStartedAt = 1_000_000;
+  assert.equal(
+    expiryProofDeadlineMilliseconds(sessionStartedAt, 1_060, 120),
+    1_135_000,
+  );
+  assert.throws(
+    () => expiryProofDeadlineMilliseconds(sessionStartedAt, 1_200, 120),
+    /JWT expiry exceeds the bounded Agent Task session/,
+  );
+});
+
+test('private redirect proof remains exact and same-origin', () => {
+  assert.equal(isPrivateSignInRedirect(
+    'https://spyboxd.com/sign-in?redirect_url=https%3A%2F%2Fspyboxd.com%2Fprofiles',
+    APP_ORIGIN,
+  ), true);
+  assert.equal(isPrivateSignInRedirect(
+    'https://evil.example/sign-in?redirect_url=https%3A%2F%2Fspyboxd.com%2Fprofiles',
+    APP_ORIGIN,
+  ), false);
+  assert.equal(isPrivateSignInRedirect(
+    'https://spyboxd.com/sign-in?redirect_url=https%3A%2F%2Fevil.example%2Fprofiles',
+    APP_ORIGIN,
+  ), false);
+  assert.equal(isPrivateSignInRedirect(
+    'https://spyboxd.com/sign-in?redirect_url=https%3A%2F%2Fspyboxd.com%2Fprofiles&extra=1',
+    APP_ORIGIN,
+  ), false);
+});
+
+test('sign-out closure clicks the real control then proves UI and API denial', async () => {
+  const events = [];
+  const redirect = new URL(
+    'https://spyboxd.com/sign-in?redirect_url=https%3A%2F%2Fspyboxd.com%2Fprofiles',
+  );
+  const urls = [new URL(APP_ORIGIN), redirect];
+  const page = {
+    getByRole(role, options) {
+      if (role === 'button' && options.name === 'Sign out') {
+        return {
+          async waitFor() { events.push('sign-out-visible'); },
+          async click() { events.push('sign-out-clicked'); },
+        };
+      }
+      if (role === 'link' && options.name === 'Sign in to monitor profiles') {
+        return {
+          async waitFor() { events.push('sign-in-visible'); },
+        };
+      }
+      throw new Error('unexpected role lookup');
+    },
+    async waitForURL(predicate) {
+      assert.equal(predicate(urls.shift()), true);
+    },
+    async goto(url) {
+      assert.equal(url, `${APP_ORIGIN}/profiles`);
+      events.push('private-route-requested');
+    },
+  };
+  const context = {
+    request: {
+      async get(url, options) {
+        assert.equal(url, 'https://api.spyboxd.com/api/me');
+        assert.equal(options.headers.Authorization, undefined);
+        events.push('anonymous-api-denied');
+        return {
+          status: () => 401,
+          body: async () => Buffer.from(JSON.stringify({
+            detail: 'Missing authorization token',
+          })),
+        };
+      },
+    },
+  };
+
+  await proveSignOutClosure(
+    page,
+    context,
+    'https://api.spyboxd.com',
+    APP_ORIGIN,
+    'canary A',
+  );
+  assert.deepEqual(events, [
+    'sign-out-visible',
+    'sign-out-clicked',
+    'sign-in-visible',
+    'anonymous-api-denied',
+    'private-route-requested',
+  ]);
+  assert.equal(urls.length, 0);
+});


### PR DESCRIPTION
Closes the remaining production-pipeline audit gaps.

- exercises seeded additive migrations and the actual previous backend against the upgraded schema
- makes rollback and interrupted-deploy recovery database-backed and failure-injected
- adds a disposable Compose startup smoke without recompiling the tested frontend artifact
- moves deployment into an exact main-CI reusable handoff, with attestation verification and no skipped PR deploy runs
- separates bounded TMDB enrichment from emergency rollback
- adds grouped Dependabot updates, Harden Runner audit coverage, and read-only dependency review
- completes public plus two-user Clerk production canaries, including sign-out, natural expiry, bootstrap safety, secret-safe staging, and cleanup

Validation: 242 backend tests, 82 Playwright tests, 40 Linux operations/canary tests, 9 PostgreSQL migration tests, Compose startup, Node 24 contracts, ShellCheck/systemd/nginx/sudoers, YAML, Zizmor, and credential scans.