### PR TITLE
Expose protected environment secrets to reusable deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,16 @@ on:
         description: Exact Production CI run containing the attested bundle
         required: true
         type: string
+    # Declaring these names makes them available to the called workflow's
+    # production job. The caller intentionally passes no values: GitHub loads
+    # the same-named secrets from the protected production environment below.
+    secrets:
+      VPS_HOST:
+        required: false
+      VPS_HOST_FINGERPRINT:
+        required: false
+      VPS_SSH_KEY:
+        required: false
 
 permissions:
   actions: read

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -129,6 +129,11 @@ class WorkflowControlsTests(unittest.TestCase):
         self.assertIn("workflow_call:", deployment)
         self.assertNotIn("workflow_run:", deployment)
         self.assertIn("environment:\n      name: production", deployment)
+        for secret_name in ("VPS_HOST", "VPS_HOST_FINGERPRINT", "VPS_SSH_KEY"):
+            self.assertRegex(
+                deployment,
+                rf"(?m)^      {secret_name}:\n        required: false$",
+            )
         self.assertIn('[[ "${CI_RUN_ID}" == "${GITHUB_RUN_ID}" ]]', deployment)
         self.assertIn('[[ "${RELEASE_SHA}" == "${GITHUB_SHA}" ]]', deployment)
         self.assertIn("ref: ${{ inputs.release_sha }}", deployment)


### PR DESCRIPTION
The first exact-SHA deployment correctly failed before connecting because the reusable workflow did not declare the secret names available to its protected production job.

This hotfix declares only the three VPS secret names as optional workflow-call secrets. The caller still passes no secret values, `secrets: inherit` remains forbidden, and the production environment remains the sole source and protection boundary. A regression test locks that contract.

Observed failure: https://github.com/Yash03x/spyboxd/actions/runs/30612962535/job/91100675166