### PR TITLE
Fix Clerk canary session handoff

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -407,7 +407,7 @@ jobs:
             exit 0
           fi
           status="$("${python_path}" "${canary_path}" status --lease-id "${lease_id}")"
-          [ "${status}" = failed ]
+          [[ "${status}" == failed || "${status}" == cleanup_failed ]]
           REMOTE
           guardian_started=1
 
@@ -421,7 +421,7 @@ jobs:
               deploy/production-ssh.sh run \
                 "${REMOTE_CANARY_PATH}" status --lease-id "${lease_id}"
             )"
-            if [[ "${guardian_status}" == failed ]]; then
+            if [[ "${guardian_status}" == failed || "${guardian_status}" == cleanup_failed ]]; then
               break
             fi
             sleep 2
@@ -451,20 +451,24 @@ jobs:
               deploy/production-ssh.sh run \
                 "${REMOTE_CANARY_PATH}" status --lease-id "${lease_id}"
             )"
-            if [[ "${guardian_status}" == passed || "${guardian_status}" == failed ]]; then
+            if [[ "${guardian_status}" == passed || "${guardian_status}" == failed || "${guardian_status}" == cleanup_failed ]]; then
               break
             fi
             sleep 2
           done
-          if [[ "${guardian_status}" == passed || "${guardian_status}" == failed ]]; then
+          if [[ "${guardian_status}" == passed || "${guardian_status}" == failed || "${guardian_status}" == cleanup_failed ]]; then
             guardian_started=0
           fi
-          if [[ "${guardian_status}" != passed ]]; then
+          if [[ "${guardian_status}" == cleanup_failed ]]; then
             echo 'The VPS guardian did not prove Clerk task and session cleanup.' >&2
             exit 1
           fi
           if (( browser_status != 0 )); then
             exit "${browser_status}"
+          fi
+          if [[ "${guardian_status}" != passed ]]; then
+            echo 'The VPS guardian rejected the authenticated canary result.' >&2
+            exit 1
           fi
 
       - name: Enforce the VPS cleanup backstop and retire the lease

--- a/deploy/run-production-auth-canary.py
+++ b/deploy/run-production-auth-canary.py
@@ -535,7 +535,11 @@ def _create_agent_task(
                 "permissions": "*",
                 "agent_name": "spyboxd-production-canary",
                 "task_description": "Read-only non-admin privacy and isolation check",
-                "redirect_url": f"{app_origin}/profiles",
+                # Land on the only public application route first. Clerk's
+                # frontend SDK must finish the Agent Task handoff and write the
+                # app-scoped session token before middleware can admit the
+                # browser to a protected route.
+                "redirect_url": f"{app_origin}/",
                 "session_max_duration_in_seconds": SESSION_MAX_DURATION_SECONDS,
             },
             clerk_backend=True,
@@ -832,6 +836,17 @@ def _cleanup_state(secret_key: str, state: Mapping[str, Any]) -> None:
         raise AuthCanaryError(
             "temporary Clerk canary state could not be proven inactive"
         )
+
+
+def _guardian_result_status(
+    primary_error: BaseException | None,
+    cleanup_error: BaseException | None,
+) -> str:
+    if cleanup_error is not None:
+        return "cleanup_failed"
+    if primary_error is not None:
+        return "failed"
+    return "passed"
 
 
 def _validate_lease_id(lease_id: str) -> str:
@@ -1227,11 +1242,7 @@ def run_guardian(
                     state["phase"] = "cleanup_failed"
                     _write_private_json(state_path, state)
 
-                status = (
-                    "passed"
-                    if primary_error is None and cleanup_error is None
-                    else "failed"
-                )
+                status = _guardian_result_status(primary_error, cleanup_error)
                 _write_private_json(
                     lease_dir / STATUS_NAME, {"version": 1, "status": status}
                 )
@@ -1287,7 +1298,11 @@ def lease_status(*, lease_id: str, shared_dir: Path) -> str:
         return "running"
     payload = _read_private_json(status_path)
     status_value = payload.get("status")
-    if payload.get("version") != 1 or status_value not in {"passed", "failed"}:
+    if payload.get("version") != 1 or status_value not in {
+        "passed",
+        "failed",
+        "cleanup_failed",
+    }:
         raise AuthCanaryError("authenticated canary status is invalid")
     return str(status_value)
 

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -542,7 +542,7 @@ class ProductionCanaryTests(unittest.TestCase):
         )
         self.assertEqual(
             request.call_args.kwargs["payload"]["redirect_url"],
-            "https://spyboxd.com/profiles",
+            "https://spyboxd.com/",
         )
 
     def test_authenticated_browser_plan_assigns_sign_out_and_expiry_proofs(self):
@@ -706,6 +706,20 @@ class ProductionCanaryTests(unittest.TestCase):
             self.assertFalse((lease / auth_canary.PLAN_NAME).exists())
             retained = auth_canary._read_private_json(lease / auth_canary.STATE_NAME)
             self.assertEqual(retained["phase"], "cleanup_failed")
+
+    def test_guardian_status_distinguishes_primary_and_cleanup_failures(self):
+        primary = auth_canary.AuthCanaryError("browser failed")
+        cleanup = auth_canary.AuthCanaryError("cleanup failed")
+        self.assertEqual(auth_canary._guardian_result_status(None, None), "passed")
+        self.assertEqual(
+            auth_canary._guardian_result_status(primary, None), "failed"
+        )
+        self.assertEqual(
+            auth_canary._guardian_result_status(None, cleanup), "cleanup_failed"
+        )
+        self.assertEqual(
+            auth_canary._guardian_result_status(primary, cleanup), "cleanup_failed"
+        )
 
     def test_consumed_agent_task_is_safe_only_for_the_exact_clerk_error(self):
         response = auth_canary.HttpResponse(

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -137,6 +137,21 @@ class WorkflowControlsTests(unittest.TestCase):
         self.assertIn("ref: ${{ github.sha }}", deployment)
         self.assertIn("run-id: ${{ github.run_id }}", deployment)
 
+    def test_authenticated_canary_separates_session_handoff_from_private_access(self) -> None:
+        workflow = read_repo_file(".github/workflows/production-canary.yml")
+        guardian = read_repo_file("deploy/run-production-auth-canary.py")
+        browser = read_repo_file("frontend/scripts/run-production-auth-canary.mjs")
+
+        self.assertIn('"redirect_url": f"{app_origin}/"', guardian)
+        self.assertIn("return \"cleanup_failed\"", guardian)
+        self.assertIn("clerk.session.getToken()", browser)
+        self.assertIn("`${taskContract.appOrigin}/profiles`", browser)
+        self.assertIn('"${guardian_status}" == cleanup_failed', workflow)
+        self.assertLess(
+            workflow.index('"${guardian_status}" == cleanup_failed'),
+            workflow.index("if (( browser_status != 0 ));"),
+        )
+
     def test_dependabot_groups_nonmajor_updates_for_every_runtime_source(self) -> None:
         cases = (
             ("npm", "/frontend", "npm-minor-and-patch"),

--- a/frontend/scripts/run-production-auth-canary.mjs
+++ b/frontend/scripts/run-production-auth-canary.mjs
@@ -226,10 +226,31 @@ export function isPrivateSignInRedirect(urlValue, appOrigin, privatePath = PRIVA
     && redirectTargets[0] === `${appOrigin}${privatePath}`;
 }
 
-async function sessionCookie(context, appOrigin, timeoutMilliseconds = 30_000) {
+export async function applicationSessionToken(
+  page,
+  context,
+  appOrigin,
+  timeoutMilliseconds = 30_000,
+) {
   const hostname = new URL(appOrigin).hostname;
   const deadline = Date.now() + timeoutMilliseconds;
   while (Date.now() < deadline) {
+    const sdkToken = await page.evaluate(async () => {
+      const clerk = globalThis.Clerk;
+      if (!clerk?.loaded || !clerk.session) return null;
+      try {
+        return await clerk.session.getToken();
+      } catch {
+        return null;
+      }
+    }).catch(() => null);
+    if (typeof sdkToken === 'string' && sdkToken) {
+      return sdkToken;
+    }
+
+    // Keep a cookie fallback for Clerk SDK versions that do not expose the
+    // global browser object. The returned JWT is still verified by Spyboxd's
+    // API before any canary assertion can pass.
     const matching = (await context.cookies(appOrigin)).filter(
       (cookie) => cookie.name === '__session'
         && cookie.secure
@@ -477,8 +498,26 @@ async function main() {
       let token;
       try {
         const page = await context.newPage();
-        const sessionStartedAtMilliseconds = Date.now();
         await page.goto(task.task_url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+        await page.waitForURL(
+          (url) => url.origin === taskContract.appOrigin
+            && url.pathname === '/',
+          { timeout: 45_000 },
+        );
+        token = await applicationSessionToken(page, context, taskContract.appOrigin);
+        // The one-time Clerk handoff may take time. Starting the natural-expiry
+        // proof only after the application can retrieve a token is
+        // conservative: it cannot declare expiry while the bounded Agent Task
+        // session is still live.
+        const sessionEstablishedAtMilliseconds = Date.now();
+        const session = decodeSession(token);
+        if (session.userId !== task.user_id) {
+          fail(`Clerk Agent Task resolved the wrong canary ${task.label} identity`);
+        }
+        await page.goto(`${taskContract.appOrigin}/profiles`, {
+          waitUntil: 'domcontentloaded',
+          timeout: 45_000,
+        });
         await page.waitForURL(
           (url) => url.origin === taskContract.appOrigin
             && url.pathname === '/profiles'
@@ -486,11 +525,6 @@ async function main() {
             && !url.hash,
           { timeout: 45_000 },
         );
-        token = await sessionCookie(context, taskContract.appOrigin);
-        const session = decodeSession(token);
-        if (session.userId !== task.user_id) {
-          fail(`Clerk Agent Task resolved the wrong canary ${task.label} identity`);
-        }
         await validateIdentity(context, taskContract.apiBase, task, other, token);
         if (task.closure === 'sign_out') {
           await proveSignOutClosure(
@@ -508,7 +542,7 @@ async function main() {
             taskContract.appOrigin,
             `canary ${task.label}`,
             token,
-            sessionStartedAtMilliseconds,
+            sessionEstablishedAtMilliseconds,
             session.expiresAtSeconds,
             taskContract.sessionMaxDurationSeconds,
           );

--- a/frontend/scripts/run-production-auth-canary.test.mjs
+++ b/frontend/scripts/run-production-auth-canary.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  applicationSessionToken,
   decodeSession,
   expiryProofDeadlineMilliseconds,
   isPrivateSignInRedirect,
@@ -77,6 +78,48 @@ test('session token contract requires a future expiry and session identity', () 
     () => decodeSession(token({ sub: 'user_A123', exp: 1_060 }), 1_000),
     /valid identity/,
   );
+});
+
+test('application session handoff prefers Clerk SDK token with a cookie fallback', async () => {
+  const sdkToken = token({ sub: 'user_A123', sid: 'sess_A123', exp: 1_060 });
+  assert.equal(await applicationSessionToken(
+    {
+      async evaluate(callback) {
+        const originalClerk = globalThis.Clerk;
+        globalThis.Clerk = {
+          loaded: true,
+          session: { getToken: async () => sdkToken },
+        };
+        try {
+          return await callback();
+        } finally {
+          if (originalClerk === undefined) {
+            delete globalThis.Clerk;
+          } else {
+            globalThis.Clerk = originalClerk;
+          }
+        }
+      },
+    },
+    { cookies: async () => [] },
+    APP_ORIGIN,
+    1_000,
+  ), sdkToken);
+
+  const cookieToken = token({ sub: 'user_B123', sid: 'sess_B123', exp: 1_060 });
+  assert.equal(await applicationSessionToken(
+    { evaluate: async () => null },
+    {
+      cookies: async () => [{
+        name: '__session',
+        value: cookieToken,
+        secure: true,
+        domain: '.spyboxd.com',
+      }],
+    },
+    APP_ORIGIN,
+    1_000,
+  ), cookieToken);
 });
 
 test('expiry proof deadline covers both JWT and Agent Task session expiry', () => {


### PR DESCRIPTION
## What changed
- complete Clerk Agent Task handoff on the public root before entering protected routes
- retrieve the browser token from the Clerk session API with a strict cookie fallback
- start natural-expiry timing after session establishment
- distinguish canary assertion failures from cleanup failures

## Verification
- 104 deployment tests passed (5 environment-dependent skips)
- 6 authenticated-canary JavaScript tests passed
- frontend lint and type-check passed
- workflow YAML parsed
- Zizmor reported no findings
- independent review found no blocker