### PR TITLE
Add unique-films count to monthly watching activity

### DIFF
--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -30,7 +30,7 @@ def _format_month_bucket(year: int, month: int) -> str:
 
 RATING_MIN = 0.0
 RATING_MAX = 5.0
-DASHBOARD_SNAPSHOT_FORMAT_VERSION = 2
+DASHBOARD_SNAPSHOT_FORMAT_VERSION = 3
 DASHBOARD_ACTIVITY_MONTHS = 12
 
 
@@ -845,6 +845,7 @@ class RatingRepository:
             year_bucket.label("year"),
             month_bucket.label("month"),
             func.count(WatchEvent.id).label("watch_count"),
+            func.count(func.distinct(WatchEvent.movie_id)).label("unique_movie_count"),
             func.avg(valid_rating).label("avg_rating"),
         ).filter(
             WatchEvent.watched_date >= window_start,
@@ -865,9 +866,10 @@ class RatingRepository:
         activity_by_month = {
             _format_month_bucket(year, month): {
                 "movies_watched": int(watch_count),
+                "unique_movies": int(unique_movie_count),
                 "average_rating": _safe_round(avg_rating, 2),
             }
-            for year, month, watch_count, avg_rating in results
+            for year, month, watch_count, unique_movie_count, avg_rating in results
         }
 
         activity = []
@@ -880,6 +882,9 @@ class RatingRepository:
                     "month": month_key,
                     "movies_watched": (
                         monthly_values["movies_watched"] if monthly_values else 0
+                    ),
+                    "unique_movies": (
+                        monthly_values["unique_movies"] if monthly_values else 0
                     ),
                     "average_rating": (
                         monthly_values["average_rating"] if monthly_values else None

--- a/backend/main.py
+++ b/backend/main.py
@@ -127,6 +127,7 @@ class PublicSystemStats(BaseModel):
 class PublicActivityPoint(BaseModel):
     month: str
     movies_watched: int = Field(ge=0)
+    unique_movies: int = Field(ge=0)
     average_rating: Optional[float] = Field(default=None, ge=0, le=5)
     is_partial: bool
 
@@ -225,6 +226,7 @@ def _public_dashboard_payload(
             {
                 "month": point["month"],
                 "movies_watched": _safe_nonnegative_int(point.get("movies_watched")),
+                "unique_movies": _safe_nonnegative_int(point.get("unique_movies")),
                 "average_rating": _safe_public_rating(point.get("average_rating")),
                 "is_partial": point.get("is_partial") is True,
             }

--- a/backend/tests/test_monthly_activity.py
+++ b/backend/tests/test_monthly_activity.py
@@ -127,7 +127,8 @@ def _seed_monthly_activity(database) -> tuple[Profile, Profile]:
     alpha = _profile(1, "alpha")
     beta = _profile(2, "beta")
     film = _movie(1, "Repeat Film")
-    database.add_all([alpha, beta, film])
+    second_film = _movie(2, "Second Film")
+    database.add_all([alpha, beta, film, second_film])
     database.add_all(
         [
             # A rolling 365-day query incorrectly exposed this as a tiny Jul 2025 bucket.
@@ -161,10 +162,12 @@ def _seed_monthly_activity(database) -> tuple[Profile, Profile]:
                 watched_date=date(2025, 9, 2),
                 rating=2.0,
             ),
+            # A different film in the same month separates the unique-film grain
+            # from the watch-event grain.
             _watch_event(
                 5,
                 profile_id=alpha.id,
-                movie_id=film.id,
+                movie_id=second_film.id,
                 watched_date=date(2025, 9, 3),
                 rating=4.0,
             ),
@@ -221,13 +224,18 @@ def test_global_monthly_activity_uses_exact_calendar_window_and_event_grain(data
 
     by_month = {point["month"]: point for point in activity}
     assert by_month["2025-08"]["movies_watched"] == 2
+    # Two diary entries for the same film stay one unique film.
+    assert by_month["2025-08"]["unique_movies"] == 1
     assert by_month["2025-08"]["average_rating"] == 4.0
     assert by_month["2025-09"]["movies_watched"] == 2
+    assert by_month["2025-09"]["unique_movies"] == 2
     assert by_month["2025-09"]["average_rating"] == 3.0
     assert by_month["2025-10"]["movies_watched"] == 0
+    assert by_month["2025-10"]["unique_movies"] == 0
     assert by_month["2025-10"]["average_rating"] is None
     assert by_month["2026-06"]["movies_watched"] == 0
     assert by_month["2026-07"]["movies_watched"] == 1
+    assert by_month["2026-07"]["unique_movies"] == 1
     assert by_month["2026-07"]["average_rating"] == 3.5
 
 
@@ -257,6 +265,7 @@ def test_first_day_of_month_marks_an_empty_current_bucket_as_partial(database):
     assert activity[-1] == {
         "month": "2026-07",
         "movies_watched": 0,
+        "unique_movies": 0,
         "average_rating": None,
         "is_partial": True,
     }

--- a/backend/tests/test_public_dashboard.py
+++ b/backend/tests/test_public_dashboard.py
@@ -18,6 +18,7 @@ def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
         "top_rated_movies": [{"title": "Private Film Sentinel"}],
         "rating_distribution": {"4.0": 250, sentinel: 1},
         "activity_data": [
+            # A legacy cached point without unique_movies must sanitize to 0.
             {
                 "month": "2026-06",
                 "movies_watched": 0,
@@ -27,6 +28,7 @@ def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
             {
                 "month": "2026-07",
                 "movies_watched": 80,
+                "unique_movies": 64,
                 "average_rating": 3.8,
                 "is_partial": True,
             },
@@ -82,12 +84,14 @@ def test_public_dashboard_payload_strictly_removes_identity_and_title_fields():
         {
             "month": "2026-06",
             "movies_watched": 0,
+            "unique_movies": 0,
             "average_rating": None,
             "is_partial": False,
         },
         {
             "month": "2026-07",
             "movies_watched": 80,
+            "unique_movies": 64,
             "average_rating": 3.8,
             "is_partial": True,
         },

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -128,9 +128,9 @@ const publicDashboard = {
   },
   rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
   activity_data: [
-    { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
-    { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
-    { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
+    { month: '2026-05', movies_watched: 10, unique_movies: 8, average_rating: 3.7, is_partial: false },
+    { month: '2026-06', movies_watched: 20, unique_movies: 16, average_rating: 3.8, is_partial: false },
+    { month: '2026-07', movies_watched: 90, unique_movies: 70, average_rating: 3.9, is_partial: true },
   ],
   signal_counts: {
     profiles_analyzed: profiles.length,
@@ -163,9 +163,9 @@ export const profileAnalysis = {
   data_coverage: profiles[0].data_coverage,
   rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
   monthly_stats: [
-    { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
-    { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
-    { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
+    { month: '2026-05', movies_watched: 10, unique_movies: 8, average_rating: 3.7, is_partial: false },
+    { month: '2026-06', movies_watched: 20, unique_movies: 16, average_rating: 3.8, is_partial: false },
+    { month: '2026-07', movies_watched: 90, unique_movies: 70, average_rating: 3.9, is_partial: true },
   ],
   recent_watching_trend: Array.from({ length: 8 }, (_, index) => ({
     movie_title: `Recent Watch ${index + 1}`,
@@ -485,9 +485,9 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
       top_rated_movies: [],
       rating_distribution: { '3.5': 120, '4.0': 240, '4.5': 80 },
       activity_data: [
-        { month: '2026-05', movies_watched: 10, average_rating: 3.7, is_partial: false },
-        { month: '2026-06', movies_watched: 20, average_rating: 3.8, is_partial: false },
-        { month: '2026-07', movies_watched: 90, average_rating: 3.9, is_partial: true },
+        { month: '2026-05', movies_watched: 10, unique_movies: 8, average_rating: 3.7, is_partial: false },
+        { month: '2026-06', movies_watched: 20, unique_movies: 16, average_rating: 3.8, is_partial: false },
+        { month: '2026-07', movies_watched: 90, unique_movies: 70, average_rating: 3.9, is_partial: true },
       ],
       group_signals: groupSignals,
       timestamp: '2026-07-29T12:00:00Z',

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -124,13 +124,30 @@ test('watching activity identifies month-to-date events and excludes them from t
     { exact: true },
   )).toBeVisible();
   await expect(activityChart.getByLabel('Average watch events per completed month')).toHaveText('15.0');
-  await expect(activityChart.getByText('Avg/Completed Month', { exact: true })).toBeVisible();
+  await expect(activityChart.getByLabel('Average unique films per completed month')).toHaveText('12.0');
+  await expect(activityChart.getByText('Watch Events/Mo', { exact: true })).toBeVisible();
+  await expect(activityChart.getByText('Unique Films/Mo', { exact: true })).toBeVisible();
   await expect(activityChart.getByRole('img')).toHaveAccessibleName(
-    /July 2026 is month to date and is excluded from the completed-month average.*15\.0 watch events per completed month/,
+    /July 2026 is month to date and is excluded from the completed-month average.*15\.0 watch events and 12\.0 unique films per completed month/,
   );
   await expect(activityChart.getByRole('list', { name: 'Watching Activity data points' })).toContainText(
-    'July 2026, month to date: 90 watch events; average rating 3.9',
+    'July 2026, month to date: 90 watch events; 70 unique films; average rating 3.9',
   );
+
+  // The chart canvas must stay inside the fixed-height card so the x-axis
+  // labels are never painted over by the following section.
+  const cardBox = await activityChart.boundingBox();
+  const canvasBox = await activityChart.getByRole('img').boundingBox();
+  expect(cardBox).not.toBeNull();
+  expect(canvasBox).not.toBeNull();
+  expect(canvasBox!.y + canvasBox!.height).toBeLessThanOrEqual(cardBox!.y + cardBox!.height + 1);
+
+  // Stat captions must render on a single line, not flex-shrunk into two.
+  for (const caption of ['Watch Events/Mo', 'Unique Films/Mo']) {
+    const captionBox = await activityChart.getByText(caption, { exact: true }).boundingBox();
+    expect(captionBox).not.toBeNull();
+    expect(captionBox!.height).toBeLessThanOrEqual(20);
+  }
 });
 
 test('analysis list panels keep intrinsic heights without animated glass artifacts', async ({ page }) => {

--- a/frontend/src/components/Charts/ActivityChart.tsx
+++ b/frontend/src/components/Charts/ActivityChart.tsx
@@ -28,6 +28,8 @@ ChartJS.register(
 interface ActivityData {
   month: string;
   movies_watched: number;
+  // Optional: cached snapshots produced before this field existed omit it.
+  unique_movies?: number | null;
   average_rating: number | null;
   is_partial: boolean;
 }
@@ -53,12 +55,22 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
   const completedAverage = completedPoints.length > 0
     ? completedTotal / completedPoints.length
     : null;
+  const completedUniqueValues = completedPoints.map((item) => item.unique_movies);
+  const uniqueAverage = completedPoints.length > 0
+    && completedUniqueValues.every((value): value is number => typeof value === 'number')
+    ? completedUniqueValues.reduce((sum, value) => sum + value, 0) / completedPoints.length
+    : null;
   const partialMonth = partialPoint
     ? formatMonth(partialPoint.month, 'long', 'numeric')
     : null;
+  const averageSummary = completedAverage === null
+    ? 'No completed-month average is available.'
+    : uniqueAverage === null
+      ? `Average: ${completedAverage.toFixed(1)} watch events per completed month.`
+      : `Average: ${completedAverage.toFixed(1)} watch events and ${uniqueAverage.toFixed(1)} unique films per completed month.`;
   const chartAccessibilityLabel = partialMonth
-    ? `${title}. ${partialMonth} is month to date and is excluded from the completed-month average. ${completedAverage === null ? 'No completed-month average is available.' : `Average: ${completedAverage.toFixed(1)} watch events per completed month.`}`
-    : `${title}. ${completedAverage === null ? 'No completed-month average is available.' : `Average: ${completedAverage.toFixed(1)} watch events per completed month.`}`;
+    ? `${title}. ${partialMonth} is month to date and is excluded from the completed-month average. ${averageSummary}`
+    : `${title}. ${averageSummary}`;
 
   const chartData = {
     labels: data.map((item) => (
@@ -205,6 +217,14 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
             }
             return `${context.dataset.label}${periodSuffix}: ${context.raw}`;
           },
+          afterBody: (items) => {
+            const point = items.length > 0 ? data[items[0].dataIndex] : undefined;
+            if (typeof point?.unique_movies !== 'number') {
+              return [];
+            }
+            const periodSuffix = point.is_partial ? ' (MTD)' : '';
+            return [`Unique Films${periodSuffix}: ${point.unique_movies}`];
+          },
         },
       },
     },
@@ -217,13 +237,13 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
   return (
     <motion.section
       aria-label={title}
-      className="card-cinema h-96"
+      className="card-cinema flex h-96 flex-col"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.6, delay: 0.1 }}
     >
-      <div className="flex items-center justify-between mb-6">
-        <div>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+        <div className="min-w-[15rem] flex-1">
           <h3 className="text-lg font-semibold text-white">{title}</h3>
           <p className="text-white/60 text-sm">
             {partialMonth
@@ -231,24 +251,35 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
               : 'Monthly watch events'}
           </p>
         </div>
-        
-        <motion.div 
-          className="text-center"
+
+        <motion.div
+          className="flex shrink-0 items-start gap-5"
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
           transition={{ delay: 0.4 }}
         >
-          <output
-            aria-label="Average watch events per completed month"
-            className="block text-xl font-bold text-cinema-400"
-          >
-            {completedAverage === null ? '—' : completedAverage.toFixed(1)}
-          </output>
-          <div className="text-xs text-white/60">Avg/Completed Month</div>
+          <div className="text-center">
+            <output
+              aria-label="Average watch events per completed month"
+              className="block text-xl font-bold text-cinema-400"
+            >
+              {completedAverage === null ? '—' : completedAverage.toFixed(1)}
+            </output>
+            <div className="whitespace-nowrap text-xs text-white/60">Watch Events/Mo</div>
+          </div>
+          <div className="text-center">
+            <output
+              aria-label="Average unique films per completed month"
+              className="block text-xl font-bold text-slate-300"
+            >
+              {uniqueAverage === null ? '—' : uniqueAverage.toFixed(1)}
+            </output>
+            <div className="whitespace-nowrap text-xs text-white/60">Unique Films/Mo</div>
+          </div>
         </motion.div>
       </div>
-      
-      <div className="h-72">
+
+      <div className="min-h-0 flex-1">
         {data.length > 0 ? (
           <motion.div 
             className="h-full"
@@ -267,6 +298,7 @@ const ActivityChart: React.FC<ActivityChartProps> = ({
                 <li key={item.month}>
                   {formatMonth(item.month, 'long', 'numeric')}
                   {item.is_partial ? ', month to date' : ''}: {item.movies_watched} watch events;{' '}
+                  {typeof item.unique_movies === 'number' ? `${item.unique_movies} unique films; ` : ''}
                   {item.average_rating === null
                     ? 'average rating unavailable'
                     : `average rating ${item.average_rating.toFixed(1)}`}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -319,6 +319,8 @@ export interface TopMovie {
 export interface ActivityData {
   month: string;
   movies_watched: number;
+  // Optional: cached snapshots produced before this field existed omit it.
+  unique_movies?: number | null;
   average_rating: number | null;
   is_partial: boolean;
 }


### PR DESCRIPTION
## What

The Watching Activity chart's completed-month average only showed **watch events**, which double-counts rewatches and same-film watches across profiles. This adds a second number: the chart header now shows **Watch Events/Mo** and **Unique Films/Mo**, both averaged over completed months only (MTD excluded, as before). Per-month unique-film counts also appear in the tooltip and the screen-reader data list.

## How

- `_get_monthly_watch_activity` now also computes `count(distinct movie_id)` per calendar month under the same filters (non-superseded events, profile scope, exact window), so all three consumers (public dashboard, My Dashboard analytics, per-profile Analysis) pick it up from one place.
- `DASHBOARD_SNAPSHOT_FORMAT_VERSION` bumped 2 → 3 so cached snapshots without the field regenerate. The public-payload sanitizer allowlists `unique_movies` (missing → 0), and the frontend treats the field as optional, rendering an em dash for stale cached payloads (worst case ~6 minutes of browser cache).
- Layout: the chart card is now a flex column with a flex-sized plot area and a wrapping header. The previous fixed `h-96`/`h-72` pairing let the canvas bleed ~41px past the card bottom even before this change; the wider header would have pushed the x-axis labels under the next card on mobile. The Playwright spec now pins canvas-inside-card and single-line captions on both desktop and Pixel 7 projects.

## Testing

- Backend: 242 passed (new assertions cover rewatch-vs-unique both ways, zero months, and legacy cached points sanitizing to 0)
- Frontend: tsc, eslint, and all 57 Playwright E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)