### PR TITLE
Harden Clerk production canary bot bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,10 +141,11 @@ jobs:
       - name: Upload frontend build for browser smoke tests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: frontend-next-${{ github.sha }}-${{ github.run_attempt }}
+          name: frontend-next-${{ github.sha }}
           path: frontend/.next
           if-no-files-found: error
           include-hidden-files: true
+          overwrite: true
           retention-days: 1
 
   e2e:
@@ -186,7 +187,7 @@ jobs:
       - name: Download tested frontend build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: frontend-next-${{ github.sha }}-${{ github.run_attempt }}
+          name: frontend-next-${{ github.sha }}
           path: frontend/.next
 
       - name: Verify downloaded frontend build
@@ -224,7 +225,7 @@ jobs:
       - name: Download the already-built frontend artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: frontend-next-${{ github.sha }}-${{ github.run_attempt }}
+          name: frontend-next-${{ github.sha }}
           path: frontend/.next
 
       - name: Verify the reused frontend build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
       - name: Type-check frontend
         run: npm run typecheck
 
+      - name: Test the production authentication canary
+        run: node --test scripts/run-production-auth-canary.test.mjs
+
       - name: Prove the production launcher accepts the pinned Node major
         run: NODE_ENV=production npm run start -- --version
 
@@ -250,7 +253,6 @@ jobs:
           [[ "$("${runtime_dir}/node" --version)" == v24.18.1 ]]
           [[ -s "${runtime_dir}/LICENSE.nodejs" ]]
           "${runtime_dir}/node" --check frontend/scripts/runtime-proof.cjs
-          "${runtime_dir}/node" --test frontend/scripts/run-production-auth-canary.test.mjs
 
       - name: Test production Clerk configuration guard
         run: python3 -m unittest -v deploy/test_validate_clerk_production.py

--- a/deploy/run-production-auth-canary.py
+++ b/deploy/run-production-auth-canary.py
@@ -29,6 +29,7 @@ USER_ID_PATTERN = re.compile(r"user_[A-Za-z0-9]+")
 PROFILE_PATTERN = re.compile(r"[A-Za-z0-9_]{2,15}")
 SESSION_ID_PATTERN = re.compile(r"sess_[A-Za-z0-9]+")
 OPAQUE_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{8,200}")
+TESTING_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9._~-]{20,2048}")
 LEASE_ID_PATTERN = re.compile(r"gha-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}")
 APP_ORIGIN = "https://spyboxd.com"
 DEFAULT_API_BASE = "https://api.spyboxd.com"
@@ -42,7 +43,10 @@ LOCK_NAME = ".auth-canary.lock"
 LIVE_SESSION_STATUSES = ("active",)
 SESSION_MAX_DURATION_SECONDS = 120
 SESSION_EXPIRY_GRACE_SECONDS = 5
-BROWSER_PLAN_VERSION = 2
+BROWSER_PLAN_VERSION = 3
+TESTING_TOKEN_MIN_REMAINING_SECONDS = 300
+# Clerk issues these for one hour; permit only two minutes of host clock skew.
+TESTING_TOKEN_MAX_REMAINING_SECONDS = 3720
 BROWSER_CLOSURE_BY_LABEL = {
     "A": "sign_out",
     "B": "session_expiry",
@@ -517,6 +521,43 @@ def _retire_agent_task(secret_key: str, agent_task_id: str) -> bool:
     raise AuthCanaryError("a Clerk canary task could not be proven inactive")
 
 
+def _create_testing_token(secret_key: str) -> tuple[str, int]:
+    created = _json(
+        _request(
+            "https://api.clerk.com/v1/testing_tokens",
+            method="POST",
+            bearer=secret_key,
+            clerk_backend=True,
+        ),
+        "Clerk production Testing Token creation",
+        200,
+    )
+    token = created.get("token") if isinstance(created, dict) else None
+    expires_at = created.get("expires_at") if isinstance(created, dict) else None
+    if (
+        not isinstance(created, dict)
+        or created.get("object") != "testing_token"
+        or not isinstance(token, str)
+        or not TESTING_TOKEN_PATTERN.fullmatch(token)
+    ):
+        raise AuthCanaryError("Clerk returned an invalid production Testing Token")
+    if isinstance(expires_at, bool) or not isinstance(expires_at, int):
+        raise AuthCanaryError("Clerk returned an invalid Testing Token expiry")
+
+    # Clerk SDKs expose this timestamp in milliseconds while older REST
+    # responses used seconds. Normalize either documented representation into
+    # seconds before the private browser-plan handoff.
+    expires_at_seconds = expires_at // 1000 if expires_at > 10_000_000_000 else expires_at
+    remaining_seconds = expires_at_seconds - int(time.time())
+    if not (
+        TESTING_TOKEN_MIN_REMAINING_SECONDS
+        <= remaining_seconds
+        <= TESTING_TOKEN_MAX_REMAINING_SECONDS
+    ):
+        raise AuthCanaryError("Clerk returned an unexpectedly bounded Testing Token")
+    return token, expires_at_seconds
+
+
 def _create_agent_task(
     secret_key: str,
     identity: CanaryIdentity,
@@ -595,6 +636,8 @@ def _build_browser_plan(
     api_base: str,
     app_origin: str,
     task_origin: str,
+    testing_token: str,
+    testing_token_expires_at: int,
     tasks: list[Mapping[str, Any]],
 ) -> dict[str, Any]:
     if len(tasks) != len(BROWSER_CLOSURE_BY_LABEL):
@@ -623,11 +666,22 @@ def _build_browser_plan(
 
     if seen_labels != set(BROWSER_CLOSURE_BY_LABEL):
         raise AuthCanaryError("authenticated browser plan is missing a task label")
+    if not TESTING_TOKEN_PATTERN.fullmatch(testing_token):
+        raise AuthCanaryError("authenticated browser plan has an invalid Testing Token")
+    if (
+        isinstance(testing_token_expires_at, bool)
+        or not isinstance(testing_token_expires_at, int)
+        or testing_token_expires_at - int(time.time())
+        < TESTING_TOKEN_MIN_REMAINING_SECONDS
+    ):
+        raise AuthCanaryError("authenticated browser plan has an expired Testing Token")
     return {
         "version": BROWSER_PLAN_VERSION,
         "api_base": api_base,
         "app_origin": app_origin,
         "task_origin": task_origin,
+        "testing_token": testing_token,
+        "testing_token_expires_at": testing_token_expires_at,
         "session_max_duration_seconds": SESSION_MAX_DURATION_SECONDS,
         "tasks": planned_tasks,
     }
@@ -1171,6 +1225,9 @@ def run_guardian(
                 _verify_bootstrap_clerk_usernames(secret_key, identities)
             _require_zero_live_sessions(secret_key, identities)
             state["session_baseline_proven_zero"] = True
+            state["phase"] = "creating_testing_token"
+            _write_private_json(state_path, state)
+            testing_token, testing_token_expires_at = _create_testing_token(secret_key)
             state["phase"] = "creating_tasks"
             _write_private_json(state_path, state)
 
@@ -1195,6 +1252,8 @@ def run_guardian(
                 api_base=api_base,
                 app_origin=APP_ORIGIN,
                 task_origin=next(iter(task_origins)),
+                testing_token=testing_token,
+                testing_token_expires_at=testing_token_expires_at,
                 tasks=tasks,
             )
             state["phase"] = "waiting_for_browser"

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -545,6 +545,34 @@ class ProductionCanaryTests(unittest.TestCase):
             "https://spyboxd.com/",
         )
 
+    def test_authenticated_canary_creates_bounded_production_testing_token(self):
+        response = auth_canary.HttpResponse(
+            200,
+            json.dumps(
+                {
+                    "object": "testing_token",
+                    "token": f"testing-{'a' * 48}",
+                    "expires_at": 1_700_000_600_000,
+                }
+            ).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        with (
+            mock.patch.object(auth_canary.time, "time", return_value=1_700_000_000),
+            mock.patch.object(
+                auth_canary, "_request", return_value=response
+            ) as request,
+        ):
+            token, expires_at = auth_canary._create_testing_token("sk_live_test")
+        self.assertEqual(token, f"testing-{'a' * 48}")
+        self.assertEqual(expires_at, 1_700_000_600)
+        self.assertEqual(
+            request.call_args.args[0],
+            "https://api.clerk.com/v1/testing_tokens",
+        )
+        self.assertEqual(request.call_args.kwargs["method"], "POST")
+        self.assertNotIn("payload", request.call_args.kwargs)
+
     def test_authenticated_browser_plan_assigns_sign_out_and_expiry_proofs(self):
         tasks = [
             {
@@ -566,6 +594,8 @@ class ProductionCanaryTests(unittest.TestCase):
             api_base="https://api.spyboxd.com",
             app_origin="https://spyboxd.com",
             task_origin="https://clerk.spyboxd.com",
+            testing_token=f"testing-{'a' * 48}",
+            testing_token_expires_at=int(auth_canary.time.time()) + 600,
             tasks=tasks,
         )
         self.assertEqual(plan["version"], auth_canary.BROWSER_PLAN_VERSION)
@@ -573,6 +603,7 @@ class ProductionCanaryTests(unittest.TestCase):
             plan["session_max_duration_seconds"],
             auth_canary.SESSION_MAX_DURATION_SECONDS,
         )
+        self.assertEqual(plan["testing_token"], f"testing-{'a' * 48}")
         self.assertEqual(
             [task["closure"] for task in plan["tasks"]],
             ["sign_out", "session_expiry"],
@@ -593,6 +624,8 @@ class ProductionCanaryTests(unittest.TestCase):
                 api_base="https://api.spyboxd.com",
                 app_origin="https://spyboxd.com",
                 task_origin="https://clerk.spyboxd.com",
+                testing_token=f"testing-{'a' * 48}",
+                testing_token_expires_at=int(auth_canary.time.time()) + 600,
                 tasks=[base, {**base, "user_id": "user_B123", "profile": "beta"}],
             )
         with self.assertRaisesRegex(auth_canary.AuthCanaryError, "task origins"):
@@ -600,6 +633,8 @@ class ProductionCanaryTests(unittest.TestCase):
                 api_base="https://api.spyboxd.com",
                 app_origin="https://spyboxd.com",
                 task_origin="https://clerk.spyboxd.com",
+                testing_token=f"testing-{'a' * 48}",
+                testing_token_expires_at=int(auth_canary.time.time()) + 600,
                 tasks=[
                     base,
                     {

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -49,11 +49,11 @@ class WorkflowControlsTests(unittest.TestCase):
         self.assertIn("path: frontend/.next", ci)
         self.assertIn("bash deploy/run-compose-smoke.sh", ci)
         self.assertIn("deploy/docker-compose.ci.yml", ci)
-        self.assertIn(
-            '"${runtime_dir}/node" --test '
-            "frontend/scripts/run-production-auth-canary.test.mjs",
-            ci,
+        install_index = ci.index("npm ci --no-audit --no-fund")
+        canary_test_index = ci.index(
+            "node --test scripts/run-production-auth-canary.test.mjs"
         )
+        self.assertLess(install_index, canary_test_index)
         self.assertIn("--project-name", smoke)
         self.assertIn("build --pull api frontend", smoke)
         self.assertIn("docker build --check -f frontend/Dockerfile .", smoke)

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -143,9 +143,20 @@ class WorkflowControlsTests(unittest.TestCase):
         browser = read_repo_file("frontend/scripts/run-production-auth-canary.mjs")
 
         self.assertIn('"redirect_url": f"{app_origin}/"', guardian)
+        self.assertIn('"https://api.clerk.com/v1/testing_tokens"', guardian)
+        self.assertIn('"testing_token": testing_token', guardian)
         self.assertIn("return \"cleanup_failed\"", guardian)
+        self.assertIn("setupClerkTestingToken", browser)
+        self.assertIn("installClerkTestingToken", browser)
+        self.assertIn("::add-mask::${secret}", browser)
+        self.assertLess(
+            browser.index("maskSecret(testingToken);"),
+            browser.index("process.env.CLERK_TESTING_TOKEN = testingToken;"),
+        )
+        self.assertIn("__clerk_testing_token", browser)
         self.assertIn("clerk.session.getToken()", browser)
         self.assertIn("`${taskContract.appOrigin}/profiles`", browser)
+        self.assertNotIn("CLERK_SECRET_KEY: ${{", workflow)
         self.assertIn('"${guardian_status}" == cleanup_failed', workflow)
         self.assertLess(
             workflow.index('"${guardian_status}" == cleanup_failed'),

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -47,6 +47,12 @@ class WorkflowControlsTests(unittest.TestCase):
         self.assertIn("needs: frontend", ci)
         self.assertIn("Download the already-built frontend artifact", ci)
         self.assertIn("path: frontend/.next", ci)
+        self.assertEqual(ci.count("name: frontend-next-${{ github.sha }}"), 3)
+        self.assertNotIn(
+            "frontend-next-${{ github.sha }}-${{ github.run_attempt }}",
+            ci,
+        )
+        self.assertIn("overwrite: true", ci)
         self.assertIn("bash deploy/run-compose-smoke.sh", ci)
         self.assertIn("deploy/docker-compose.ci.yml", ci)
         install_index = ci.index("npm ci --no-audit --no-fund")

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "react-hot-toast": "^2.6.0"
       },
       "devDependencies": {
+        "@clerk/testing": "2.2.15",
         "@playwright/test": "^1.62.0",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.14",
@@ -310,12 +311,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.13.2.tgz",
-      "integrity": "sha512-z6rPQzEj1SbGmjMoyGnECY1R7YrcD4dJILlWLXFvSUsWxb8csAYzcXp50T2kVtV3ThlcjOMrI0oDQyqvTdt65A==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.14.0.tgz",
+      "integrity": "sha512-WsphTvDFHDuQilKI7dyVE5qmt7USu8qSrujAq6SqpEHbVFfNBfINDNuzxlF9M2skOTfHFfgiTE8Jjb1egIBGLg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.25.8",
+        "@clerk/shared": "^4.25.9",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -362,9 +363,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.25.8",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.8.tgz",
-      "integrity": "sha512-ob0E/YJAoDTO4CzHI0nasXGsJUc1cFo0jxPO8xVz/A0+C1R0k1da0EJD8L6F03DzKMn3efSa4mOy3BXTpBVZqw==",
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.9.tgz",
+      "integrity": "sha512-nw3maGzqPrwmUKjGffOM9Zvw24IyOllq0TkQGzsTfQX312WLu2u5CNvjKntMb6Ok6kXa1Zdc77zmPLn1/EAIFA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "^5.100.6",
@@ -396,6 +397,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.15.tgz",
+      "integrity": "sha512-wSw0qJUZVgMPvZPdRpYLHOCYnpq3j66DryLpjBR0yVCfeQF+nYDwzZNocA/RdewwNTlQEpp9J8wNcD2Nw8zoPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.14.0",
+        "@clerk/shared": "^4.25.9",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -3275,6 +3303,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -7785,11 +7826,11 @@
       }
     },
     "@clerk/backend": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.13.2.tgz",
-      "integrity": "sha512-z6rPQzEj1SbGmjMoyGnECY1R7YrcD4dJILlWLXFvSUsWxb8csAYzcXp50T2kVtV3ThlcjOMrI0oDQyqvTdt65A==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.14.0.tgz",
+      "integrity": "sha512-WsphTvDFHDuQilKI7dyVE5qmt7USu8qSrujAq6SqpEHbVFfNBfINDNuzxlF9M2skOTfHFfgiTE8Jjb1egIBGLg==",
       "requires": {
-        "@clerk/shared": "^4.25.8",
+        "@clerk/shared": "^4.25.9",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       }
@@ -7816,9 +7857,9 @@
       }
     },
     "@clerk/shared": {
-      "version": "4.25.8",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.8.tgz",
-      "integrity": "sha512-ob0E/YJAoDTO4CzHI0nasXGsJUc1cFo0jxPO8xVz/A0+C1R0k1da0EJD8L6F03DzKMn3efSa4mOy3BXTpBVZqw==",
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.25.9.tgz",
+      "integrity": "sha512-nw3maGzqPrwmUKjGffOM9Zvw24IyOllq0TkQGzsTfQX312WLu2u5CNvjKntMb6Ok6kXa1Zdc77zmPLn1/EAIFA==",
       "requires": {
         "@tanstack/query-core": "^5.100.6",
         "dequal": "2.0.3",
@@ -7831,6 +7872,17 @@
           "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
           "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="
         }
+      }
+    },
+    "@clerk/testing": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.15.tgz",
+      "integrity": "sha512-wSw0qJUZVgMPvZPdRpYLHOCYnpq3j66DryLpjBR0yVCfeQF+nYDwzZNocA/RdewwNTlQEpp9J8wNcD2Nw8zoPg==",
+      "dev": true,
+      "requires": {
+        "@clerk/backend": "^3.14.0",
+        "@clerk/shared": "^4.25.9",
+        "dotenv": "17.2.2"
       }
     },
     "@emnapi/core": {
@@ -9467,6 +9519,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     ]
   },
   "devDependencies": {
+    "@clerk/testing": "2.2.15",
     "@playwright/test": "^1.62.0",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.14",

--- a/frontend/scripts/run-production-auth-canary.mjs
+++ b/frontend/scripts/run-production-auth-canary.mjs
@@ -10,8 +10,12 @@ const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const USER_ID = /^user_[A-Za-z0-9]+$/;
 const SESSION_ID = /^sess_[A-Za-z0-9]+$/;
 const PROFILE = /^[A-Za-z0-9_]{2,15}$/;
-const BROWSER_PLAN_VERSION = 2;
+const TESTING_TOKEN = /^[A-Za-z0-9._~-]{20,2048}$/;
+const BROWSER_PLAN_VERSION = 3;
 const EXPECTED_SESSION_MAX_DURATION_SECONDS = 120;
+const TESTING_TOKEN_MIN_REMAINING_SECONDS = 180;
+// Clerk issues these for one hour; permit only two minutes of host clock skew.
+const TESTING_TOKEN_MAX_REMAINING_SECONDS = 3720;
 const JWT_EXPIRY_GRACE_SECONDS = 5;
 const SESSION_EXPIRY_GRACE_SECONDS = 15;
 const MAX_EXPIRY_OVERHEAD_SECONDS = 30;
@@ -94,11 +98,15 @@ function bareHttpsOrigin(value, label) {
   return parsed.origin;
 }
 
-export function validateTasks(payload) {
+export function validateTasks(payload, nowSeconds = Math.floor(Date.now() / 1000)) {
   if (
     !payload
     || payload.version !== BROWSER_PLAN_VERSION
     || payload.session_max_duration_seconds !== EXPECTED_SESSION_MAX_DURATION_SECONDS
+    || !TESTING_TOKEN.test(payload.testing_token ?? '')
+    || !Number.isSafeInteger(payload.testing_token_expires_at)
+    || payload.testing_token_expires_at - nowSeconds < TESTING_TOKEN_MIN_REMAINING_SECONDS
+    || payload.testing_token_expires_at - nowSeconds > TESTING_TOKEN_MAX_REMAINING_SECONDS
     || !Array.isArray(payload.tasks)
   ) {
     fail('authenticated canary task contract is invalid');
@@ -152,8 +160,106 @@ export function validateTasks(payload) {
   return {
     apiBase,
     appOrigin,
+    taskOrigin,
+    testingToken: payload.testing_token,
+    testingTokenExpiresAt: payload.testing_token_expires_at,
     sessionMaxDurationSeconds: payload.session_max_duration_seconds,
     tasks: payload.tasks,
+  };
+}
+
+export function registerGitHubSecretMask(secret) {
+  if (process.env.GITHUB_ACTIONS !== 'true' || !TESTING_TOKEN.test(secret ?? '')) {
+    fail('Clerk production Testing Token masking is unavailable');
+  }
+  process.stdout.write(`::add-mask::${secret}\n`);
+}
+
+function redactClerkDiagnostic(value, testingToken) {
+  if (typeof value === 'string') {
+    return value.replaceAll(testingToken, '[REDACTED_TESTING_TOKEN]');
+  }
+  if (value instanceof Error) {
+    const redacted = new Error(
+      value.message.replaceAll(testingToken, '[REDACTED_TESTING_TOKEN]'),
+    );
+    redacted.name = value.name;
+    return redacted;
+  }
+  try {
+    if (JSON.stringify(value)?.includes(testingToken)) {
+      return '[REDACTED_CLERK_DIAGNOSTIC]';
+    }
+  } catch {
+    return '[UNSERIALIZABLE_CLERK_DIAGNOSTIC]';
+  }
+  return value;
+}
+
+export async function installClerkTestingToken(
+  context,
+  taskUrl,
+  taskOrigin,
+  testingToken,
+  setupClerkTestingToken,
+  maskSecret = registerGitHubSecretMask,
+) {
+  if (
+    typeof setupClerkTestingToken !== 'function'
+    || typeof maskSecret !== 'function'
+    || !TESTING_TOKEN.test(testingToken ?? '')
+    || process.env.CLERK_TESTING_TOKEN !== undefined
+    || process.env.CLERK_TESTING_DEBUG !== undefined
+  ) {
+    fail('Clerk production Testing Token setup is invalid');
+  }
+  const parsedTask = new URL(taskUrl);
+  const parsedOrigin = new URL(taskOrigin);
+  if (parsedTask.origin !== parsedOrigin.origin || parsedOrigin.pathname !== '/') {
+    fail('Clerk production Testing Token targets an invalid origin');
+  }
+
+  maskSecret(testingToken);
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values) => originalWarn(
+    ...values.map((value) => redactClerkDiagnostic(value, testingToken)),
+  );
+  console.error = (...values) => originalError(
+    ...values.map((value) => redactClerkDiagnostic(value, testingToken)),
+  );
+  process.env.CLERK_TESTING_TOKEN = testingToken;
+  let installed = false;
+  try {
+    await setupClerkTestingToken({
+      context,
+      options: { frontendApiUrl: parsedOrigin.host },
+    });
+    // The official helper parses JSON FAPI responses. Agent Task consumption
+    // is a one-use document navigation, so handle that exact URL separately
+    // while still using the helper for every subsequent ClerkJS request.
+    await context.route(taskUrl, async (route) => {
+      const requestUrl = new URL(route.request().url());
+      requestUrl.searchParams.set('__clerk_testing_token', testingToken);
+      await route.continue({ url: requestUrl.toString() });
+    }, { times: 1 });
+    installed = true;
+  } finally {
+    if (!installed) {
+      delete process.env.CLERK_TESTING_TOKEN;
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+  }
+
+  let cleared = false;
+  return () => {
+    if (!cleared) {
+      cleared = true;
+      delete process.env.CLERK_TESTING_TOKEN;
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
   };
 }
 
@@ -264,7 +370,28 @@ export async function applicationSessionToken(
     }
     await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  fail('Clerk did not establish an application session in time');
+  const state = await page.evaluate(() => ({
+    clerkPresent: Boolean(globalThis.Clerk),
+    clerkLoaded: Boolean(globalThis.Clerk?.loaded),
+    sessionPresent: Boolean(globalThis.Clerk?.session),
+  })).catch(() => ({ clerkPresent: false, clerkLoaded: false, sessionPresent: false }));
+  let pageState = 'unexpected-origin';
+  try {
+    const current = new URL(page.url());
+    if (current.origin === appOrigin) {
+      pageState = current.pathname === '/' ? 'public-root' : 'other-app-path';
+    }
+  } catch {
+    pageState = 'invalid-location';
+  }
+  const clerkState = state.sessionPresent
+    ? 'session-present'
+    : state.clerkLoaded
+      ? 'loaded-without-session'
+      : state.clerkPresent
+        ? 'present-not-loaded'
+        : 'missing';
+  fail(`Clerk did not establish an application session in time (${pageState}; ${clerkState})`);
 }
 
 async function responseJson(context, apiBase, path, token, expectedStatus, label) {
@@ -484,7 +611,10 @@ async function main() {
   const { tasksPath } = argumentsFromCommandLine();
   const taskContract = validateTasks(await readBoundedJson(tasksPath, 'task file'));
 
-  const { chromium } = await import('playwright');
+  const [{ chromium }, { setupClerkTestingToken }] = await Promise.all([
+    import('playwright'),
+    import('@clerk/testing/playwright'),
+  ]);
   let browser;
   try {
     browser = await chromium.launch({ headless: true });
@@ -495,8 +625,16 @@ async function main() {
         acceptDownloads: false,
         serviceWorkers: 'block',
       });
+      let clearTestingToken;
       let token;
       try {
+        clearTestingToken = await installClerkTestingToken(
+          context,
+          task.task_url,
+          taskContract.taskOrigin,
+          taskContract.testingToken,
+          setupClerkTestingToken,
+        );
         const page = await context.newPage();
         await page.goto(task.task_url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
         await page.waitForURL(
@@ -551,8 +689,12 @@ async function main() {
         }
       } finally {
         token = undefined;
-        await context.clearCookies();
-        await context.close();
+        try {
+          await context.clearCookies();
+          await context.close();
+        } finally {
+          clearTestingToken?.();
+        }
       }
     }
   } finally {

--- a/frontend/scripts/run-production-auth-canary.test.mjs
+++ b/frontend/scripts/run-production-auth-canary.test.mjs
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { setupClerkTestingToken as realSetupClerkTestingToken } from '@clerk/testing/playwright';
 
 import {
   applicationSessionToken,
   decodeSession,
   expiryProofDeadlineMilliseconds,
+  installClerkTestingToken,
   isPrivateSignInRedirect,
   proveSignOutClosure,
   validateTasks,
@@ -25,10 +27,12 @@ function task(label, closure, userId, profile) {
 
 function plan() {
   return {
-    version: 2,
+    version: 3,
     api_base: 'https://api.spyboxd.com',
     app_origin: APP_ORIGIN,
     task_origin: TASK_ORIGIN,
+    testing_token: `testing-${'a'.repeat(48)}`,
+    testing_token_expires_at: Math.floor(Date.now() / 1000) + 600,
     session_max_duration_seconds: 120,
     tasks: [
       task('A', 'sign_out', 'user_A123', 'alpha'),
@@ -56,6 +60,120 @@ test('browser plan requires distinct sign-out and natural-expiry closures', () =
   const wrongDuration = plan();
   wrongDuration.session_max_duration_seconds = 1800;
   assert.throws(() => validateTasks(wrongDuration), /task contract is invalid/);
+
+  const expiredTestingToken = plan();
+  expiredTestingToken.testing_token_expires_at = Math.floor(Date.now() / 1000) + 30;
+  assert.throws(() => validateTasks(expiredTestingToken), /task contract is invalid/);
+});
+
+test('Clerk Testing Token is installed before one-use task navigation and cleared', async () => {
+  const events = [];
+  const diagnostics = [];
+  let taskHandler;
+  const context = {
+    async route(url, handler, options) {
+      events.push(['route', url, options]);
+      taskHandler = handler;
+    },
+  };
+  const testingToken = `testing-${'b'.repeat(48)}`;
+  const taskUrl = `${TASK_ORIGIN}/v1/agent-tasks/a-ticket`;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values) => diagnostics.push(values.map(String).join(' '));
+  console.error = (...values) => diagnostics.push(values.map(String).join(' '));
+  let clear;
+  try {
+    clear = await installClerkTestingToken(
+      context,
+      taskUrl,
+      TASK_ORIGIN,
+      testingToken,
+      async (options) => {
+        assert.equal(options.context, context);
+        assert.deepEqual(options.options, { frontendApiUrl: 'clerk.spyboxd.com' });
+        assert.equal(process.env.CLERK_TESTING_TOKEN, testingToken);
+        console.warn(`Clerk retry URL contained ${testingToken}`);
+        console.error(new Error(`Clerk route failed with ${testingToken}`));
+        events.push(['setup']);
+      },
+      (secret) => events.push(['mask', secret]),
+    );
+    assert.deepEqual(events, [
+      ['mask', testingToken],
+      ['setup'],
+      ['route', taskUrl, { times: 1 }],
+    ]);
+
+    let continuedUrl;
+    await taskHandler({
+      request: () => ({ url: () => taskUrl }),
+      continue: async ({ url }) => { continuedUrl = new URL(url); },
+    });
+    assert.equal(continuedUrl.origin, TASK_ORIGIN);
+    assert.equal(continuedUrl.pathname, '/v1/agent-tasks/a-ticket');
+    assert.equal(continuedUrl.searchParams.get('__clerk_testing_token'), testingToken);
+  } finally {
+    clear?.();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+  assert.equal(process.env.CLERK_TESTING_TOKEN, undefined);
+  assert.equal(diagnostics.some((line) => line.includes(testingToken)), false);
+  assert.equal(
+    diagnostics.filter((line) => line.includes('[REDACTED_TESTING_TOKEN]')).length,
+    2,
+  );
+});
+
+test('real Clerk helper failure diagnostics cannot expose the production Testing Token', async () => {
+  const testingToken = `testing-${'c'.repeat(48)}`;
+  const taskUrl = `${TASK_ORIGIN}/v1/agent-tasks/a-ticket`;
+  const handlers = [];
+  const context = {
+    async route(matcher, handler) {
+      handlers.push({ matcher, handler });
+    },
+  };
+  const diagnostics = [];
+  const originalWarn = console.warn;
+  const originalSetTimeout = globalThis.setTimeout;
+  console.warn = (...values) => diagnostics.push(values.map(String).join(' '));
+  globalThis.setTimeout = (callback) => {
+    callback();
+    return 0;
+  };
+  let clear;
+  try {
+    clear = await installClerkTestingToken(
+      context,
+      taskUrl,
+      TASK_ORIGIN,
+      testingToken,
+      realSetupClerkTestingToken,
+      () => {},
+    );
+    assert.equal(handlers.length, 2);
+    const fapiHandler = handlers[0].handler;
+    let fetches = 0;
+    await fapiHandler({
+      request: () => ({ url: () => `${TASK_ORIGIN}/v1/client` }),
+      fetch: async ({ url }) => {
+        fetches += 1;
+        throw new Error(`simulated FAPI failure for ${url}`);
+      },
+      continue: async () => {},
+    });
+    assert.equal(fetches, 4);
+  } finally {
+    clear?.();
+    console.warn = originalWarn;
+    globalThis.setTimeout = originalSetTimeout;
+  }
+  assert.equal(process.env.CLERK_TESTING_TOKEN, undefined);
+  assert.equal(diagnostics.length, 1);
+  assert.equal(diagnostics[0].includes(testingToken), false);
+  assert.match(diagnostics[0], /REDACTED_TESTING_TOKEN/);
 });
 
 test('session token contract requires a future expiry and session identity', () => {


### PR DESCRIPTION
## Outcome

Uses Clerk production Testing Tokens only inside the VPS canary execution boundary so the authenticated production isolation check can bypass automated-browser bot detection. The Clerk secret remains on the VPS, the short-lived token is masked and redacted, and private canary plans are securely removed.

## Validation

- 236 backend tests passed
- 105 deployment and workflow tests passed with 5 environment-only skips
- 8 Node canary tests passed, including a real helper failure-path redaction regression
- Frontend lint, typecheck, and production build passed
- Production npm audit reports zero vulnerabilities
- Workflow YAML, diff checks, and security review passed