### PR TITLE
Deploy pipeline: yield cleanly when superseded mid-flight, fix reconcile marker validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -721,10 +721,11 @@ jobs:
       - name: Release validated commit to Hetzner
         id: activate
         run: |
+          activation_status=0
           timeout --signal=TERM --kill-after=2m 30m \
             deploy/production-ssh.sh run sh -s -- \
               "${RELEASE_SHA}" "${REMOTE_BUNDLE}" "${REMOTE_CHECKSUM}" \
-              "${REPOSITORY_URL}" "${CLERK_BRIDGE_EDGE}" <<'REMOTE'
+              "${REPOSITORY_URL}" "${CLERK_BRIDGE_EDGE}" <<'REMOTE' || activation_status=$?
             set -eu
             RELEASE_SHA="$1"
             REMOTE_BUNDLE="$2"
@@ -1426,9 +1427,20 @@ jobs:
           [ "$(read_state_revision active)" = "${previous_target}" ]
           echo "Restored healthy previous release ${previous_target} after interrupted activation."
           REMOTE
+          if [ "${activation_status}" -eq 75 ]; then
+            # The release yielded because main moved past it mid-flight; the
+            # newer deploy owns production. Record a clean skip so the failed
+            # -activation reconciliation and public verification never run
+            # against a release that deliberately stood down.
+            echo "superseded=true" >>"${GITHUB_OUTPUT}"
+            echo "Release ${RELEASE_SHA} was superseded on main before activation; yielding to the newer deploy." >&2
+            exit 0
+          fi
+          exit "${activation_status}"
 
       - name: Verify public release from GitHub runner
         id: external_smoke
+        if: steps.activate.outputs.superseded != 'true'
         run: |
           set -Eeuo pipefail
 
@@ -1500,6 +1512,7 @@ jobs:
           [[ "${protected_profile_status}" == 401 ]]
 
       - name: Observe production RSS ingestion health without automatic rollback
+        if: steps.activate.outputs.superseded != 'true'
         run: |
           set -Eeuo pipefail
           for _ in {1..3}; do

--- a/deploy/reconcile-interrupted-deployment.sh
+++ b/deploy/reconcile-interrupted-deployment.sh
@@ -199,7 +199,11 @@ if [[ "${active_marker}" == "${RELEASE_SHA}" ]]; then
 elif [[ -n "${previous_marker}" \
     && "${previous_marker}" != "${PREVIOUS_TARGET}" \
     && "${previous_marker}" != "${RELEASE_SHA}" ]]; then
-    fail "the previous release-state marker does not identify a recovery revision"
+    # The activation never switched away from PREVIOUS_TARGET, so a valid
+    # marker naming an older revision is ordinary residue from the last
+    # successful deploy: it is the rollback target of the release that is
+    # still active and must be preserved, not treated as corruption.
+    log "Retaining the historical previous-release marker ${previous_marker} for the still-active release."
 fi
 
 validate_runtime_release "${PREVIOUS_RELEASE}" "${PREVIOUS_TARGET}" false

--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -304,8 +304,14 @@ refresh_and_require_deploy_tip() {
     deploy_tip="$(git --git-dir="${REPOSITORY_DIR}" rev-parse --verify "${DEPLOY_REF}^{commit}" 2>/dev/null || true)"
     [[ -n "${deploy_tip}" ]] \
         || fail "deployment ref ${DEPLOY_REF} does not exist after fetch"
-    [[ "${deploy_tip}" == "${RELEASE_SHA}" ]] \
-        || fail "deployment ref ${DEPLOY_REF} is now ${deploy_tip}; refusing stale release ${RELEASE_SHA}"
+    if [[ "${deploy_tip}" != "${RELEASE_SHA}" ]]; then
+        # Being superseded mid-flight is a yield, not a failure: nothing that
+        # ran so far mutated the active release (migrations are additive-only
+        # when the pre-activation recheck fires), and the newer deploy owns
+        # production from here. Exit 75 so the workflow records a clean skip.
+        log "deployment ref ${DEPLOY_REF} is now ${deploy_tip}; yielding superseded release ${RELEASE_SHA} to the newer deploy" >&2
+        exit 75
+    fi
 }
 
 refresh_and_require_deploy_tip

--- a/deploy/test_reconcile_interrupted_deployment.py
+++ b/deploy/test_reconcile_interrupted_deployment.py
@@ -325,6 +325,28 @@ class InterruptedDeploymentReconciliationTests(unittest.TestCase):
         )
         self.assertFalse((self.state / "previous").exists())
 
+    def test_stale_previous_marker_from_an_older_deploy_is_retained(self) -> None:
+        # Steady production state after a successful deploy keeps the previous
+        # marker pointing at the release before the active one. An attempt that
+        # failed before activation must restore the active release and keep
+        # that marker as the standing rollback target instead of refusing.
+        ancestor_revision = "1234567890abcdef1234567890abcdef12345678"
+        self.current_link.unlink()
+        self.current_link.symlink_to(self.previous_release)
+        self._write_state(self.previous_revision, ancestor_revision)
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.current_link.resolve(), self.previous_release)
+        self.assertEqual(
+            (self.state / "active").read_text().strip(), self.previous_revision
+        )
+        self.assertEqual(
+            (self.state / "previous").read_text().strip(), ancestor_revision
+        )
+        self.assertIn(
+            "Retaining the historical previous-release marker", result.stdout
+        )
+
     def test_first_activation_stops_services_and_clears_current_state(self) -> None:
         self._write_state(self.attempted_revision, None)
         result = self._run("none")

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -195,6 +195,22 @@ class WorkflowControlsTests(unittest.TestCase):
             workflow.index("if (( browser_status != 0 ));"),
         )
 
+    def test_superseded_release_yields_instead_of_failing(self) -> None:
+        ci = read_repo_file(".github/workflows/ci.yml")
+        release = read_repo_file("deploy/release.sh")
+        reconcile = read_repo_file("deploy/reconcile-interrupted-deployment.sh")
+
+        # A release overtaken on main mid-flight stands down with exit 75; the
+        # deploy job records a clean skip instead of a failed activation, and
+        # the public verification never probes for a release that yielded.
+        self.assertIn("yielding superseded release", release)
+        self.assertIn('if [ "${activation_status}" -eq 75 ]; then', ci)
+        self.assertIn('echo "superseded=true" >>"${GITHUB_OUTPUT}"', ci)
+        self.assertEqual(
+            ci.count("if: steps.activate.outputs.superseded != 'true'"), 2
+        )
+        self.assertIn("Retaining the historical previous-release marker", reconcile)
+
     def test_dependabot_groups_nonmajor_updates_for_every_runtime_source(self) -> None:
         cases = (
             ("npm", "/frontend", "npm-minor-and-patch"),


### PR DESCRIPTION
Fixes the two defects that turned today's benign deploy race into a production API outage.

## What happened
A deploy was mid-flight when a newer commit landed on main. The release script's staleness guard correctly refused to continue — but it exited as a generic failure, which triggered the failed-activation reconcile. The reconcile then hard-failed on completely normal state: the `previous` release-state marker names the release *before* the active one (it is the standing rollback target written by every successful deploy), and the validation only accepted the two current recovery revisions. Result: a red deploy, a failed recovery, and no self-healing while the backend was down.

## Changes
- **`deploy/release.sh`**: a moved deployment ref is now a *yield* (exit 75, distinct log), not a generic failure. Nothing has mutated the active release at any of the recheck points (migrations are additive-only by repo contract), so standing down is safe.
- **`.github/workflows/ci.yml`**: the activation step maps remote exit 75 to a clean skip — records a `superseded=true` output, exits 0, and gates the public release verification and RSS observation on it. The failed-activation reconcile no longer fires for a deliberate stand-down.
- **`deploy/reconcile-interrupted-deployment.sh`**: when activation never switched away from the previous target, a valid `previous` marker naming an older revision is recognized as historical residue and retained (it is the active release's rollback target), and recovery proceeds to restore service health instead of aborting.

## Testing
- New behavioral regression test: pre-activation failure with steady-state markers (`active=running release`, `previous=older release`) now restores the active release, keeps the rollback marker, and exits 0.
- New workflow contract test pins the exit-75 yield semantics across all three files.
- Full `deploy/` unittest suite passes (16 tests); `bash -n` and YAML validation clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh)_