### PR TITLE
Make the production auth canary reliable and fail-closed

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -153,7 +153,7 @@ jobs:
             echo '### Authenticated isolation phase not enabled'
             echo
             echo 'The public, RSS, redirect, and anonymous API checks passed.'
-            echo 'To enable the hourly fail-closed two-user phase, enable Clerk Agent Tasks, create two dedicated non-admin Clerk accounts whose usernames match completed unclaimed Spyboxd profiles, store their four identity values as production environment secrets, and set the repository Actions variable `PRODUCTION_AUTH_CANARY_ENABLED=true`.'
+            echo 'To enable the hourly fail-closed two-user phase, create two dedicated non-admin Clerk accounts whose usernames match completed unclaimed Spyboxd profiles, store their four identity values as production environment secrets, and set the repository Actions variable `PRODUCTION_AUTH_CANARY_ENABLED=true`.'
             echo 'The workflow stages those non-password identity values only for a single run. Clerk, database, password, and session secrets remain on the VPS.'
           } >>"${GITHUB_STEP_SUMMARY}"
 
@@ -188,7 +188,7 @@ jobs:
       (github.event_name == 'schedule' && github.event.schedule == '7 * * * *' &&
       vars.PRODUCTION_AUTH_CANARY_ENABLED == 'true'))
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     concurrency:
       group: spyboxd-production-auth-canary
       queue: max
@@ -223,6 +223,18 @@ jobs:
           npm ci --ignore-scripts --no-audit --no-fund
           ./node_modules/.bin/playwright install --with-deps chromium
 
+      - name: Confirm the exact release before loading production credentials
+        env:
+          EXPECTED_REVISION: ${{ needs.public_canary.outputs.revision }}
+        run: |
+          set -Eeuo pipefail
+          [[ "${EXPECTED_REVISION}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${EXPECTED_REVISION}" == "${GITHUB_SHA}" ]]
+          python3 deploy/run-production-canary.py \
+            --health-validator deploy/check-runtime-health.py \
+            --attempts 1 \
+            --expected-revision "${EXPECTED_REVISION}"
+
       - name: Establish one pinned IPv4 production SSH connection
         id: production_ssh
         env:
@@ -254,7 +266,7 @@ jobs:
           printf 'env_path=%s\n' "${remote_env_path}" >>"${GITHUB_OUTPUT}"
           trap - ERR INT TERM
 
-      - name: Install the exact remote Clerk task helper
+      - name: Install the exact remote Clerk canary guardian
         env:
           REMOTE_CANARY_PATH: ${{ steps.remote_canary.outputs.path }}
         run: |
@@ -340,22 +352,31 @@ jobs:
           REMOTE_CANARY_PATH: ${{ steps.remote_canary.outputs.path }}
         run: |
           set -Eeuo pipefail
-          task_file="${RUNNER_TEMP}/spyboxd-auth-tasks.json"
+          plan_file="${RUNNER_TEMP}/spyboxd-auth-browser-plan.json"
           lease_id="gha-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           remote_lease="/opt/spyboxd/shared/auth-canary-leases/${lease_id}"
           remote_plan="${remote_lease}/plan.json"
-          [[ ! -e "${task_file}" && ! -L "${task_file}" ]]
+          [[ ! -e "${plan_file}" && ! -L "${plan_file}" ]]
           [[ "${lease_id}" =~ ^gha-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}$ ]]
           [[ "${REMOTE_CANARY_PATH}" =~ ^/tmp/spyboxd-auth-canary\.[A-Za-z0-9]{6}$ ]]
           [[ "${REMOTE_CANARY_ENV_PATH}" =~ ^/tmp/spyboxd-auth-canary-env\.[A-Za-z0-9]{6}$ ]]
 
           guardian_started=0
           signal_guardian() {
+            completion_result="${1:-failed}"
             if (( guardian_started == 1 )); then
-              timeout --signal=TERM --kill-after=5s 30s \
-                deploy/production-ssh.sh run \
-                  "${REMOTE_CANARY_PATH}" complete --lease-id "${lease_id}" \
-                  >/dev/null 2>&1 || true
+              if [[ "${completion_result}" == passed ]]; then
+                timeout --signal=TERM --kill-after=5s 30s \
+                  deploy/production-ssh.sh run \
+                    "${REMOTE_CANARY_PATH}" complete --lease-id "${lease_id}" \
+                    --browser-passed \
+                    >/dev/null 2>&1 || true
+              else
+                timeout --signal=TERM --kill-after=5s 30s \
+                  deploy/production-ssh.sh run \
+                    "${REMOTE_CANARY_PATH}" complete --lease-id "${lease_id}" \
+                    >/dev/null 2>&1 || true
+              fi
             fi
           }
           trap signal_guardian EXIT
@@ -398,7 +419,7 @@ jobs:
           umask 077
           nohup setsid "${python_path}" "${canary_path}" guard \
             --lease-id "${lease_id}" \
-            --max-wait-seconds 600 \
+            --max-wait-seconds 900 \
             --canary-env "${canary_env_path}" \
             </dev/null >/dev/null 2>&1 &
           guardian_pid=$!
@@ -431,22 +452,28 @@ jobs:
           if (( plan_ready == 1 )); then
             umask 077
             if deploy/production-ssh.sh copy \
-              "spyboxd-production:${remote_plan}" "${task_file}"
+              "spyboxd-production:${remote_plan}" "${plan_file}"
             then
-              chmod 0600 "${task_file}"
+              chmod 0600 "${plan_file}"
+              [[ "$(stat -c '%a' "${plan_file}")" == 600 ]]
               browser_status=0
               (
                 cd frontend
-                node scripts/run-production-auth-canary.mjs --tasks "${task_file}"
+                timeout --signal=TERM --kill-after=15s 12m \
+                  node scripts/run-production-auth-canary.mjs --plan "${plan_file}"
               ) || browser_status=$?
             fi
           else
             echo 'The VPS guardian did not publish a canary plan.' >&2
           fi
 
-          signal_guardian
+          if (( browser_status == 0 )); then
+            signal_guardian passed
+          else
+            signal_guardian failed
+          fi
           guardian_status=running
-          for _ in $(seq 1 180); do
+          for _ in $(seq 1 240); do
             guardian_status="$(
               deploy/production-ssh.sh run \
                 "${REMOTE_CANARY_PATH}" status --lease-id "${lease_id}"
@@ -460,7 +487,7 @@ jobs:
             guardian_started=0
           fi
           if [[ "${guardian_status}" == cleanup_failed ]]; then
-            echo 'The VPS guardian did not prove Clerk task and session cleanup.' >&2
+            echo 'The VPS guardian did not prove Clerk ticket and session cleanup.' >&2
             exit 1
           fi
           if (( browser_status != 0 )); then
@@ -490,8 +517,8 @@ jobs:
           if [[ "${guardian_status}" == running ]]; then
             deploy/production-ssh.sh run \
               "${REMOTE_CANARY_PATH}" complete --lease-id "${lease_id}" \
-              >/dev/null
-            for _ in $(seq 1 180); do
+              >/dev/null 2>&1 || true
+            for _ in $(seq 1 240); do
               sleep 2
               guardian_status="$(
                 deploy/production-ssh.sh run \
@@ -505,7 +532,7 @@ jobs:
           if [[ "${guardian_status}" == absent ]]; then
             exit 0
           fi
-          timeout --signal=TERM --kill-after=15s 5m \
+          timeout --signal=TERM --kill-after=15s 7m \
             deploy/production-ssh.sh run \
               "${REMOTE_CANARY_PATH}" cleanup --lease-id "${lease_id}"
 
@@ -564,7 +591,7 @@ jobs:
         run: |
           for path in \
             "${RUNNER_TEMP}/spyboxd-auth-canary.env" \
-            "${RUNNER_TEMP}/spyboxd-auth-tasks.json"
+            "${RUNNER_TEMP}/spyboxd-auth-browser-plan.json"
           do
             if [[ -L "${path}" ]]; then
               echo 'Refusing to remove a local canary symlink.' >&2
@@ -578,6 +605,18 @@ jobs:
             fi
           done
 
+      - name: Confirm the release remained exact after authenticated isolation
+        env:
+          EXPECTED_REVISION: ${{ needs.public_canary.outputs.revision }}
+        run: |
+          set -Eeuo pipefail
+          [[ "${EXPECTED_REVISION}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${EXPECTED_REVISION}" == "${GITHUB_SHA}" ]]
+          python3 deploy/run-production-canary.py \
+            --health-validator deploy/check-runtime-health.py \
+            --attempts 1 \
+            --expected-revision "${EXPECTED_REVISION}"
+
       - name: Summarize passing authenticated isolation
         if: success()
         env:
@@ -587,8 +626,10 @@ jobs:
             echo '### Production authenticated canary passed'
             echo
             echo "- Release: \`${PRODUCTION_REVISION}\`"
-            echo '- Two short-lived browser-established non-admin Clerk sessions proved per-user profile isolation'
-            echo '- Global/admin access remained denied and the VPS re-listed both users to prove no canary session remained live'
+            echo '- The exact release was rechecked immediately before and after authenticated isolation'
+            echo '- Two browser-established non-admin Clerk sessions proved per-user profile isolation and cross-user denial'
+            echo '- Clerk server state confirmed the real sign-out control closed identity A; a captured short-lived JWT from identity B was rejected after expiry'
+            echo '- Global/admin access remained denied; the VPS revoked remaining ordinary sessions and required two empty server-side samples'
             echo '- The two dedicated identities either passed strict existing-state checks or were safely provisioned from completed unclaimed profiles during their first browser run'
-            echo '- The ephemeral identity configuration was securely removed locally and remotely; Clerk and database secrets remained on the VPS'
+            echo '- One-use tickets and identity configuration were securely removed locally and remotely; Clerk and database secrets remained on the VPS'
           } >>"${GITHUB_STEP_SUMMARY}"

--- a/deploy/run-production-auth-canary.py
+++ b/deploy/run-production-auth-canary.py
@@ -30,6 +30,8 @@ PROFILE_PATTERN = re.compile(r"[A-Za-z0-9_]{2,15}")
 SESSION_ID_PATTERN = re.compile(r"sess_[A-Za-z0-9]+")
 OPAQUE_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{8,200}")
 TESTING_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9._~-]{20,2048}")
+SIGN_IN_TOKEN_ID_PATTERN = re.compile(r"sit_[A-Za-z0-9]+")
+SIGN_IN_TOKEN_PATTERN = re.compile(r"[A-Za-z0-9._~-]{20,4096}")
 LEASE_ID_PATTERN = re.compile(r"gha-[1-9][0-9]{0,19}-[1-9][0-9]{0,9}")
 APP_ORIGIN = "https://spyboxd.com"
 DEFAULT_API_BASE = "https://api.spyboxd.com"
@@ -41,15 +43,20 @@ DONE_NAME = "done"
 STATUS_NAME = "status.json"
 LOCK_NAME = ".auth-canary.lock"
 LIVE_SESSION_STATUSES = ("active",)
-SESSION_MAX_DURATION_SECONDS = 120
-SESSION_EXPIRY_GRACE_SECONDS = 5
-BROWSER_PLAN_VERSION = 3
+LEGACY_AGENT_SESSION_MAX_DURATION_SECONDS = 120
+CAPABILITY_EXPIRY_GRACE_SECONDS = 5
+SIGN_IN_TOKEN_DURATION_SECONDS = 300
+SIGN_IN_TOKEN_MIN_PLAN_REMAINING_SECONDS = 120
+SESSION_TOKEN_MAX_LIFETIME_SECONDS = 90
+BROWSER_PLAN_VERSION = 4
 TESTING_TOKEN_MIN_REMAINING_SECONDS = 300
-# Clerk issues these for one hour; permit only two minutes of host clock skew.
-TESTING_TOKEN_MAX_REMAINING_SECONDS = 3720
+GUARDIAN_MAX_WAIT_SECONDS = 900
+DATABASE_CONNECT_TIMEOUT_SECONDS = 5
+DATABASE_STATEMENT_TIMEOUT_MILLISECONDS = 10_000
+DATABASE_LOCK_TIMEOUT_MILLISECONDS = 5_000
 BROWSER_CLOSURE_BY_LABEL = {
     "A": "sign_out",
-    "B": "session_expiry",
+    "B": "jwt_expiry",
 }
 DATABASE_STATE_BOOTSTRAP = "bootstrap"
 DATABASE_STATE_PROVISIONED = "provisioned"
@@ -279,7 +286,7 @@ def _database_preflight(
 
     engine = None
     try:
-        engine = create_engine(database_url, pool_pre_ping=True)
+        engine = create_engine(database_url, **_database_engine_options(database_url))
         with engine.connect() as connection:
             identity_rows = (
                 connection.execute(
@@ -358,6 +365,28 @@ def _database_preflight(
         profile_rows,
         claimed_rows,
     )
+
+
+def _database_engine_options(database_url: str) -> dict[str, Any]:
+    """Bound every PostgreSQL wait before the guardian creates an engine."""
+
+    scheme, separator, _ = database_url.partition(":")
+    backend = scheme.split("+", 1)[0].lower() if separator else ""
+    options: dict[str, Any] = {"pool_pre_ping": True}
+    if backend in {"postgres", "postgresql"}:
+        options["connect_args"] = {
+            "connect_timeout": DATABASE_CONNECT_TIMEOUT_SECONDS,
+            "options": (
+                "-c statement_timeout="
+                f"{DATABASE_STATEMENT_TIMEOUT_MILLISECONDS} "
+                "-c lock_timeout="
+                f"{DATABASE_LOCK_TIMEOUT_MILLISECONDS}"
+            ),
+        }
+        return options
+    if backend == "sqlite":
+        return options
+    raise AuthCanaryError("the canary database backend is unsupported")
 
 
 def _bounded_body(opened: Any) -> bytes:
@@ -500,6 +529,8 @@ def _error_codes(response: HttpResponse) -> set[str]:
 
 
 def _retire_agent_task(secret_key: str, agent_task_id: str) -> bool:
+    """Clean a legacy Agent Task left by an interrupted older canary release."""
+
     response = _request(
         f"https://api.clerk.com/v1/agents/tasks/{urllib.parse.quote(agent_task_id, safe='')}/revoke",
         method="POST",
@@ -549,85 +580,100 @@ def _create_testing_token(secret_key: str) -> tuple[str, int]:
     # seconds before the private browser-plan handoff.
     expires_at_seconds = expires_at // 1000 if expires_at > 10_000_000_000 else expires_at
     remaining_seconds = expires_at_seconds - int(time.time())
-    if not (
-        TESTING_TOKEN_MIN_REMAINING_SECONDS
-        <= remaining_seconds
-        <= TESTING_TOKEN_MAX_REMAINING_SECONDS
-    ):
-        raise AuthCanaryError("Clerk returned an unexpectedly bounded Testing Token")
+    if remaining_seconds < TESTING_TOKEN_MIN_REMAINING_SECONDS:
+        raise AuthCanaryError("Clerk returned an unexpectedly short Testing Token")
     return token, expires_at_seconds
 
 
-def _create_agent_task(
+def _retire_sign_in_token(secret_key: str, sign_in_token_id: str) -> bool:
+    response = _request(
+        "https://api.clerk.com/v1/sign_in_tokens/"
+        f"{urllib.parse.quote(sign_in_token_id, safe='')}/revoke",
+        method="POST",
+        bearer=secret_key,
+        clerk_backend=True,
+    )
+    if response.status == 200:
+        payload = _json(response, "Clerk canary Sign-in Token revocation", 200)
+        if (
+            not isinstance(payload, dict)
+            or payload.get("object") != "sign_in_token"
+            or payload.get("id") != sign_in_token_id
+            or payload.get("status") != "revoked"
+        ):
+            raise AuthCanaryError(
+                "Clerk returned an invalid Sign-in Token revocation"
+            )
+        return False
+    if response.status == 404:
+        # The capability no longer exists. It may already have created a session,
+        # so the authoritative session sweep still runs below.
+        return True
+    if response.status == 400 and "sign_in_token_cannot_be_revoked_code" in (
+        _error_codes(response)
+    ):
+        # Clerk only revokes pending tickets, but this response alone does not
+        # prove whether consumption created a session. The success marker or the
+        # persisted expiry guard plus the session sweep must close that ambiguity.
+        return True
+    raise AuthCanaryError("a Clerk canary Sign-in Token could not be proven inactive")
+
+
+def _create_sign_in_token(
     secret_key: str,
     identity: CanaryIdentity,
     *,
-    allowed_frontend_origins: set[str],
-    app_origin: str,
-    record_task_id: Callable[[str], None],
-) -> dict[str, str]:
+    record_token: Callable[[str, int], None],
+) -> dict[str, Any]:
+    requested_at = int(time.time())
     created = _json(
         _request(
-            "https://api.clerk.com/v1/agents/tasks",
+            "https://api.clerk.com/v1/sign_in_tokens",
             method="POST",
             bearer=secret_key,
             payload={
-                "on_behalf_of": {"user_id": identity.user_id},
-                "permissions": "*",
-                "agent_name": "spyboxd-production-canary",
-                "task_description": "Read-only non-admin privacy and isolation check",
-                # Land on the only public application route first. Clerk's
-                # frontend SDK must finish the Agent Task handoff and write the
-                # app-scoped session token before middleware can admit the
-                # browser to a protected route.
-                "redirect_url": f"{app_origin}/",
-                "session_max_duration_in_seconds": SESSION_MAX_DURATION_SECONDS,
+                "user_id": identity.user_id,
+                "expires_in_seconds": SIGN_IN_TOKEN_DURATION_SECONDS,
             },
             clerk_backend=True,
         ),
-        f"Clerk agent task creation for canary {identity.label}",
+        f"Clerk Sign-in Token creation for canary {identity.label}",
         200,
     )
-    task_id = created.get("agent_task_id") if isinstance(created, dict) else None
-    if not isinstance(task_id, str) or not OPAQUE_ID_PATTERN.fullmatch(task_id):
-        raise AuthCanaryError(
-            f"Clerk returned an invalid agent task for canary {identity.label}"
-        )
-
-    # Persist the cleanup handle before validating or exporting the one-time URL.
-    record_task_id(task_id)
-    task_url = created.get("url") if isinstance(created, dict) else None
-    if not isinstance(task_url, str):
-        raise AuthCanaryError(
-            f"Clerk omitted the agent task URL for canary {identity.label}"
-        )
-    try:
-        parsed_task = urllib.parse.urlsplit(task_url)
-        _ = parsed_task.port
-    except ValueError as exc:
-        raise AuthCanaryError(
-            f"Clerk returned an invalid task URL for canary {identity.label}"
-        ) from exc
-    task_origin = urllib.parse.urlunsplit(
-        (parsed_task.scheme, parsed_task.netloc, "", "", "")
-    )
-    if (
-        parsed_task.scheme != "https"
-        or not parsed_task.hostname
-        or parsed_task.username is not None
-        or parsed_task.password is not None
-        or parsed_task.fragment
-        or task_origin not in allowed_frontend_origins
+    response_received_at = int(time.time())
+    token_id = created.get("id") if isinstance(created, dict) else None
+    if not isinstance(token_id, str) or not SIGN_IN_TOKEN_ID_PATTERN.fullmatch(
+        token_id
     ):
         raise AuthCanaryError(
-            f"Clerk returned an unsafe task URL for canary {identity.label}"
+            f"Clerk returned an invalid Sign-in Token for canary {identity.label}"
+        )
+
+    # Browser use gets a conservative lower deadline from request start. Cleanup
+    # gets a safe upper deadline from response receipt because Clerk necessarily
+    # created the ticket before returning it. Persist that cleanup handle before
+    # validating or exporting the bearer capability.
+    browser_expires_at = requested_at + SIGN_IN_TOKEN_DURATION_SECONDS
+    cleanup_deadline = response_received_at + SIGN_IN_TOKEN_DURATION_SECONDS
+    record_token(token_id, cleanup_deadline)
+    token = created.get("token") if isinstance(created, dict) else None
+    if (
+        not isinstance(created, dict)
+        or created.get("object") != "sign_in_token"
+        or created.get("status") != "pending"
+        or created.get("user_id") != identity.user_id
+        or not isinstance(token, str)
+        or not SIGN_IN_TOKEN_PATTERN.fullmatch(token)
+    ):
+        raise AuthCanaryError(
+            f"Clerk returned an invalid Sign-in Token for canary {identity.label}"
         )
     return {
         "label": identity.label,
         "user_id": identity.user_id,
         "profile": identity.profile,
-        "task_url": task_url,
-        "task_origin": task_origin,
+        "sign_in_token": token,
+        "sign_in_token_expires_at": browser_expires_at,
     }
 
 
@@ -635,16 +681,27 @@ def _build_browser_plan(
     *,
     api_base: str,
     app_origin: str,
-    task_origin: str,
+    clerk_frontend_origin: str,
     testing_token: str,
     testing_token_expires_at: int,
     tasks: list[Mapping[str, Any]],
 ) -> dict[str, Any]:
+    api_base = _origin(api_base, "authenticated browser plan API")
+    app_origin = _origin(app_origin, "authenticated browser plan application")
+    clerk_frontend_origin = _origin(
+        clerk_frontend_origin, "authenticated browser plan Clerk frontend"
+    )
+    if api_base != DEFAULT_API_BASE or app_origin != APP_ORIGIN:
+        raise AuthCanaryError("authenticated browser plan targets are unexpected")
     if len(tasks) != len(BROWSER_CLOSURE_BY_LABEL):
         raise AuthCanaryError("authenticated browser plan requires exactly two tasks")
 
     planned_tasks: list[dict[str, Any]] = []
     seen_labels: set[str] = set()
+    seen_tokens: set[str] = set()
+    seen_user_ids: set[str] = set()
+    seen_profiles: set[str] = set()
+    now = int(time.time())
     for task in tasks:
         label = task.get("label")
         if not isinstance(label, str):
@@ -652,14 +709,49 @@ def _build_browser_plan(
         closure = BROWSER_CLOSURE_BY_LABEL.get(label)
         if closure is None or label in seen_labels:
             raise AuthCanaryError("authenticated browser plan has invalid task labels")
-        if task.get("task_origin") != task_origin:
+        sign_in_token = task.get("sign_in_token")
+        if not isinstance(sign_in_token, str) or not SIGN_IN_TOKEN_PATTERN.fullmatch(
+            sign_in_token
+        ):
             raise AuthCanaryError(
-                "authenticated browser plan has inconsistent task origins"
+                "authenticated browser plan has an invalid Sign-in Token"
+            )
+        if sign_in_token in seen_tokens:
+            raise AuthCanaryError(
+                "authenticated browser plan has duplicate Sign-in Tokens"
+            )
+        user_id = task.get("user_id")
+        profile = task.get("profile")
+        expires_at = task.get("sign_in_token_expires_at")
+        if (
+            not isinstance(user_id, str)
+            or not USER_ID_PATTERN.fullmatch(user_id)
+            or not isinstance(profile, str)
+            or not PROFILE_PATTERN.fullmatch(profile)
+            or isinstance(expires_at, bool)
+            or not isinstance(expires_at, int)
+            or expires_at - now < SIGN_IN_TOKEN_MIN_PLAN_REMAINING_SECONDS
+            or expires_at - now > SIGN_IN_TOKEN_DURATION_SECONDS
+        ):
+            raise AuthCanaryError(
+                "authenticated browser plan has an invalid Sign-in Token identity"
+            )
+        normalized_profile = profile.casefold()
+        if user_id in seen_user_ids or normalized_profile in seen_profiles:
+            raise AuthCanaryError(
+                "authenticated browser plan has duplicate Sign-in Token identities"
             )
         seen_labels.add(label)
+        seen_tokens.add(sign_in_token)
+        seen_user_ids.add(user_id)
+        seen_profiles.add(normalized_profile)
         planned_tasks.append(
             {
-                **{key: value for key, value in task.items() if key != "task_origin"},
+                "label": label,
+                "user_id": user_id,
+                "profile": profile,
+                "sign_in_token": sign_in_token,
+                "sign_in_token_expires_at": expires_at,
                 "closure": closure,
             }
         )
@@ -671,18 +763,17 @@ def _build_browser_plan(
     if (
         isinstance(testing_token_expires_at, bool)
         or not isinstance(testing_token_expires_at, int)
-        or testing_token_expires_at - int(time.time())
-        < TESTING_TOKEN_MIN_REMAINING_SECONDS
+        or testing_token_expires_at - now < TESTING_TOKEN_MIN_REMAINING_SECONDS
     ):
         raise AuthCanaryError("authenticated browser plan has an expired Testing Token")
     return {
         "version": BROWSER_PLAN_VERSION,
         "api_base": api_base,
         "app_origin": app_origin,
-        "task_origin": task_origin,
+        "clerk_frontend_origin": clerk_frontend_origin,
         "testing_token": testing_token,
         "testing_token_expires_at": testing_token_expires_at,
-        "session_max_duration_seconds": SESSION_MAX_DURATION_SECONDS,
+        "session_token_max_lifetime_seconds": SESSION_TOKEN_MAX_LIFETIME_SECONDS,
         "tasks": planned_tasks,
     }
 
@@ -800,6 +891,8 @@ def _state_identities(
 
 
 def _state_task_ids(state: Mapping[str, Any]) -> list[str]:
+    """Load legacy Agent Task handles from state version 1."""
+
     task_ids = state.get("task_ids")
     if (
         not isinstance(task_ids, list)
@@ -814,45 +907,129 @@ def _state_task_ids(state: Mapping[str, Any]) -> list[str]:
     return task_ids
 
 
-def _cleanup_state(secret_key: str, state: Mapping[str, Any]) -> None:
+def _state_sign_in_tokens(state: Mapping[str, Any]) -> list[tuple[str, int]]:
+    raw_tokens = state.get("sign_in_tokens")
+    if not isinstance(raw_tokens, list) or len(raw_tokens) > 2:
+        raise AuthCanaryError("stored authenticated canary Sign-in Tokens are invalid")
+    tokens: list[tuple[str, int]] = []
+    now = int(time.time())
+    for raw in raw_tokens:
+        if not isinstance(raw, dict):
+            raise AuthCanaryError(
+                "stored authenticated canary Sign-in Tokens are invalid"
+            )
+        token_id = raw.get("id")
+        expires_at = raw.get("expires_at")
+        if (
+            not isinstance(token_id, str)
+            or not SIGN_IN_TOKEN_ID_PATTERN.fullmatch(token_id)
+            or isinstance(expires_at, bool)
+            or not isinstance(expires_at, int)
+            or expires_at <= 0
+            or expires_at
+            > now + SIGN_IN_TOKEN_DURATION_SECONDS + CAPABILITY_EXPIRY_GRACE_SECONDS
+        ):
+            raise AuthCanaryError(
+                "stored authenticated canary Sign-in Tokens are invalid"
+            )
+        tokens.append((token_id, expires_at))
+    if len({token_id for token_id, _ in tokens}) != len(tokens):
+        raise AuthCanaryError(
+            "stored authenticated canary Sign-in Tokens are duplicated"
+        )
+    return tokens
+
+
+def _cleanup_state(secret_key: str, state: Mapping[str, Any]) -> bool:
     identities = _state_identities(state)
-    task_ids = _state_task_ids(state)
+    version = state.get("version")
+    if version == 1:
+        task_ids = _state_task_ids(state)
+        sign_in_tokens: list[tuple[str, int]] = []
+        browser_completed = False
+    elif version == 2:
+        task_ids = []
+        sign_in_tokens = _state_sign_in_tokens(state)
+        if not isinstance(state.get("browser_completed"), bool):
+            raise AuthCanaryError(
+                "stored authenticated canary browser completion is invalid"
+            )
+        browser_completed = state["browser_completed"]
+    else:
+        raise AuthCanaryError("stored authenticated canary state version is invalid")
     baseline_zero = state.get("session_baseline_proven_zero") is True
-    if task_ids and not baseline_zero:
-        raise AuthCanaryError("stored task state lacks a proven clean session baseline")
+    if (task_ids or sign_in_tokens) and not baseline_zero:
+        raise AuthCanaryError(
+            "stored capability state lacks a proven clean session baseline"
+        )
 
     cleanup_errors: list[Exception] = []
-    expiry_guard_required = False
+    browser_closure_proven = True
+    legacy_expiry_guard_required = False
+    sign_in_expiry_deadline = 0
     # Retire one-use capabilities first, preventing a pending ticket from racing
     # the authoritative server-side session sweep.
     for task_id in task_ids:
         try:
-            expiry_guard_required = (
-                _retire_agent_task(secret_key, task_id) or expiry_guard_required
+            legacy_expiry_guard_required = (
+                _retire_agent_task(secret_key, task_id)
+                or legacy_expiry_guard_required
             )
+        except Exception as exc:  # noqa: BLE001 - cleanup must attempt every resource
+            cleanup_errors.append(exc)
+    for token_id, expires_at in sign_in_tokens:
+        try:
+            if _retire_sign_in_token(secret_key, token_id) and not browser_completed:
+                sign_in_expiry_deadline = max(sign_in_expiry_deadline, expires_at)
         except Exception as exc:  # noqa: BLE001 - cleanup must attempt every resource
             cleanup_errors.append(exc)
 
     if baseline_zero:
         live_sessions: set[str] = set()
+        live_sessions_by_label: dict[str, set[str]] = {}
         session_listing_failed = False
         for identity in identities:
             try:
-                live_sessions.update(_list_live_sessions(secret_key, identity.user_id))
+                identity_sessions = _list_live_sessions(
+                    secret_key, identity.user_id
+                )
+                live_sessions_by_label[identity.label] = identity_sessions
+                live_sessions.update(identity_sessions)
             except Exception as exc:  # noqa: BLE001 - cleanup continues after one API failure
                 cleanup_errors.append(exc)
                 session_listing_failed = True
+        if browser_completed and not session_listing_failed:
+            if live_sessions_by_label.get("A") or len(
+                live_sessions_by_label.get("B", set())
+            ) != 1:
+                browser_closure_proven = False
         for session_id in sorted(live_sessions):
             try:
                 _revoke_session(secret_key, session_id)
             except Exception as exc:  # noqa: BLE001 - cleanup continues after one API failure
                 cleanup_errors.append(exc)
 
-        if expiry_guard_required:
+        if legacy_expiry_guard_required:
             # Clerk guarantees these Agent Task sessions cannot outlive this
             # ceiling. Waiting after every ticket is no longer pending closes
             # the list-sessions visibility race even if the first samples lag.
-            time.sleep(SESSION_MAX_DURATION_SECONDS + SESSION_EXPIRY_GRACE_SECONDS)
+            time.sleep(
+                LEGACY_AGENT_SESSION_MAX_DURATION_SECONDS
+                + CAPABILITY_EXPIRY_GRACE_SECONDS
+            )
+        if sign_in_expiry_deadline:
+            # On an interrupted browser run, a 400/404 retirement result alone
+            # cannot prove the ticket inactive. Wait only to its persisted,
+            # conservative local deadline. The success-only browser marker
+            # proves both one-use tickets were consumed, so the normal path does
+            # not pay this wait and proceeds directly to the session sweep.
+            remaining = (
+                sign_in_expiry_deadline
+                + CAPABILITY_EXPIRY_GRACE_SECONDS
+                - time.time()
+            )
+            if remaining > 0:
+                time.sleep(remaining)
 
         # Require two consecutive empty server-side samples. If consumption won
         # a race with task retirement, a newly visible session is revoked here.
@@ -890,6 +1067,7 @@ def _cleanup_state(secret_key: str, state: Mapping[str, Any]) -> None:
         raise AuthCanaryError(
             "temporary Clerk canary state could not be proven inactive"
         )
+    return browser_closure_proven
 
 
 def _guardian_result_status(
@@ -1080,7 +1258,8 @@ def _load_secret(frontend_env: Path) -> str:
 
 
 def _cleanup_stored_lease(lease_dir: Path, secret_key: str) -> None:
-    # Never retain the one-use URL, including when Clerk cleanup is unavailable.
+    # Never retain one-use browser capabilities, including when Clerk cleanup is
+    # unavailable.
     _safe_unlink(lease_dir / PLAN_NAME)
     _safe_unlink(lease_dir / DONE_NAME)
     state_path = lease_dir / STATE_NAME
@@ -1113,24 +1292,24 @@ def _sweep_stale_leases(root: Path, secret_key: str) -> None:
         _remove_completed_lease(lease_dir)
 
 
-def _done_requested(lease_dir: Path) -> bool:
+def _browser_completion_status(lease_dir: Path) -> bool | None:
     path = lease_dir / DONE_NAME
     try:
-        metadata = path.lstat()
+        path.lstat()
     except FileNotFoundError:
-        return False
+        return None
     except OSError as exc:
         raise AuthCanaryError(
             "authenticated canary completion marker is unavailable"
         ) from exc
+    payload = _read_private_json(path)
     if (
-        stat.S_ISLNK(metadata.st_mode)
-        or not stat.S_ISREG(metadata.st_mode)
-        or metadata.st_uid != os.geteuid()
-        or metadata.st_mode & 0o077
+        set(payload) != {"version", "browser_passed"}
+        or payload.get("version") != 1
+        or not isinstance(payload.get("browser_passed"), bool)
     ):
-        raise AuthCanaryError("authenticated canary completion marker is unsafe")
-    return True
+        raise AuthCanaryError("authenticated canary completion marker is invalid")
+    return payload["browser_passed"]
 
 
 def _signal_handler(signum: int, _frame: Any) -> None:
@@ -1147,7 +1326,7 @@ def run_guardian(
     canary_env: Path,
     shared_dir: Path,
 ) -> bool:
-    if not 30 <= max_wait_seconds <= 600:
+    if not 30 <= max_wait_seconds <= GUARDIAN_MAX_WAIT_SECONDS:
         raise AuthCanaryError("authenticated canary guardian timeout is invalid")
     lease_id = _validate_lease_id(lease_id)
     api_base = _origin(api_base, "authenticated canary API")
@@ -1173,8 +1352,11 @@ def run_guardian(
         for value in configured_frontend_urls
         if value
     }
-    if not allowed_frontend_origins:
-        raise AuthCanaryError("a configured Clerk frontend origin is required")
+    if len(allowed_frontend_origins) != 1:
+        raise AuthCanaryError(
+            "exactly one configured Clerk frontend origin is required"
+        )
+    clerk_frontend_origin = next(iter(allowed_frontend_origins))
     configured_admin_ids = {
         value.strip()
         for value in api_values.get("CLERK_ADMIN_USER_IDS", "").split(",")
@@ -1194,10 +1376,11 @@ def run_guardian(
         _secure_directory(lease_dir, mode=0o700)
 
         state: dict[str, Any] = {
-            "version": 1,
+            "version": 2,
             "lease_id": lease_id,
             "phase": "preflight",
             "session_baseline_proven_zero": False,
+            "browser_completed": False,
             "identities": [
                 {
                     "label": identity.label,
@@ -1206,7 +1389,7 @@ def run_guardian(
                 }
                 for identity in identities
             ],
-            "task_ids": [],
+            "sign_in_tokens": [],
         }
         state_path = lease_dir / STATE_NAME
         _write_private_json(state_path, state)
@@ -1228,30 +1411,27 @@ def run_guardian(
             state["phase"] = "creating_testing_token"
             _write_private_json(state_path, state)
             testing_token, testing_token_expires_at = _create_testing_token(secret_key)
-            state["phase"] = "creating_tasks"
+            state["phase"] = "creating_sign_in_tokens"
             _write_private_json(state_path, state)
 
-            def record_task_id(task_id: str) -> None:
-                state["task_ids"].append(task_id)
+            def record_sign_in_token(token_id: str, expires_at: int) -> None:
+                state["sign_in_tokens"].append(
+                    {"id": token_id, "expires_at": expires_at}
+                )
                 _write_private_json(state_path, state)
 
             tasks = [
-                _create_agent_task(
+                _create_sign_in_token(
                     secret_key,
                     identity,
-                    allowed_frontend_origins=allowed_frontend_origins,
-                    app_origin=APP_ORIGIN,
-                    record_task_id=record_task_id,
+                    record_token=record_sign_in_token,
                 )
                 for identity in identities
             ]
-            task_origins = {task.get("task_origin") for task in tasks}
-            if len(task_origins) != 1:
-                raise AuthCanaryError("Clerk returned inconsistent task origins")
             plan = _build_browser_plan(
                 api_base=api_base,
                 app_origin=APP_ORIGIN,
-                task_origin=next(iter(task_origins)),
+                clerk_frontend_origin=clerk_frontend_origin,
                 testing_token=testing_token,
                 testing_token_expires_at=testing_token_expires_at,
                 tasks=tasks,
@@ -1261,12 +1441,17 @@ def run_guardian(
             _write_private_json(lease_dir / PLAN_NAME, plan)
 
             deadline = time.monotonic() + max_wait_seconds
-            while not _done_requested(lease_dir):
+            browser_passed = _browser_completion_status(lease_dir)
+            while browser_passed is None:
                 if time.monotonic() >= deadline:
                     raise AuthCanaryError(
                         "authenticated browser canary did not finish before its deadline"
                     )
                 time.sleep(0.5)
+                browser_passed = _browser_completion_status(lease_dir)
+            if not browser_passed:
+                raise AuthCanaryError("authenticated browser canary reported failure")
+            state["browser_completed"] = True
             state["phase"] = "verifying_database_provisioning"
             _write_private_json(state_path, state)
             _require_post_browser_provisioning(
@@ -1287,7 +1472,11 @@ def run_guardian(
                     except BaseException as exc:  # noqa: BLE001 - keep cleaning
                         cleanup_failures.append(exc)
                 try:
-                    _cleanup_state(secret_key, state)
+                    browser_closure_proven = _cleanup_state(secret_key, state)
+                    if not browser_closure_proven and primary_error is None:
+                        primary_error = AuthCanaryError(
+                            "browser closure state was not confirmed by Clerk"
+                        )
                 except BaseException as exc:  # noqa: BLE001 - retain failure state
                     cleanup_failures.append(exc)
 
@@ -1322,18 +1511,48 @@ def run_guardian(
         return True
 
 
-def signal_completion(*, lease_id: str, shared_dir: Path) -> None:
+def signal_completion(
+    *, lease_id: str, shared_dir: Path, browser_passed: bool = False
+) -> None:
+    if not isinstance(browser_passed, bool):
+        raise AuthCanaryError("authenticated canary completion result is invalid")
     lease_dir = _lease_directory(shared_dir, lease_id)
     _secure_directory(lease_dir, mode=0o700)
     marker = lease_dir / DONE_NAME
+    encoded = (
+        json.dumps(
+            {"version": 1, "browser_passed": browser_passed}, separators=(",", ":")
+        )
+        + "\n"
+    ).encode("utf-8")
+    if len(encoded) > MAX_STATE_BYTES:
+        raise AuthCanaryError("authenticated canary completion marker is too large")
+    descriptor = None
+    created = False
     try:
         descriptor = os.open(
             marker,
-            os.O_WRONLY | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_NOFOLLOW", 0),
             0o600,
         )
-        os.close(descriptor)
+        created = True
+        with os.fdopen(descriptor, "wb") as opened:
+            descriptor = None
+            opened.write(encoded)
+            opened.flush()
+            os.fsync(opened.fileno())
+        _fsync_directory(lease_dir)
     except OSError as exc:
+        if descriptor is not None:
+            os.close(descriptor)
+        if created:
+            try:
+                _safe_unlink(marker)
+            except AuthCanaryError:
+                pass
         raise AuthCanaryError(
             "authenticated canary completion could not be signalled"
         ) from exc
@@ -1400,6 +1619,7 @@ def main() -> int:
     complete = commands.add_parser("complete")
     complete.add_argument("--lease-id", required=True)
     complete.add_argument("--shared-dir", type=Path, default=DEFAULT_SHARED_DIR)
+    complete.add_argument("--browser-passed", action="store_true")
 
     status_command = commands.add_parser("status")
     status_command.add_argument("--lease-id", required=True)
@@ -1426,7 +1646,11 @@ def main() -> int:
             )
             print("authenticated production canary guardian passed")
         elif args.command == "complete":
-            signal_completion(lease_id=args.lease_id, shared_dir=args.shared_dir)
+            signal_completion(
+                lease_id=args.lease_id,
+                shared_dir=args.shared_dir,
+                browser_passed=args.browser_passed,
+            )
         elif args.command == "status":
             print(lease_status(lease_id=args.lease_id, shared_dir=args.shared_dir))
         else:

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -7,6 +7,7 @@ import os
 import stat
 import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -436,10 +437,10 @@ class ProductionCanaryTests(unittest.TestCase):
             auth_canary._CLERK_OPENER, "open", return_value=Opened()
         ) as open_request:
             auth_canary._request(
-                "https://api.clerk.com/v1/agents/tasks",
+                "https://api.clerk.com/v1/sign_in_tokens",
                 method="POST",
                 bearer="sk_live_test",
-                payload={"permissions": "*"},
+                payload={"user_id": "user_A123", "expires_in_seconds": 300},
                 clerk_backend=True,
             )
         request = open_request.call_args.args[0]
@@ -509,43 +510,106 @@ class ProductionCanaryTests(unittest.TestCase):
                         "sk_live_test", "user_A123", "active"
                     )
 
-    def test_authenticated_canary_records_task_id_before_url_validation(self):
+    def test_authenticated_canary_records_sign_in_token_before_ticket_export(self):
         identity = auth_canary.CanaryIdentity("A", "user_A123", "alpha")
         response = auth_canary.HttpResponse(
             200,
             json.dumps(
                 {
-                    "agent_task_id": "agent_task_A123456",
-                    "url": "https://evil.example/v1/agent-tasks/ticket",
+                    "object": "sign_in_token",
+                    "id": "sit_A123456",
+                    "status": "pending",
+                    "user_id": "user_A123",
+                    "token": "too-short",
+                    "url": "https://example.invalid/ignored",
                 }
             ).encode("utf-8"),
             {"Content-Type": "application/json"},
         )
-        recorded: list[str] = []
+        recorded: list[tuple[str, int]] = []
         with (
+            mock.patch.object(auth_canary.time, "time", return_value=1_700_000_000),
             mock.patch.object(
                 auth_canary, "_request", return_value=response
             ) as request,
-            self.assertRaisesRegex(auth_canary.AuthCanaryError, "unsafe task URL"),
+            self.assertRaisesRegex(auth_canary.AuthCanaryError, "invalid Sign-in Token"),
         ):
-            auth_canary._create_agent_task(
+            auth_canary._create_sign_in_token(
                 "sk_live_test",
                 identity,
-                allowed_frontend_origins={"https://clerk.spyboxd.com"},
-                app_origin="https://spyboxd.com",
-                record_task_id=recorded.append,
+                record_token=lambda token_id, expires_at: recorded.append(
+                    (token_id, expires_at)
+                ),
             )
-        self.assertEqual(recorded, ["agent_task_A123456"])
+        self.assertEqual(recorded, [("sit_A123456", 1_700_000_300)])
         self.assertEqual(
-            request.call_args.kwargs["payload"]["session_max_duration_in_seconds"],
-            auth_canary.SESSION_MAX_DURATION_SECONDS,
+            request.call_args.args[0],
+            "https://api.clerk.com/v1/sign_in_tokens",
         )
         self.assertEqual(
-            request.call_args.kwargs["payload"]["redirect_url"],
-            "https://spyboxd.com/",
+            request.call_args.kwargs["payload"],
+            {
+                "user_id": "user_A123",
+                "expires_in_seconds": auth_canary.SIGN_IN_TOKEN_DURATION_SECONDS,
+            },
+        )
+        self.assertNotIn("redirect_url", request.call_args.kwargs["payload"])
+
+    def test_authenticated_canary_exports_only_the_valid_one_use_ticket(self):
+        identity = auth_canary.CanaryIdentity("A", "user_A123", "alpha")
+        ticket = f"ticket-a-{'a' * 32}"
+        response = auth_canary.HttpResponse(
+            200,
+            json.dumps(
+                {
+                    "object": "sign_in_token",
+                    "id": "sit_A123456",
+                    "status": "pending",
+                    "user_id": "user_A123",
+                    "token": ticket,
+                    "url": "https://example.invalid/not-a-contract-input",
+                    "future_field": "ignored",
+                }
+            ).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        recorded: list[tuple[str, int]] = []
+        events: list[str] = []
+        clock_values = iter((1_700_000_000, 1_700_000_012))
+
+        def request_after_clock(*_args, **_kwargs):
+            events.append("request")
+            return response
+
+        def request_clock() -> int:
+            events.append("clock")
+            return next(clock_values)
+
+        with (
+            mock.patch.object(auth_canary.time, "time", side_effect=request_clock),
+            mock.patch.object(auth_canary, "_request", side_effect=request_after_clock),
+        ):
+            exported = auth_canary._create_sign_in_token(
+                "sk_live_test",
+                identity,
+                record_token=lambda token_id, expires_at: recorded.append(
+                    (token_id, expires_at)
+                ),
+            )
+        self.assertEqual(recorded, [("sit_A123456", 1_700_000_312)])
+        self.assertEqual(events, ["clock", "request", "clock"])
+        self.assertEqual(
+            exported,
+            {
+                "label": "A",
+                "user_id": "user_A123",
+                "profile": "alpha",
+                "sign_in_token": ticket,
+                "sign_in_token_expires_at": 1_700_000_300,
+            },
         )
 
-    def test_authenticated_canary_creates_bounded_production_testing_token(self):
+    def test_authenticated_canary_creates_sufficiently_lived_production_testing_token(self):
         response = auth_canary.HttpResponse(
             200,
             json.dumps(
@@ -573,76 +637,128 @@ class ProductionCanaryTests(unittest.TestCase):
         self.assertEqual(request.call_args.kwargs["method"], "POST")
         self.assertNotIn("payload", request.call_args.kwargs)
 
+        # Clerk documents Testing Tokens as short-lived but does not promise a
+        # maximum lifetime. A longer valid response must not create a brittle
+        # production-only failure.
+        longer_response = auth_canary.HttpResponse(
+            200,
+            json.dumps(
+                {
+                    "object": "testing_token",
+                    "token": f"testing-{'b' * 48}",
+                    "expires_at": 1_700_086_400,
+                }
+            ).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        with (
+            mock.patch.object(auth_canary.time, "time", return_value=1_700_000_000),
+            mock.patch.object(auth_canary, "_request", return_value=longer_response),
+        ):
+            _, longer_expiry = auth_canary._create_testing_token("sk_live_test")
+        self.assertEqual(longer_expiry, 1_700_086_400)
+
     def test_authenticated_browser_plan_assigns_sign_out_and_expiry_proofs(self):
+        now = int(auth_canary.time.time())
         tasks = [
             {
                 "label": "A",
                 "user_id": "user_A123",
                 "profile": "alpha",
-                "task_url": "https://clerk.spyboxd.com/task-a",
-                "task_origin": "https://clerk.spyboxd.com",
+                "sign_in_token": f"ticket-a-{'a' * 32}",
+                "sign_in_token_expires_at": now + 300,
             },
             {
                 "label": "B",
                 "user_id": "user_B123",
                 "profile": "beta",
-                "task_url": "https://clerk.spyboxd.com/task-b",
-                "task_origin": "https://clerk.spyboxd.com",
+                "sign_in_token": f"ticket-b-{'b' * 32}",
+                "sign_in_token_expires_at": now + 300,
             },
         ]
         plan = auth_canary._build_browser_plan(
             api_base="https://api.spyboxd.com",
             app_origin="https://spyboxd.com",
-            task_origin="https://clerk.spyboxd.com",
+            clerk_frontend_origin="https://clerk.spyboxd.com",
             testing_token=f"testing-{'a' * 48}",
-            testing_token_expires_at=int(auth_canary.time.time()) + 600,
+            testing_token_expires_at=now + 600,
             tasks=tasks,
         )
         self.assertEqual(plan["version"], auth_canary.BROWSER_PLAN_VERSION)
         self.assertEqual(
-            plan["session_max_duration_seconds"],
-            auth_canary.SESSION_MAX_DURATION_SECONDS,
+            plan["session_token_max_lifetime_seconds"],
+            auth_canary.SESSION_TOKEN_MAX_LIFETIME_SECONDS,
         )
+        self.assertEqual(plan["clerk_frontend_origin"], "https://clerk.spyboxd.com")
         self.assertEqual(plan["testing_token"], f"testing-{'a' * 48}")
         self.assertEqual(
             [task["closure"] for task in plan["tasks"]],
-            ["sign_out", "session_expiry"],
+            ["sign_out", "jwt_expiry"],
         )
+        self.assertNotIn("task_url", plan["tasks"][0])
+        self.assertNotIn("task_origin", plan)
         self.assertNotIn("closure", tasks[0])
         self.assertNotIn("closure", tasks[1])
 
     def test_authenticated_browser_plan_rejects_duplicate_or_inconsistent_tasks(self):
+        now = int(auth_canary.time.time())
         base = {
             "label": "A",
             "user_id": "user_A123",
             "profile": "alpha",
-            "task_url": "https://clerk.spyboxd.com/task-a",
-            "task_origin": "https://clerk.spyboxd.com",
+            "sign_in_token": f"ticket-a-{'a' * 32}",
+            "sign_in_token_expires_at": now + 300,
         }
         with self.assertRaisesRegex(auth_canary.AuthCanaryError, "task labels"):
             auth_canary._build_browser_plan(
                 api_base="https://api.spyboxd.com",
                 app_origin="https://spyboxd.com",
-                task_origin="https://clerk.spyboxd.com",
+                clerk_frontend_origin="https://clerk.spyboxd.com",
                 testing_token=f"testing-{'a' * 48}",
-                testing_token_expires_at=int(auth_canary.time.time()) + 600,
-                tasks=[base, {**base, "user_id": "user_B123", "profile": "beta"}],
+                testing_token_expires_at=now + 600,
+                tasks=[
+                    base,
+                    {
+                        **base,
+                        "user_id": "user_B123",
+                        "profile": "beta",
+                        "sign_in_token": f"ticket-b-{'b' * 32}",
+                    },
+                ],
             )
-        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "task origins"):
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "duplicate Sign-in Tokens"):
             auth_canary._build_browser_plan(
                 api_base="https://api.spyboxd.com",
                 app_origin="https://spyboxd.com",
-                task_origin="https://clerk.spyboxd.com",
+                clerk_frontend_origin="https://clerk.spyboxd.com",
                 testing_token=f"testing-{'a' * 48}",
-                testing_token_expires_at=int(auth_canary.time.time()) + 600,
+                testing_token_expires_at=now + 600,
                 tasks=[
                     base,
                     {
                         "label": "B",
                         "user_id": "user_B123",
                         "profile": "beta",
-                        "task_url": "https://clerk.spyboxd.com/task-b",
-                        "task_origin": "https://other.example",
+                        "sign_in_token": base["sign_in_token"],
+                        "sign_in_token_expires_at": now + 300,
+                    },
+                ],
+            )
+        with self.assertRaisesRegex(auth_canary.AuthCanaryError, "invalid Sign-in Token identity"):
+            auth_canary._build_browser_plan(
+                api_base="https://api.spyboxd.com",
+                app_origin="https://spyboxd.com",
+                clerk_frontend_origin="https://clerk.spyboxd.com",
+                testing_token=f"testing-{'a' * 48}",
+                testing_token_expires_at=now + 600,
+                tasks=[
+                    base,
+                    {
+                        "label": "B",
+                        "user_id": "user_B123",
+                        "profile": "beta",
+                        "sign_in_token": f"ticket-b-{'b' * 32}",
+                        "sign_in_token_expires_at": now + 30,
                     },
                 ],
             )
@@ -673,7 +789,7 @@ class ProductionCanaryTests(unittest.TestCase):
             )
         list_sessions.assert_called_once_with("sk_live_test", "user_A123", "active")
 
-    def test_cleanup_retires_tasks_and_re_lists_every_new_session(self):
+    def test_legacy_cleanup_retires_tasks_and_re_lists_every_new_session(self):
         state = {
             "version": 1,
             "lease_id": "gha-123-1",
@@ -702,7 +818,8 @@ class ProductionCanaryTests(unittest.TestCase):
             mock.patch.object(auth_canary, "_revoke_session") as revoke,
             mock.patch.object(auth_canary.time, "sleep"),
         ):
-            auth_canary._cleanup_state("sk_live_test", state)
+            closure_proven = auth_canary._cleanup_state("sk_live_test", state)
+        self.assertTrue(closure_proven)
         self.assertEqual(retire.call_count, 2)
         self.assertEqual(list_sessions.call_count, 6)
         self.assertEqual(
@@ -710,24 +827,176 @@ class ProductionCanaryTests(unittest.TestCase):
             {"sess_A123", "sess_B123"},
         )
 
-    def test_failed_cleanup_removes_plan_but_retains_recoverable_state(self):
+    def test_completed_ticket_cleanup_sweeps_sessions_without_ttl_wait(self):
         state = {
-            "version": 1,
+            "version": 2,
             "lease_id": "gha-123-1",
-            "phase": "waiting_for_browser",
+            "phase": "verifying_database_provisioning",
             "session_baseline_proven_zero": True,
+            "browser_completed": True,
             "identities": [
                 {"label": "A", "user_id": "user_A123", "profile": "alpha"},
                 {"label": "B", "user_id": "user_B123", "profile": "beta"},
             ],
-            "task_ids": ["agent_task_A123456"],
+            "sign_in_tokens": [
+                {"id": "sit_A123456", "expires_at": 1_700_000_300},
+                {"id": "sit_B123456", "expires_at": 1_700_000_300},
+            ],
+        }
+        with (
+            mock.patch.object(auth_canary.time, "time", return_value=1_700_000_000),
+            mock.patch.object(
+                auth_canary, "_retire_sign_in_token", return_value=True
+            ) as retire,
+            mock.patch.object(
+                auth_canary,
+                "_list_live_sessions",
+                side_effect=[
+                    set(),
+                    {"sess_B123"},
+                    set(),
+                    set(),
+                    set(),
+                    set(),
+                ],
+            ) as list_sessions,
+            mock.patch.object(auth_canary, "_revoke_session") as revoke,
+            mock.patch.object(auth_canary.time, "sleep") as sleep,
+        ):
+            closure_proven = auth_canary._cleanup_state("sk_live_test", state)
+        self.assertTrue(closure_proven)
+        self.assertEqual(retire.call_count, 2)
+        self.assertEqual(list_sessions.call_count, 6)
+        self.assertEqual(
+            {call.args[1] for call in revoke.call_args_list},
+            {"sess_B123"},
+        )
+        self.assertFalse(any(call.args[0] > 1 for call in sleep.call_args_list))
+
+    def test_completed_cleanup_fails_if_server_closure_state_is_wrong(self):
+        state = {
+            "version": 2,
+            "lease_id": "gha-123-1",
+            "phase": "verifying_database_provisioning",
+            "session_baseline_proven_zero": True,
+            "browser_completed": True,
+            "identities": [
+                {"label": "A", "user_id": "user_A123", "profile": "alpha"},
+                {"label": "B", "user_id": "user_B123", "profile": "beta"},
+            ],
+            "sign_in_tokens": [
+                {"id": "sit_A123456", "expires_at": 1_700_000_300},
+                {"id": "sit_B123456", "expires_at": 1_700_000_300},
+            ],
+        }
+        for initial_sessions in (
+            ({"sess_A123"}, {"sess_B123"}),
+            (set(), set()),
+            (set(), {"sess_B123", "sess_B456"}),
+        ):
+            with (
+                self.subTest(initial_sessions=initial_sessions),
+                mock.patch.object(
+                    auth_canary.time, "time", return_value=1_700_000_000
+                ),
+                mock.patch.object(
+                    auth_canary, "_retire_sign_in_token", return_value=True
+                ),
+                mock.patch.object(
+                    auth_canary,
+                    "_list_live_sessions",
+                    side_effect=[
+                        *initial_sessions,
+                        set(),
+                        set(),
+                        set(),
+                        set(),
+                    ],
+                ),
+                mock.patch.object(auth_canary, "_revoke_session") as revoke,
+                mock.patch.object(auth_canary.time, "sleep"),
+            ):
+                closure_proven = auth_canary._cleanup_state("sk_live_test", state)
+            self.assertFalse(closure_proven)
+            self.assertEqual(
+                {call.args[1] for call in revoke.call_args_list},
+                set().union(*initial_sessions),
+            )
+
+    def test_interrupted_ticket_cleanup_waits_to_expiry_then_sweeps_again(self):
+        state = {
+            "version": 2,
+            "lease_id": "gha-123-1",
+            "phase": "waiting_for_browser",
+            "session_baseline_proven_zero": True,
+            "browser_completed": False,
+            "identities": [
+                {"label": "A", "user_id": "user_A123", "profile": "alpha"},
+                {"label": "B", "user_id": "user_B123", "profile": "beta"},
+            ],
+            "sign_in_tokens": [
+                {"id": "sit_A123456", "expires_at": 1_700_000_300},
+                {"id": "sit_B123456", "expires_at": 1_700_000_300},
+            ],
+        }
+        with (
+            mock.patch.object(auth_canary.time, "time", return_value=1_700_000_000),
+            mock.patch.object(
+                auth_canary, "_retire_sign_in_token", return_value=True
+            ) as retire,
+            mock.patch.object(
+                auth_canary,
+                "_list_live_sessions",
+                side_effect=[
+                    set(),
+                    set(),
+                    {"sess_late"},
+                    set(),
+                    set(),
+                    set(),
+                    set(),
+                    set(),
+                ],
+            ) as list_sessions,
+            mock.patch.object(auth_canary, "_revoke_session") as revoke,
+            mock.patch.object(auth_canary.time, "sleep") as sleep,
+        ):
+            auth_canary._cleanup_state("sk_live_test", state)
+        self.assertEqual(retire.call_count, 2)
+        self.assertEqual(list_sessions.call_count, 8)
+        revoke.assert_called_once_with("sk_live_test", "sess_late")
+        self.assertEqual(
+            sleep.call_args_list[0],
+            mock.call(
+                auth_canary.SIGN_IN_TOKEN_DURATION_SECONDS
+                + auth_canary.CAPABILITY_EXPIRY_GRACE_SECONDS
+            ),
+        )
+
+    def test_failed_cleanup_removes_plan_but_retains_recoverable_state(self):
+        state = {
+            "version": 2,
+            "lease_id": "gha-123-1",
+            "phase": "waiting_for_browser",
+            "session_baseline_proven_zero": True,
+            "browser_completed": False,
+            "identities": [
+                {"label": "A", "user_id": "user_A123", "profile": "alpha"},
+                {"label": "B", "user_id": "user_B123", "profile": "beta"},
+            ],
+            "sign_in_tokens": [
+                {"id": "sit_A123456", "expires_at": 1_700_000_300}
+            ],
         }
         with tempfile.TemporaryDirectory() as temporary_directory:
             lease = Path(temporary_directory)
             auth_canary._write_private_json(lease / auth_canary.STATE_NAME, state)
             auth_canary._write_private_json(
                 lease / auth_canary.PLAN_NAME,
-                {"version": 1, "task_url": "https://clerk.example/one-use"},
+                {
+                    "version": 4,
+                    "sign_in_token": f"ticket-a-{'a' * 32}",
+                },
             )
             with (
                 mock.patch.object(
@@ -741,6 +1010,43 @@ class ProductionCanaryTests(unittest.TestCase):
             self.assertFalse((lease / auth_canary.PLAN_NAME).exists())
             retained = auth_canary._read_private_json(lease / auth_canary.STATE_NAME)
             self.assertEqual(retained["phase"], "cleanup_failed")
+
+    def test_completion_marker_is_private_explicit_and_single_assignment(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            shared_dir = Path(temporary_directory)
+            shared_dir.chmod(0o750)
+            lease_dir = auth_canary._lease_root(shared_dir) / "gha-123-1"
+            lease_dir.mkdir(mode=0o700)
+
+            self.assertIsNone(auth_canary._browser_completion_status(lease_dir))
+            auth_canary.signal_completion(
+                lease_id="gha-123-1",
+                shared_dir=shared_dir,
+            )
+            marker = lease_dir / auth_canary.DONE_NAME
+            self.assertEqual(stat.S_IMODE(marker.stat().st_mode), 0o600)
+            self.assertIs(auth_canary._browser_completion_status(lease_dir), False)
+            with self.assertRaisesRegex(
+                auth_canary.AuthCanaryError, "could not be signalled"
+            ):
+                auth_canary.signal_completion(
+                    lease_id="gha-123-1",
+                    shared_dir=shared_dir,
+                    browser_passed=True,
+                )
+            self.assertIs(auth_canary._browser_completion_status(lease_dir), False)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            shared_dir = Path(temporary_directory)
+            shared_dir.chmod(0o750)
+            lease_dir = auth_canary._lease_root(shared_dir) / "gha-456-1"
+            lease_dir.mkdir(mode=0o700)
+            auth_canary.signal_completion(
+                lease_id="gha-456-1",
+                shared_dir=shared_dir,
+                browser_passed=True,
+            )
+            self.assertIs(auth_canary._browser_completion_status(lease_dir), True)
 
     def test_guardian_status_distinguishes_primary_and_cleanup_failures(self):
         primary = auth_canary.AuthCanaryError("browser failed")
@@ -756,7 +1062,133 @@ class ProductionCanaryTests(unittest.TestCase):
             auth_canary._guardian_result_status(primary, cleanup), "cleanup_failed"
         )
 
-    def test_consumed_agent_task_is_safe_only_for_the_exact_clerk_error(self):
+    def test_sign_in_token_retirement_distinguishes_revoked_and_ambiguous(self):
+        revoked = auth_canary.HttpResponse(
+            200,
+            json.dumps(
+                {
+                    "object": "sign_in_token",
+                    "id": "sit_A123456",
+                    "status": "revoked",
+                }
+            ).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        ambiguous = auth_canary.HttpResponse(
+            400,
+            json.dumps(
+                {
+                    "errors": [
+                        {"code": "sign_in_token_cannot_be_revoked_code"}
+                    ]
+                }
+            ).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        missing = auth_canary.HttpResponse(404, b"{}", {})
+        with mock.patch.object(auth_canary, "_request", return_value=revoked):
+            self.assertFalse(
+                auth_canary._retire_sign_in_token(
+                    "sk_live_test",
+                    "sit_A123456",
+                )
+            )
+        for response in (ambiguous, missing):
+            with self.subTest(status=response.status), mock.patch.object(
+                auth_canary, "_request", return_value=response
+            ):
+                self.assertTrue(
+                    auth_canary._retire_sign_in_token(
+                        "sk_live_test",
+                        "sit_A123456",
+                    )
+                )
+
+        unexpected = auth_canary.HttpResponse(
+            400,
+            json.dumps({"errors": [{"code": "unexpected"}]}).encode("utf-8"),
+            {"Content-Type": "application/json"},
+        )
+        with (
+            mock.patch.object(auth_canary, "_request", return_value=unexpected),
+            self.assertRaisesRegex(
+                auth_canary.AuthCanaryError, "could not be proven inactive"
+            ),
+        ):
+            auth_canary._retire_sign_in_token(
+                "sk_live_test",
+                "sit_A123456",
+            )
+
+    def test_auth_canary_bounds_postgres_waits_without_breaking_sqlite_tests(self):
+        expected_postgres = {
+            "pool_pre_ping": True,
+            "connect_args": {
+                "connect_timeout": auth_canary.DATABASE_CONNECT_TIMEOUT_SECONDS,
+                "options": (
+                    "-c statement_timeout="
+                    f"{auth_canary.DATABASE_STATEMENT_TIMEOUT_MILLISECONDS} "
+                    "-c lock_timeout="
+                    f"{auth_canary.DATABASE_LOCK_TIMEOUT_MILLISECONDS}"
+                ),
+            },
+        }
+        self.assertEqual(
+            auth_canary._database_engine_options(
+                "postgresql+psycopg://spyboxd:secret@database:5432/spyboxd"
+            ),
+            expected_postgres,
+        )
+        self.assertEqual(
+            auth_canary._database_engine_options(
+                "postgres://spyboxd:secret@database:5432/spyboxd"
+            ),
+            expected_postgres,
+        )
+        self.assertEqual(
+            auth_canary._database_engine_options("sqlite+pysqlite:///:memory:"),
+            {"pool_pre_ping": True},
+        )
+        with self.assertRaisesRegex(
+            auth_canary.AuthCanaryError, "database backend is unsupported"
+        ):
+            auth_canary._database_engine_options("mysql://database/spyboxd")
+
+        database_url = (
+            "postgresql+psycopg://spyboxd:secret@database:5432/spyboxd"
+        )
+        identities = (
+            auth_canary.CanaryIdentity("A", "user_A123", "alpha"),
+            auth_canary.CanaryIdentity("B", "user_B123", "beta"),
+        )
+        engine = mock.MagicMock()
+        connection = engine.connect.return_value.__enter__.return_value
+        query_results = []
+        for rows in ([], [], [], []):
+            result = mock.MagicMock()
+            result.mappings.return_value.all.return_value = rows
+            query_results.append(result)
+        connection.execute.side_effect = query_results
+        create_engine = mock.Mock(return_value=engine)
+        sqlalchemy_module = types.ModuleType("sqlalchemy")
+        sqlalchemy_module.create_engine = create_engine
+        sqlalchemy_module.text = lambda statement: statement
+        with (
+            mock.patch.dict(sys.modules, {"sqlalchemy": sqlalchemy_module}),
+            mock.patch.object(
+                auth_canary,
+                "_validate_database_rows",
+                return_value=auth_canary.DATABASE_STATE_BOOTSTRAP,
+            ),
+        ):
+            self.assertEqual(
+                auth_canary._database_preflight(database_url, identities, set()),
+                auth_canary.DATABASE_STATE_BOOTSTRAP,
+            )
+        create_engine.assert_called_once_with(database_url, **expected_postgres)
+        engine.dispose.assert_called_once_with()
+
+    def test_legacy_consumed_agent_task_remains_recoverable(self):
         response = auth_canary.HttpResponse(
             400,
             json.dumps({"errors": [{"code": "agent_task_cannot_be_revoked"}]}).encode(

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -148,21 +148,47 @@ class WorkflowControlsTests(unittest.TestCase):
         guardian = read_repo_file("deploy/run-production-auth-canary.py")
         browser = read_repo_file("frontend/scripts/run-production-auth-canary.mjs")
 
-        self.assertIn('"redirect_url": f"{app_origin}/"', guardian)
+        self.assertIn('"https://api.clerk.com/v1/sign_in_tokens"', guardian)
+        self.assertIn(
+            '"expires_in_seconds": SIGN_IN_TOKEN_DURATION_SECONDS', guardian
+        )
         self.assertIn('"https://api.clerk.com/v1/testing_tokens"', guardian)
         self.assertIn('"testing_token": testing_token', guardian)
         self.assertIn("return \"cleanup_failed\"", guardian)
         self.assertIn("setupClerkTestingToken", browser)
         self.assertIn("installClerkTestingToken", browser)
         self.assertIn("::add-mask::${secret}", browser)
+        self.assertIn("clerk.client.signIn.create", browser)
+        self.assertIn("strategy: 'ticket'", browser)
+        self.assertIn("await clerk.setActive", browser)
         self.assertLess(
-            browser.index("maskSecret(testingToken);"),
+            browser.index("openClerkCapabilityScope(testingToken, signInTokens)"),
+            browser.index("await installClerkTestingToken("),
+        )
+        self.assertLess(
+            browser.index("await consumeSignInTicket("),
+            browser.index("await Promise.all(runtimes.map"),
+        )
+        self.assertLess(
+            browser.index("add(testingToken);"),
             browser.index("process.env.CLERK_TESTING_TOKEN = testingToken;"),
         )
-        self.assertIn("__clerk_testing_token", browser)
+        self.assertNotIn("__clerk_testing_token", browser)
+        self.assertNotIn("task_url", browser)
         self.assertIn("clerk.session.getToken()", browser)
         self.assertIn("`${taskContract.appOrigin}/profiles`", browser)
         self.assertNotIn("CLERK_SECRET_KEY: ${{", workflow)
+        self.assertIn('chmod 0600 "${plan_file}"', workflow)
+        self.assertIn('shred --force --iterations=1 --zero --remove -- "${path}"', workflow)
+        self.assertIn("timeout --signal=TERM --kill-after=15s 12m", workflow)
+        self.assertIn("--plan \"${plan_file}\"", workflow)
+        self.assertIn("if (( browser_status == 0 ));", workflow)
+        self.assertIn("signal_guardian passed", workflow)
+        self.assertIn("--browser-passed", workflow)
+        self.assertIn("signal_guardian failed", workflow)
+        self.assertIn('>/dev/null 2>&1 || true', workflow)
+        self.assertEqual(workflow.count('--expected-revision "${EXPECTED_REVISION}"'), 2)
+        self.assertEqual(workflow.count('[[ "${EXPECTED_REVISION}" == "${GITHUB_SHA}" ]]'), 2)
         self.assertIn('"${guardian_status}" == cleanup_failed', workflow)
         self.assertLess(
             workflow.index('"${guardian_status}" == cleanup_failed'),

--- a/frontend/scripts/run-production-auth-canary.mjs
+++ b/frontend/scripts/run-production-auth-canary.mjs
@@ -11,16 +11,18 @@ const USER_ID = /^user_[A-Za-z0-9]+$/;
 const SESSION_ID = /^sess_[A-Za-z0-9]+$/;
 const PROFILE = /^[A-Za-z0-9_]{2,15}$/;
 const TESTING_TOKEN = /^[A-Za-z0-9._~-]{20,2048}$/;
-const BROWSER_PLAN_VERSION = 3;
-const EXPECTED_SESSION_MAX_DURATION_SECONDS = 120;
+const SIGN_IN_TOKEN = /^[A-Za-z0-9._~-]{20,4096}$/;
+const CLERK_CAPABILITY = /^[A-Za-z0-9._~-]{20,8192}$/;
+const BROWSER_PLAN_VERSION = 4;
+const EXPECTED_SESSION_TOKEN_MAX_LIFETIME_SECONDS = 90;
 const TESTING_TOKEN_MIN_REMAINING_SECONDS = 180;
-// Clerk issues these for one hour; permit only two minutes of host clock skew.
-const TESTING_TOKEN_MAX_REMAINING_SECONDS = 3720;
+const SIGN_IN_TOKEN_MIN_REMAINING_SECONDS = 120;
+const SIGN_IN_TOKEN_CONSUMPTION_MARGIN_SECONDS = 30;
+const SIGN_IN_OPERATION_TIMEOUT_MILLISECONDS = 45_000;
 const JWT_EXPIRY_GRACE_SECONDS = 5;
-const SESSION_EXPIRY_GRACE_SECONDS = 15;
 const MAX_EXPIRY_OVERHEAD_SECONDS = 30;
 const PRIVATE_PROOF_PATH = '/profiles';
-const CLOSURES = new Set(['sign_out', 'session_expiry']);
+const CLOSURES = new Set(['sign_out', 'jwt_expiry']);
 
 class CanaryError extends Error {}
 
@@ -29,10 +31,10 @@ function fail(message) {
 }
 
 function argumentsFromCommandLine() {
-  if (process.argv.length !== 4 || process.argv[2] !== '--tasks' || !process.argv[3]) {
-    fail('Usage: run-production-auth-canary.mjs --tasks <file>');
+  if (process.argv.length !== 4 || process.argv[2] !== '--plan' || !process.argv[3]) {
+    fail('Usage: run-production-auth-canary.mjs --plan <file>');
   }
-  return { tasksPath: process.argv[3] };
+  return { planPath: process.argv[3] };
 }
 
 async function readBoundedJson(path, label) {
@@ -102,92 +104,97 @@ export function validateTasks(payload, nowSeconds = Math.floor(Date.now() / 1000
   if (
     !payload
     || payload.version !== BROWSER_PLAN_VERSION
-    || payload.session_max_duration_seconds !== EXPECTED_SESSION_MAX_DURATION_SECONDS
+    || payload.session_token_max_lifetime_seconds
+      !== EXPECTED_SESSION_TOKEN_MAX_LIFETIME_SECONDS
     || !TESTING_TOKEN.test(payload.testing_token ?? '')
     || !Number.isSafeInteger(payload.testing_token_expires_at)
     || payload.testing_token_expires_at - nowSeconds < TESTING_TOKEN_MIN_REMAINING_SECONDS
-    || payload.testing_token_expires_at - nowSeconds > TESTING_TOKEN_MAX_REMAINING_SECONDS
     || !Array.isArray(payload.tasks)
   ) {
-    fail('authenticated canary task contract is invalid');
+    fail('authenticated canary browser plan is invalid');
   }
   const apiBase = bareHttpsOrigin(payload.api_base, 'API base');
   const appOrigin = bareHttpsOrigin(payload.app_origin, 'application origin');
-  const taskOrigin = bareHttpsOrigin(payload.task_origin, 'Clerk task origin');
+  const clerkFrontendOrigin = bareHttpsOrigin(
+    payload.clerk_frontend_origin,
+    'Clerk frontend origin',
+  );
   if (apiBase !== 'https://api.spyboxd.com' || appOrigin !== 'https://spyboxd.com') {
     fail('authenticated canary targets an unexpected production origin');
   }
   if (payload.tasks.length !== 2) {
-    fail('authenticated canary requires exactly two tasks');
+    fail('authenticated canary requires exactly two identities');
   }
   const labels = new Set();
   const userIds = new Set();
   const profiles = new Set();
   const closures = new Set();
+  const signInTokens = new Set();
   for (const task of payload.tasks) {
-    let taskUrl;
-    try {
-      taskUrl = new URL(task?.task_url);
-    } catch {
-      fail('Clerk returned an invalid Agent Task URL');
-    }
     if (
       !['A', 'B'].includes(task?.label)
       || !CLOSURES.has(task?.closure)
       || !USER_ID.test(task?.user_id ?? '')
       || !PROFILE.test(task?.profile ?? '')
-      || taskUrl.protocol !== 'https:'
-      || taskUrl.username
-      || taskUrl.password
-      || taskUrl.hash
-      || taskUrl.origin !== taskOrigin
+      || !SIGN_IN_TOKEN.test(task?.sign_in_token ?? '')
+      || !Number.isSafeInteger(task?.sign_in_token_expires_at)
+      || task.sign_in_token_expires_at - nowSeconds
+        < SIGN_IN_TOKEN_MIN_REMAINING_SECONDS
     ) {
-      fail('authenticated canary task identity is invalid');
+      fail('authenticated canary identity is invalid');
     }
     labels.add(task.label);
     userIds.add(task.user_id);
     profiles.add(task.profile.toLowerCase());
     closures.add(task.closure);
+    signInTokens.add(task.sign_in_token);
   }
   if (
     labels.size !== 2
     || userIds.size !== 2
     || profiles.size !== 2
     || closures.size !== 2
+    || signInTokens.size !== 2
   ) {
-    fail('authenticated canary tasks are not isolated identities');
+    fail('authenticated canary identities are not isolated');
   }
   return {
     apiBase,
     appOrigin,
-    taskOrigin,
+    clerkFrontendOrigin,
     testingToken: payload.testing_token,
     testingTokenExpiresAt: payload.testing_token_expires_at,
-    sessionMaxDurationSeconds: payload.session_max_duration_seconds,
+    sessionTokenMaxLifetimeSeconds: payload.session_token_max_lifetime_seconds,
     tasks: payload.tasks,
   };
 }
 
 export function registerGitHubSecretMask(secret) {
-  if (process.env.GITHUB_ACTIONS !== 'true' || !TESTING_TOKEN.test(secret ?? '')) {
-    fail('Clerk production Testing Token masking is unavailable');
+  if (
+    process.env.GITHUB_ACTIONS !== 'true'
+    || !CLERK_CAPABILITY.test(secret ?? '')
+  ) {
+    fail('Clerk temporary capability masking is unavailable');
   }
   process.stdout.write(`::add-mask::${secret}\n`);
 }
 
-function redactClerkDiagnostic(value, testingToken) {
+function redactClerkDiagnostic(value, secrets) {
+  const redact = (text) => secrets.reduce(
+    (result, secret) => result.replaceAll(secret, '[REDACTED_CLERK_CAPABILITY]'),
+    text,
+  );
   if (typeof value === 'string') {
-    return value.replaceAll(testingToken, '[REDACTED_TESTING_TOKEN]');
+    return redact(value);
   }
   if (value instanceof Error) {
-    const redacted = new Error(
-      value.message.replaceAll(testingToken, '[REDACTED_TESTING_TOKEN]'),
-    );
+    const redacted = new Error(redact(value.message));
     redacted.name = value.name;
     return redacted;
   }
   try {
-    if (JSON.stringify(value)?.includes(testingToken)) {
+    const serialized = JSON.stringify(value);
+    if (secrets.some((secret) => serialized?.includes(secret))) {
       return '[REDACTED_CLERK_DIAGNOSTIC]';
     }
   } catch {
@@ -196,71 +203,149 @@ function redactClerkDiagnostic(value, testingToken) {
   return value;
 }
 
-export async function installClerkTestingToken(
-  context,
-  taskUrl,
-  taskOrigin,
+export function openClerkCapabilityScope(
   testingToken,
-  setupClerkTestingToken,
+  additionalCapabilities = [],
   maskSecret = registerGitHubSecretMask,
 ) {
   if (
-    typeof setupClerkTestingToken !== 'function'
-    || typeof maskSecret !== 'function'
+    typeof maskSecret !== 'function'
     || !TESTING_TOKEN.test(testingToken ?? '')
+    || !Array.isArray(additionalCapabilities)
+    || additionalCapabilities.some((value) => !SIGN_IN_TOKEN.test(value ?? ''))
     || process.env.CLERK_TESTING_TOKEN !== undefined
     || process.env.CLERK_TESTING_DEBUG !== undefined
   ) {
     fail('Clerk production Testing Token setup is invalid');
   }
-  const parsedTask = new URL(taskUrl);
-  const parsedOrigin = new URL(taskOrigin);
-  if (parsedTask.origin !== parsedOrigin.origin || parsedOrigin.pathname !== '/') {
-    fail('Clerk production Testing Token targets an invalid origin');
-  }
 
-  maskSecret(testingToken);
+  const redactedCapabilities = [];
+  const knownCapabilities = new Set();
+  const add = (capability) => {
+    if (!CLERK_CAPABILITY.test(capability ?? '')) {
+      fail('Clerk temporary capability is invalid');
+    }
+    if (!knownCapabilities.has(capability)) {
+      maskSecret(capability);
+      knownCapabilities.add(capability);
+      redactedCapabilities.push(capability);
+    }
+  };
+  add(testingToken);
+  additionalCapabilities.forEach(add);
   const originalWarn = console.warn;
   const originalError = console.error;
   console.warn = (...values) => originalWarn(
-    ...values.map((value) => redactClerkDiagnostic(value, testingToken)),
+    ...values.map((value) => redactClerkDiagnostic(value, redactedCapabilities)),
   );
   console.error = (...values) => originalError(
-    ...values.map((value) => redactClerkDiagnostic(value, testingToken)),
+    ...values.map((value) => redactClerkDiagnostic(value, redactedCapabilities)),
   );
   process.env.CLERK_TESTING_TOKEN = testingToken;
-  let installed = false;
-  try {
-    await setupClerkTestingToken({
-      context,
-      options: { frontendApiUrl: parsedOrigin.host },
-    });
-    // The official helper parses JSON FAPI responses. Agent Task consumption
-    // is a one-use document navigation, so handle that exact URL separately
-    // while still using the helper for every subsequent ClerkJS request.
-    await context.route(taskUrl, async (route) => {
-      const requestUrl = new URL(route.request().url());
-      requestUrl.searchParams.set('__clerk_testing_token', testingToken);
-      await route.continue({ url: requestUrl.toString() });
-    }, { times: 1 });
-    installed = true;
-  } finally {
-    if (!installed) {
-      delete process.env.CLERK_TESTING_TOKEN;
-      console.warn = originalWarn;
-      console.error = originalError;
-    }
-  }
 
-  let cleared = false;
-  return () => {
-    if (!cleared) {
-      cleared = true;
+  let closed = false;
+  return {
+    add,
+    close() {
+      if (closed) return;
+      closed = true;
       delete process.env.CLERK_TESTING_TOKEN;
       console.warn = originalWarn;
       console.error = originalError;
-    }
+      redactedCapabilities.length = 0;
+      knownCapabilities.clear();
+    },
   };
+}
+
+export async function installClerkTestingToken(
+  context,
+  clerkFrontendOrigin,
+  testingToken,
+  setupClerkTestingToken,
+) {
+  if (
+    typeof setupClerkTestingToken !== 'function'
+    || !TESTING_TOKEN.test(testingToken ?? '')
+    || process.env.CLERK_TESTING_TOKEN !== testingToken
+    || process.env.CLERK_TESTING_DEBUG !== undefined
+  ) {
+    fail('Clerk production Testing Token context setup is invalid');
+  }
+  const parsedOrigin = new URL(
+    bareHttpsOrigin(clerkFrontendOrigin, 'Clerk frontend origin'),
+  );
+  await setupClerkTestingToken({
+    context,
+    options: { frontendApiUrl: parsedOrigin.host },
+  });
+}
+
+export async function consumeSignInTicket(
+  page,
+  signInToken,
+  maskSecret = registerGitHubSecretMask,
+) {
+  if (
+    !SIGN_IN_TOKEN.test(signInToken ?? '')
+    || typeof maskSecret !== 'function'
+  ) {
+    fail('Clerk Sign-in Token setup is invalid');
+  }
+  maskSecret(signInToken);
+  let oneUseTicket = signInToken;
+  try {
+    await page.waitForFunction(
+      () => Boolean(globalThis.Clerk?.loaded),
+      undefined,
+      { timeout: 30_000 },
+    );
+    const outcome = await page.evaluate(
+      async ({ ticket, timeoutMilliseconds }) => {
+        let timeoutId;
+        try {
+          return await Promise.race([
+            (async () => {
+              try {
+                const clerk = globalThis.Clerk;
+                if (!clerk?.loaded || typeof clerk.client?.signIn?.create !== 'function') {
+                  return 'sdk_unavailable';
+                }
+                const signIn = await clerk.client.signIn.create({
+                  strategy: 'ticket',
+                  ticket,
+                });
+                if (signIn?.status !== 'complete' || !signIn.createdSessionId) {
+                  return 'sign_in_incomplete';
+                }
+                await clerk.setActive({ session: signIn.createdSessionId });
+                return 'complete';
+              } catch {
+                return 'sign_in_failed';
+              }
+            })(),
+            new Promise((resolveTimeout) => {
+              timeoutId = globalThis.setTimeout(
+                () => resolveTimeout('sign_in_timeout'),
+                timeoutMilliseconds,
+              );
+            }),
+          ]);
+        } finally {
+          if (timeoutId !== undefined) globalThis.clearTimeout(timeoutId);
+        }
+      },
+      {
+        ticket: oneUseTicket,
+        timeoutMilliseconds: SIGN_IN_OPERATION_TIMEOUT_MILLISECONDS,
+      },
+    );
+    if (outcome !== 'complete') {
+      fail('Clerk did not consume the one-use Sign-in Token');
+    }
+  } finally {
+    oneUseTicket = undefined;
+  }
 }
 
 export function decodeSession(token, nowSeconds = Math.floor(Date.now() / 1000)) {
@@ -289,27 +374,25 @@ export function decodeSession(token, nowSeconds = Math.floor(Date.now() / 1000))
 }
 
 export function expiryProofDeadlineMilliseconds(
-  sessionStartedAtMilliseconds,
+  tokenCapturedAtMilliseconds,
   tokenExpiresAtSeconds,
-  sessionMaxDurationSeconds,
+  sessionTokenMaxLifetimeSeconds,
 ) {
   if (
-    !Number.isSafeInteger(sessionStartedAtMilliseconds)
-    || sessionStartedAtMilliseconds <= 0
+    !Number.isSafeInteger(tokenCapturedAtMilliseconds)
+    || tokenCapturedAtMilliseconds <= 0
     || !Number.isSafeInteger(tokenExpiresAtSeconds)
-    || !Number.isSafeInteger(sessionMaxDurationSeconds)
-    || sessionMaxDurationSeconds !== EXPECTED_SESSION_MAX_DURATION_SECONDS
+    || !Number.isSafeInteger(sessionTokenMaxLifetimeSeconds)
+    || sessionTokenMaxLifetimeSeconds
+      !== EXPECTED_SESSION_TOKEN_MAX_LIFETIME_SECONDS
   ) {
     fail('authenticated canary expiry inputs are invalid');
   }
-  const tokenDeadline = (tokenExpiresAtSeconds + JWT_EXPIRY_GRACE_SECONDS) * 1000;
-  const sessionDeadline = sessionStartedAtMilliseconds
-    + ((sessionMaxDurationSeconds + SESSION_EXPIRY_GRACE_SECONDS) * 1000);
-  const proofDeadline = Math.max(tokenDeadline, sessionDeadline);
-  const maximumDeadline = sessionStartedAtMilliseconds
-    + ((sessionMaxDurationSeconds + MAX_EXPIRY_OVERHEAD_SECONDS) * 1000);
-  if (proofDeadline > maximumDeadline) {
-    fail('Clerk JWT expiry exceeds the bounded Agent Task session');
+  const proofDeadline = (tokenExpiresAtSeconds + JWT_EXPIRY_GRACE_SECONDS) * 1000;
+  const maximumDeadline = tokenCapturedAtMilliseconds
+    + ((sessionTokenMaxLifetimeSeconds + MAX_EXPIRY_OVERHEAD_SECONDS) * 1000);
+  if (proofDeadline <= tokenCapturedAtMilliseconds || proofDeadline > maximumDeadline) {
+    fail('Clerk JWT expiry exceeds the canary wait bound');
   }
   return proofDeadline;
 }
@@ -565,28 +648,27 @@ export async function proveSignOutClosure(page, context, apiBase, appOrigin, lab
   await proveAnonymousPrivateBoundary(page, context, apiBase, appOrigin, label);
 }
 
-async function proveSessionExpiryClosure(
+export async function proveJwtExpiryClosure(
   page,
   context,
   apiBase,
-  appOrigin,
   label,
   token,
-  sessionStartedAtMilliseconds,
+  tokenCapturedAtMilliseconds,
   tokenExpiresAtSeconds,
-  sessionMaxDurationSeconds,
+  sessionTokenMaxLifetimeSeconds,
 ) {
-  // Clerk refreshes short-lived cookie JWTs while the browser session is live.
-  // Waiting past both the captured JWT exp and the Agent Task session ceiling
-  // proves the backend expiry check and the frontend's eventual signed-out state.
+  // This proves the API rejects the exact captured bearer after its exp. It does
+  // not claim the ordinary browser session expired: the VPS guardian separately
+  // revokes that session and requires two empty server-side samples.
   const proofDeadline = expiryProofDeadlineMilliseconds(
-    sessionStartedAtMilliseconds,
+    tokenCapturedAtMilliseconds,
     tokenExpiresAtSeconds,
-    sessionMaxDurationSeconds,
+    sessionTokenMaxLifetimeSeconds,
   );
   const remainingMilliseconds = proofDeadline - Date.now();
   const maximumWaitMilliseconds = (
-    sessionMaxDurationSeconds + MAX_EXPIRY_OVERHEAD_SECONDS
+    sessionTokenMaxLifetimeSeconds + MAX_EXPIRY_OVERHEAD_SECONDS
   ) * 1000;
   if (remainingMilliseconds > maximumWaitMilliseconds) {
     fail(`${label} expiry proof exceeded its bounded wait`);
@@ -604,20 +686,30 @@ async function proveSessionExpiryClosure(
     `${label} expired JWT boundary`,
   );
   requireDetail(expiredMe, 'Token has expired', `${label} expired JWT boundary`);
-  await proveAnonymousPrivateBoundary(page, context, apiBase, appOrigin, label);
 }
 
 async function main() {
-  const { tasksPath } = argumentsFromCommandLine();
-  const taskContract = validateTasks(await readBoundedJson(tasksPath, 'task file'));
+  const { planPath } = argumentsFromCommandLine();
+  const taskContract = validateTasks(await readBoundedJson(planPath, 'browser plan'));
 
   const [{ chromium }, { setupClerkTestingToken }] = await Promise.all([
     import('playwright'),
     import('@clerk/testing/playwright'),
   ]);
   let browser;
+  let capabilityScope;
+  let testingToken = taskContract.testingToken;
+  const runtimes = [];
   try {
     browser = await chromium.launch({ headless: true });
+    const signInTokens = taskContract.tasks.map((task) => task.sign_in_token);
+    capabilityScope = openClerkCapabilityScope(testingToken, signInTokens);
+    signInTokens.length = 0;
+    taskContract.testingToken = undefined;
+
+    // Consume both jointly-created tickets before any slower profile/API/UI
+    // assertions. This removes the possibility that identity B's one-use
+    // capability expires while identity A is being validated.
     for (let index = 0; index < taskContract.tasks.length; index += 1) {
       const task = taskContract.tasks[index];
       const other = taskContract.tasks[1 - index];
@@ -625,85 +717,133 @@ async function main() {
         acceptDownloads: false,
         serviceWorkers: 'block',
       });
-      let clearTestingToken;
-      let token;
+      const runtime = {
+        task,
+        other,
+        context,
+        page: undefined,
+        token: undefined,
+        tokenCapturedAtMilliseconds: undefined,
+        session: undefined,
+      };
+      runtimes.push(runtime);
+      await installClerkTestingToken(
+        context,
+        taskContract.clerkFrontendOrigin,
+        testingToken,
+        setupClerkTestingToken,
+      );
+      const page = await context.newPage();
+      runtime.page = page;
+      await page.goto(taskContract.appOrigin, {
+        waitUntil: 'domcontentloaded',
+        timeout: 45_000,
+      });
+      if (
+        task.sign_in_token_expires_at - Math.floor(Date.now() / 1000)
+        < SIGN_IN_TOKEN_CONSUMPTION_MARGIN_SECONDS
+      ) {
+        fail(`canary ${task.label} Sign-in Token is too close to expiry`);
+      }
+      const signInToken = task.sign_in_token;
       try {
-        clearTestingToken = await installClerkTestingToken(
-          context,
-          task.task_url,
-          taskContract.taskOrigin,
-          taskContract.testingToken,
-          setupClerkTestingToken,
-        );
-        const page = await context.newPage();
-        await page.goto(task.task_url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
-        await page.waitForURL(
-          (url) => url.origin === taskContract.appOrigin
-            && url.pathname === '/',
-          { timeout: 45_000 },
-        );
-        token = await applicationSessionToken(page, context, taskContract.appOrigin);
-        // The one-time Clerk handoff may take time. Starting the natural-expiry
-        // proof only after the application can retrieve a token is
-        // conservative: it cannot declare expiry while the bounded Agent Task
-        // session is still live.
-        const sessionEstablishedAtMilliseconds = Date.now();
-        const session = decodeSession(token);
-        if (session.userId !== task.user_id) {
-          fail(`Clerk Agent Task resolved the wrong canary ${task.label} identity`);
-        }
-        await page.goto(`${taskContract.appOrigin}/profiles`, {
-          waitUntil: 'domcontentloaded',
-          timeout: 45_000,
-        });
-        await page.waitForURL(
-          (url) => url.origin === taskContract.appOrigin
-            && url.pathname === '/profiles'
-            && !url.search
-            && !url.hash,
-          { timeout: 45_000 },
-        );
-        await validateIdentity(context, taskContract.apiBase, task, other, token);
-        if (task.closure === 'sign_out') {
-          await proveSignOutClosure(
-            page,
-            context,
-            taskContract.apiBase,
-            taskContract.appOrigin,
-            `canary ${task.label}`,
-          );
-        } else if (task.closure === 'session_expiry') {
-          await proveSessionExpiryClosure(
-            page,
-            context,
-            taskContract.apiBase,
-            taskContract.appOrigin,
-            `canary ${task.label}`,
-            token,
-            sessionEstablishedAtMilliseconds,
-            session.expiresAtSeconds,
-            taskContract.sessionMaxDurationSeconds,
-          );
-        } else {
-          fail(`canary ${task.label} has an unsupported closure proof`);
-        }
+        await consumeSignInTicket(page, signInToken, capabilityScope.add);
       } finally {
-        token = undefined;
+        task.sign_in_token = undefined;
+      }
+      const token = await applicationSessionToken(
+        page,
+        context,
+        taskContract.appOrigin,
+      );
+      capabilityScope.add(token);
+      runtime.token = token;
+      runtime.tokenCapturedAtMilliseconds = Date.now();
+      runtime.session = decodeSession(token);
+      if (runtime.session.userId !== task.user_id) {
+        fail(`Clerk resolved the wrong canary ${task.label} identity`);
+      }
+    }
+
+    await Promise.all(runtimes.map(async (runtime) => {
+      const {
+        task,
+        other,
+        context,
+        page,
+        token,
+        tokenCapturedAtMilliseconds,
+        session,
+      } = runtime;
+      if (!page || !token || !session || !tokenCapturedAtMilliseconds) {
+        fail(`canary ${task.label} browser session was not established`);
+      }
+      await page.goto(`${taskContract.appOrigin}/profiles`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 45_000,
+      });
+      await page.waitForURL(
+        (url) => url.origin === taskContract.appOrigin
+          && url.pathname === '/profiles'
+          && !url.search
+          && !url.hash,
+        { timeout: 45_000 },
+      );
+      await validateIdentity(context, taskContract.apiBase, task, other, token);
+      if (task.closure === 'sign_out') {
+        await proveSignOutClosure(
+          page,
+          context,
+          taskContract.apiBase,
+          taskContract.appOrigin,
+          `canary ${task.label}`,
+        );
+      } else if (task.closure === 'jwt_expiry') {
+        await proveJwtExpiryClosure(
+          page,
+          context,
+          taskContract.apiBase,
+          `canary ${task.label}`,
+          token,
+          tokenCapturedAtMilliseconds,
+          session.expiresAtSeconds,
+          taskContract.sessionTokenMaxLifetimeSeconds,
+        );
+      } else {
+        fail(`canary ${task.label} has an unsupported closure proof`);
+      }
+    }));
+  } finally {
+    testingToken = undefined;
+    for (const task of taskContract.tasks) {
+      task.sign_in_token = undefined;
+    }
+    let cleanupFailed = false;
+    for (const runtime of runtimes.reverse()) {
+      runtime.token = undefined;
+      if (runtime.context) {
         try {
-          await context.clearCookies();
-          await context.close();
-        } finally {
-          clearTestingToken?.();
+          await runtime.context.clearCookies();
+          await runtime.context.close();
+        } catch {
+          cleanupFailed = true;
         }
       }
     }
-  } finally {
+    capabilityScope?.close();
     if (browser) {
-      await browser.close();
+      try {
+        await browser.close();
+      } catch {
+        cleanupFailed = true;
+      }
+    }
+    if (cleanupFailed) {
+      fail('browser canary context cleanup failed');
     }
   }
   process.stdout.write(
-    'authenticated production canary passed: two-user isolation, sign-out, and natural expiry proven\n',
+    'authenticated browser canary passed: two-user isolation, sign-out, and captured JWT expiry proven\n',
   );
 }
 

--- a/frontend/scripts/run-production-auth-canary.test.mjs
+++ b/frontend/scripts/run-production-auth-canary.test.mjs
@@ -4,16 +4,19 @@ import { setupClerkTestingToken as realSetupClerkTestingToken } from '@clerk/tes
 
 import {
   applicationSessionToken,
+  consumeSignInTicket,
   decodeSession,
   expiryProofDeadlineMilliseconds,
   installClerkTestingToken,
   isPrivateSignInRedirect,
+  openClerkCapabilityScope,
+  proveJwtExpiryClosure,
   proveSignOutClosure,
   validateTasks,
 } from './run-production-auth-canary.mjs';
 
 const APP_ORIGIN = 'https://spyboxd.com';
-const TASK_ORIGIN = 'https://clerk.spyboxd.com';
+const CLERK_FRONTEND_ORIGIN = 'https://clerk.spyboxd.com';
 
 function task(label, closure, userId, profile) {
   return {
@@ -21,22 +24,23 @@ function task(label, closure, userId, profile) {
     closure,
     user_id: userId,
     profile,
-    task_url: `${TASK_ORIGIN}/v1/agent-tasks/${label.toLowerCase()}-ticket`,
+    sign_in_token: `ticket-${label.toLowerCase()}-${label.toLowerCase().repeat(48)}`,
+    sign_in_token_expires_at: Math.floor(Date.now() / 1000) + 300,
   };
 }
 
 function plan() {
   return {
-    version: 3,
+    version: 4,
     api_base: 'https://api.spyboxd.com',
     app_origin: APP_ORIGIN,
-    task_origin: TASK_ORIGIN,
+    clerk_frontend_origin: CLERK_FRONTEND_ORIGIN,
     testing_token: `testing-${'a'.repeat(48)}`,
     testing_token_expires_at: Math.floor(Date.now() / 1000) + 600,
-    session_max_duration_seconds: 120,
+    session_token_max_lifetime_seconds: 90,
     tasks: [
       task('A', 'sign_out', 'user_A123', 'alpha'),
-      task('B', 'session_expiry', 'user_B123', 'beta'),
+      task('B', 'jwt_expiry', 'user_B123', 'beta'),
     ],
   };
 }
@@ -48,87 +52,87 @@ function token(payload) {
   return `${encodedHeader}.${encodedPayload}.${'s'.repeat(96)}`;
 }
 
-test('browser plan requires distinct sign-out and natural-expiry closures', () => {
+test('browser plan requires distinct sign-out and captured-JWT-expiry closures', () => {
   const contract = validateTasks(plan());
-  assert.equal(contract.sessionMaxDurationSeconds, 120);
-  assert.deepEqual(contract.tasks.map((item) => item.closure), ['sign_out', 'session_expiry']);
+  assert.equal(contract.sessionTokenMaxLifetimeSeconds, 90);
+  assert.deepEqual(contract.tasks.map((item) => item.closure), ['sign_out', 'jwt_expiry']);
 
   const duplicated = plan();
   duplicated.tasks[1].closure = 'sign_out';
-  assert.throws(() => validateTasks(duplicated), /not isolated identities/);
+  assert.throws(() => validateTasks(duplicated), /not isolated/);
 
   const wrongDuration = plan();
-  wrongDuration.session_max_duration_seconds = 1800;
-  assert.throws(() => validateTasks(wrongDuration), /task contract is invalid/);
+  wrongDuration.session_token_max_lifetime_seconds = 1800;
+  assert.throws(() => validateTasks(wrongDuration), /browser plan is invalid/);
 
   const expiredTestingToken = plan();
   expiredTestingToken.testing_token_expires_at = Math.floor(Date.now() / 1000) + 30;
-  assert.throws(() => validateTasks(expiredTestingToken), /task contract is invalid/);
+  assert.throws(() => validateTasks(expiredTestingToken), /browser plan is invalid/);
+
+  const expiringTicket = plan();
+  expiringTicket.tasks[1].sign_in_token_expires_at = Math.floor(Date.now() / 1000) + 30;
+  assert.throws(() => validateTasks(expiringTicket), /identity is invalid/);
+
+  const duplicateTicket = plan();
+  duplicateTicket.tasks[1].sign_in_token = duplicateTicket.tasks[0].sign_in_token;
+  assert.throws(() => validateTasks(duplicateTicket), /not isolated/);
+
+  const undocumentedTestingTokenLifetime = plan();
+  undocumentedTestingTokenLifetime.testing_token_expires_at += 86_400;
+  assert.doesNotThrow(() => validateTasks(undocumentedTestingTokenLifetime));
 });
 
-test('Clerk Testing Token is installed before one-use task navigation and cleared', async () => {
+test('Clerk Testing Token and one-use ticket are masked before helper setup', async () => {
   const events = [];
   const diagnostics = [];
-  let taskHandler;
-  const context = {
-    async route(url, handler, options) {
-      events.push(['route', url, options]);
-      taskHandler = handler;
-    },
-  };
+  const context = {};
   const testingToken = `testing-${'b'.repeat(48)}`;
-  const taskUrl = `${TASK_ORIGIN}/v1/agent-tasks/a-ticket`;
+  const signInToken = `ticket-${'d'.repeat(48)}`;
   const originalWarn = console.warn;
   const originalError = console.error;
   console.warn = (...values) => diagnostics.push(values.map(String).join(' '));
   console.error = (...values) => diagnostics.push(values.map(String).join(' '));
-  let clear;
+  let capabilityScope;
   try {
-    clear = await installClerkTestingToken(
+    capabilityScope = openClerkCapabilityScope(
+      testingToken,
+      [signInToken],
+      (secret) => events.push(['mask', secret]),
+    );
+    await installClerkTestingToken(
       context,
-      taskUrl,
-      TASK_ORIGIN,
+      CLERK_FRONTEND_ORIGIN,
       testingToken,
       async (options) => {
         assert.equal(options.context, context);
         assert.deepEqual(options.options, { frontendApiUrl: 'clerk.spyboxd.com' });
         assert.equal(process.env.CLERK_TESTING_TOKEN, testingToken);
         console.warn(`Clerk retry URL contained ${testingToken}`);
-        console.error(new Error(`Clerk route failed with ${testingToken}`));
+        console.error(new Error(`Clerk route failed with ${signInToken}`));
         events.push(['setup']);
       },
-      (secret) => events.push(['mask', secret]),
     );
     assert.deepEqual(events, [
       ['mask', testingToken],
+      ['mask', signInToken],
       ['setup'],
-      ['route', taskUrl, { times: 1 }],
     ]);
-
-    let continuedUrl;
-    await taskHandler({
-      request: () => ({ url: () => taskUrl }),
-      continue: async ({ url }) => { continuedUrl = new URL(url); },
-    });
-    assert.equal(continuedUrl.origin, TASK_ORIGIN);
-    assert.equal(continuedUrl.pathname, '/v1/agent-tasks/a-ticket');
-    assert.equal(continuedUrl.searchParams.get('__clerk_testing_token'), testingToken);
   } finally {
-    clear?.();
+    capabilityScope?.close();
     console.warn = originalWarn;
     console.error = originalError;
   }
   assert.equal(process.env.CLERK_TESTING_TOKEN, undefined);
   assert.equal(diagnostics.some((line) => line.includes(testingToken)), false);
+  assert.equal(diagnostics.some((line) => line.includes(signInToken)), false);
   assert.equal(
-    diagnostics.filter((line) => line.includes('[REDACTED_TESTING_TOKEN]')).length,
+    diagnostics.filter((line) => line.includes('[REDACTED_CLERK_CAPABILITY]')).length,
     2,
   );
 });
 
 test('real Clerk helper failure diagnostics cannot expose the production Testing Token', async () => {
   const testingToken = `testing-${'c'.repeat(48)}`;
-  const taskUrl = `${TASK_ORIGIN}/v1/agent-tasks/a-ticket`;
   const handlers = [];
   const context = {
     async route(matcher, handler) {
@@ -143,21 +147,24 @@ test('real Clerk helper failure diagnostics cannot expose the production Testing
     callback();
     return 0;
   };
-  let clear;
+  let capabilityScope;
   try {
-    clear = await installClerkTestingToken(
-      context,
-      taskUrl,
-      TASK_ORIGIN,
+    capabilityScope = openClerkCapabilityScope(
       testingToken,
-      realSetupClerkTestingToken,
+      [],
       () => {},
     );
-    assert.equal(handlers.length, 2);
+    await installClerkTestingToken(
+      context,
+      CLERK_FRONTEND_ORIGIN,
+      testingToken,
+      realSetupClerkTestingToken,
+    );
+    assert.equal(handlers.length, 1);
     const fapiHandler = handlers[0].handler;
     let fetches = 0;
     await fapiHandler({
-      request: () => ({ url: () => `${TASK_ORIGIN}/v1/client` }),
+      request: () => ({ url: () => `${CLERK_FRONTEND_ORIGIN}/v1/client` }),
       fetch: async ({ url }) => {
         fetches += 1;
         throw new Error(`simulated FAPI failure for ${url}`);
@@ -166,14 +173,62 @@ test('real Clerk helper failure diagnostics cannot expose the production Testing
     });
     assert.equal(fetches, 4);
   } finally {
-    clear?.();
+    capabilityScope?.close();
     console.warn = originalWarn;
     globalThis.setTimeout = originalSetTimeout;
   }
   assert.equal(process.env.CLERK_TESTING_TOKEN, undefined);
   assert.equal(diagnostics.length, 1);
   assert.equal(diagnostics[0].includes(testingToken), false);
-  assert.match(diagnostics[0], /REDACTED_TESTING_TOKEN/);
+  assert.match(diagnostics[0], /REDACTED_CLERK_CAPABILITY/);
+});
+
+test('Sign-in ticket uses ClerkJS ticket strategy and activates the session', async () => {
+  const events = [];
+  const signInToken = `ticket-${'e'.repeat(48)}`;
+  const originalClerk = globalThis.Clerk;
+  const page = {
+    async waitForFunction() { events.push('clerk-loaded'); },
+    async evaluate(callback, ticketValue) {
+      assert.deepEqual(ticketValue, {
+        ticket: signInToken,
+        timeoutMilliseconds: 45_000,
+      });
+      globalThis.Clerk = {
+        loaded: true,
+        client: {
+          signIn: {
+            async create(input) {
+              assert.deepEqual(input, { strategy: 'ticket', ticket: signInToken });
+              events.push('ticket-consumed');
+              return { status: 'complete', createdSessionId: 'sess_A123' };
+            },
+          },
+        },
+        async setActive(input) {
+          assert.deepEqual(input, { session: 'sess_A123' });
+          events.push('session-activated');
+        },
+      };
+      try {
+        return await callback(ticketValue);
+      } finally {
+        if (originalClerk === undefined) delete globalThis.Clerk;
+        else globalThis.Clerk = originalClerk;
+      }
+    },
+  };
+  await consumeSignInTicket(
+    page,
+    signInToken,
+    (secret) => events.push(`masked:${secret === signInToken}`),
+  );
+  assert.deepEqual(events, [
+    'masked:true',
+    'clerk-loaded',
+    'ticket-consumed',
+    'session-activated',
+  ]);
 });
 
 test('session token contract requires a future expiry and session identity', () => {
@@ -240,16 +295,58 @@ test('application session handoff prefers Clerk SDK token with a cookie fallback
   ), cookieToken);
 });
 
-test('expiry proof deadline covers both JWT and Agent Task session expiry', () => {
-  const sessionStartedAt = 1_000_000;
+test('expiry proof deadline covers only the captured JWT within a strict bound', () => {
+  const tokenCapturedAt = 1_000_000;
   assert.equal(
-    expiryProofDeadlineMilliseconds(sessionStartedAt, 1_060, 120),
-    1_135_000,
+    expiryProofDeadlineMilliseconds(tokenCapturedAt, 1_060, 90),
+    1_065_000,
   );
   assert.throws(
-    () => expiryProofDeadlineMilliseconds(sessionStartedAt, 1_200, 120),
-    /JWT expiry exceeds the bounded Agent Task session/,
+    () => expiryProofDeadlineMilliseconds(tokenCapturedAt, 1_200, 90),
+    /JWT expiry exceeds the canary wait bound/,
   );
+});
+
+test('JWT closure proves the fixed bearer expired without claiming browser sign-out', async () => {
+  const now = Date.now();
+  const expiry = Math.floor(now / 1000) + 60;
+  const events = [];
+  const page = {
+    async waitForTimeout(milliseconds) {
+      assert.ok(milliseconds > 0 && milliseconds <= 120_000);
+      events.push('waited-for-jwt-expiry');
+    },
+  };
+  const context = {
+    request: {
+      async get(url, options) {
+        assert.equal(url, 'https://api.spyboxd.com/api/me');
+        assert.equal(options.headers.Authorization, 'Bearer captured-jwt');
+        events.push('expired-bearer-rejected');
+        return {
+          status: () => 401,
+          body: async () => Buffer.from(JSON.stringify({
+            detail: 'Token has expired',
+          })),
+        };
+      },
+    },
+  };
+
+  await proveJwtExpiryClosure(
+    page,
+    context,
+    'https://api.spyboxd.com',
+    'canary B',
+    'captured-jwt',
+    now,
+    expiry,
+    90,
+  );
+  assert.deepEqual(events, [
+    'waited-for-jwt-expiry',
+    'expired-bearer-rejected',
+  ]);
 });
 
 test('private redirect proof remains exact and same-origin', () => {


### PR DESCRIPTION
## What changed

- replace unreliable Clerk Agent Task browser handoff with documented one-use Sign-in Tokens plus a production Testing Token
- mask both tickets before browser work, establish both isolated users promptly, and bound every browser/Node/guardian/database wait
- prove own-profile access, cross-user/global/admin denial, real UI sign-out, fixed-JWT expiry, server-side A/B session state, revocation, and two empty cleanup samples
- preserve cleanup compatibility for interrupted legacy Agent Task leases
- recheck the exact deployed revision before credentials and after authenticated isolation
- keep the Clerk secret on the VPS and securely remove temporary plans and identity material

## Validation

- 242 backend tests passed; 3 optional PostgreSQL tests skipped
- 112 deployment/workflow tests passed; 5 expected platform/database skips
- 10 Node canary tests passed
- 82 desktop/mobile Playwright tests passed
- frontend lint, typecheck, and production build passed
- Compose build/start/health/migration smoke passed
- runtime npm audit and locked Python dependency audit passed
- Zizmor medium+ scan and independent security/workflow reviews found no remaining blockers