### PR TITLE
Unify Compare and Watch Together with the app's cinema design language

### DIFF
--- a/frontend/src/components/insights/ComparePanels.tsx
+++ b/frontend/src/components/insights/ComparePanels.tsx
@@ -50,7 +50,7 @@ function MetricStrip({ metrics }: {
   }>;
 }) {
   return (
-    <section className="grid overflow-hidden rounded-xl border border-white/12 bg-white/[0.025] sm:grid-cols-2 xl:grid-cols-4">
+    <section className="grid overflow-hidden panel-insight sm:grid-cols-2 xl:grid-cols-4">
       {metrics.map((metric, index) => (
         <div key={metric.label} className={`min-w-0 px-5 py-4 ${index > 0 ? 'border-t border-white/10 sm:border-t-0 sm:border-l' : ''} ${index === 2 ? 'sm:border-l-0 xl:border-l' : ''}`}>
           <p className="text-xs font-medium text-white/55">{metric.label}</p>
@@ -67,7 +67,7 @@ function PairComparisonTable({ title, rows, tone }: {
   tone: 'love' | 'split';
 }) {
   return (
-    <section className="min-w-0 rounded-xl border border-white/12 bg-white/[0.02]">
+    <section className="min-w-0 panel-insight">
       <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
         <h3 className="flex items-center gap-2 text-sm font-semibold text-white">
           {tone === 'love' ? <Heart className="h-4 w-4 text-emerald-400" /> : <Zap className="h-4 w-4 text-cinema-400" />}
@@ -110,7 +110,7 @@ function PairComparisonTable({ title, rows, tone }: {
 function PairTimeline({ data }: { data: PairDossierResponse }) {
   const paths = data.influence_paths ?? [];
   return (
-    <section className="rounded-xl border border-white/12 bg-white/[0.02]">
+    <section className="panel-insight">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
         <h3 className="flex items-center gap-2 text-sm font-semibold text-white">
           <Clock3 className="h-4 w-4 text-cinema-400" />
@@ -215,7 +215,7 @@ export function PairDossierPanel({ data, coverage }: {
             const movieLabel = `${row.movie.title}${row.movie.year ? ` (${row.movie.year})` : ''}`;
 
             return (
-              <section key={`${row.movie.title}-reviews`} className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+              <section key={`${row.movie.title}-reviews`} className="panel-insight p-4">
                 <div className="flex items-center gap-3">
                   <MoviePoster movie={row.movie} className="h-14 w-10" />
                   <div>
@@ -338,7 +338,7 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
           ]} />
 
           <div className="grid gap-4 2xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,.75fr)]">
-            <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+            <section className="panel-insight p-4">
               <div className="mb-4 flex items-center justify-between gap-3">
                 <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Dna className="h-4 w-4 text-cinema-400" /> Where your tastes align</h3>
                 <div className="flex items-center gap-4 text-[11px] text-white/45">
@@ -364,7 +364,7 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
             </section>
 
             <div className="space-y-4">
-              <section className="rounded-xl border border-white/12 bg-white/[0.02]">
+              <section className="panel-insight">
                 <div className="border-b border-white/10 px-4 py-3">
                   <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Sparkles className="h-4 w-4 text-cinema-400" /> Strongest shared affinities</h3>
                 </div>
@@ -379,7 +379,7 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
                 </div>
               </section>
 
-              <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+              <section className="panel-insight p-4">
                 <h3 className="text-sm font-semibold text-white">Taste splits</h3>
                 <p className="mt-1 text-xs text-white/40">Traits where these profiles lean in different directions.</p>
                 <div className="mt-4 space-y-3">
@@ -391,7 +391,7 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
           </div>
 
           <div className="grid gap-4 xl:grid-cols-2">
-            <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+            <section className="panel-insight p-4">
               <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Heart className="h-4 w-4 text-cinema-400" /> Shared taste, real examples</h3>
               <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
                 {(data.shared_signature ?? []).flatMap((trait) => trait.top_movies ?? []).slice(0, 8).map((movie, index) => (
@@ -402,7 +402,7 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
                 ))}
               </div>
             </section>
-            <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+            <section className="panel-insight p-4">
               <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Film className="h-4 w-4 text-cinema-400" /> Semantic neighbors</h3>
               <p className="mt-1 text-xs text-white/40">Contextual matches, not exact-title co-watches.</p>
               <div className="mt-4 flex gap-3 overflow-x-auto pb-2">
@@ -490,7 +490,7 @@ export function SignalCalendarPanel({ data, coverage }: {
             { label: 'Peak day', value: peakBucket ? formatCalendarDate(peakBucket.date) : '—', detail: peakBucket ? `${peakBucket.signal_count} signals` : 'No signal peak' },
           ]} />
 
-          <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+          <section className="panel-insight p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><CalendarDays className="h-4 w-4 text-cinema-400" /> Signal activity</h3>
@@ -522,7 +522,7 @@ export function SignalCalendarPanel({ data, coverage }: {
           </section>
 
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
-            <section className="rounded-xl border border-white/12 bg-white/[0.02]">
+            <section className="panel-insight">
               <div className="border-b border-white/10 px-4 py-3">
                 <h3 className="text-sm font-semibold text-white">Monthly signal rhythm</h3>
               </div>
@@ -539,7 +539,7 @@ export function SignalCalendarPanel({ data, coverage }: {
               </div>
             </section>
 
-            <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+            <section className="panel-insight p-4">
               <h3 className="text-sm font-semibold text-white">{selectedDate ? formatCalendarDate(selectedDate) : 'Choose a signal day'}</h3>
               {selectedDate ? (
                 selectedEvents.length > 0 ? (

--- a/frontend/src/components/insights/InsightUI.tsx
+++ b/frontend/src/components/insights/InsightUI.tsx
@@ -195,7 +195,7 @@ export function FeatureState({
   actionLabel?: string;
 }) {
   return (
-    <section className="flex min-h-72 flex-col items-center justify-center rounded-xl border border-dashed border-white/15 bg-white/[0.025] px-6 text-center">
+    <section className="card-cinema flex min-h-72 flex-col items-center justify-center text-center">
       <span className="grid h-12 w-12 place-items-center rounded-xl border border-cinema-400/25 bg-cinema-500/10 text-cinema-300">
         {loading ? <Loader2 className="h-6 w-6 animate-spin" /> : <CircleSlash className="h-6 w-6" />}
       </span>

--- a/frontend/src/components/insights/ProfileMultiSelect.tsx
+++ b/frontend/src/components/insights/ProfileMultiSelect.tsx
@@ -70,7 +70,7 @@ export default function ProfileMultiSelect({
         aria-expanded={open}
         aria-controls={panelId}
         onClick={() => setOpen((value) => !value)}
-        className="flex min-h-12 w-full items-center justify-between gap-3 rounded-xl border border-white/15 bg-black/15 px-3 text-left transition-colors hover:border-cinema-400/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-cinema-400/70"
+        className="flex min-h-12 w-full items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-3 text-left transition-colors hover:border-cinema-400/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-cinema-400/70"
       >
         <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
           {selectedProfiles.slice(0, 4).map((profile) => (

--- a/frontend/src/components/insights/RewatchEchoesPanel.tsx
+++ b/frontend/src/components/insights/RewatchEchoesPanel.tsx
@@ -74,7 +74,7 @@ export default function RewatchEchoesPanel({
 
   if (error || !data) {
     return (
-      <section className="rounded-xl border border-white/12 bg-white/[0.02] px-5 py-8 text-center">
+      <section className="panel-insight px-5 py-8 text-center">
         <History className="mx-auto h-7 w-7 text-cinema-400" />
         <h2 className="mt-3 text-base font-semibold text-white">Rewatch Echoes are unavailable</h2>
         <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-white/45">
@@ -93,7 +93,7 @@ export default function RewatchEchoesPanel({
   return (
     <section className="space-y-4" aria-labelledby="rewatch-echoes-title">
       <CoverageBanner coverage={data.coverage} />
-      <div className="overflow-hidden rounded-xl border border-white/12 bg-white/[0.02]">
+      <div className="overflow-hidden panel-insight">
         <header className="flex flex-col gap-3 border-b border-white/10 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 id="rewatch-echoes-title" className="flex items-center gap-2 text-base font-semibold text-white">

--- a/frontend/src/components/insights/TasteTimelinePanel.tsx
+++ b/frontend/src/components/insights/TasteTimelinePanel.tsx
@@ -129,7 +129,7 @@ export default function TasteTimelinePanel({ data, coverage }: {
   return (
     <div className="space-y-4">
       <CoverageBanner coverage={data.coverage} />
-      <section className="grid overflow-hidden rounded-xl border border-white/12 bg-white/[0.025] sm:grid-cols-2 xl:grid-cols-4">
+      <section className="grid overflow-hidden panel-insight sm:grid-cols-2 xl:grid-cols-4">
         {[
           { label: 'Observed years', value: data.summary.years, detail: data.summary.first_year && data.summary.last_year ? `${data.summary.first_year}–${data.summary.last_year}` : 'No dated range' },
           { label: 'Date coverage', value: percent(data.summary.date_coverage_ratio), detail: `${data.summary.dated_watch_events.toLocaleString()} dated events` },
@@ -148,7 +148,7 @@ export default function TasteTimelinePanel({ data, coverage }: {
         <Info className="mt-0.5 h-4 w-4 shrink-0" /> Only observed, dated watch events are placed on the timeline. {data.summary.undated_known_watches.toLocaleString()} known watches without dates remain excluded.
       </p>
 
-      <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+      <section className="panel-insight p-4">
         <div className="mb-4 flex justify-end">
           <div className="flex rounded-lg border border-white/10 bg-black/15 p-1" aria-label="Timeline detail">
             {(['yearly', 'seasonal'] as TimelineGrain[]).map((value) => (
@@ -163,7 +163,7 @@ export default function TasteTimelinePanel({ data, coverage }: {
 
       {periods.length > 0 && (
         <div className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_22rem]">
-          <section className="overflow-hidden rounded-xl border border-white/12 bg-white/[0.02]">
+          <section className="overflow-hidden panel-insight">
             <div className="border-b border-white/10 px-4 py-3">
               <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><CalendarRange className="h-4 w-4 text-cinema-400" /> Period details</h3>
             </div>
@@ -182,7 +182,7 @@ export default function TasteTimelinePanel({ data, coverage }: {
             </div>
           </section>
 
-          <aside className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+          <aside className="panel-insight p-4">
             <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Dna className="h-4 w-4 text-cinema-400" /> {selectedPeriod?.label ?? 'Period'} signals</h3>
             <p className="mt-1 text-xs text-white/40">Most observed metadata traits in this period.</p>
             <div className="mt-4 space-y-2.5">

--- a/frontend/src/components/insights/WatchTogetherResults.tsx
+++ b/frontend/src/components/insights/WatchTogetherResults.tsx
@@ -302,7 +302,7 @@ export default function WatchTogetherResults({
       <CoverageBanner coverage={data.coverage} />
       <div className={`grid min-w-0 grid-cols-[minmax(0,1fr)] gap-4 ${selectedCandidate ? '2xl:grid-cols-[minmax(0,1fr)_20rem]' : ''}`}>
         <div className="min-w-0 space-y-4">
-          <section className="overflow-hidden rounded-xl border border-white/12 bg-white/[0.02]">
+          <section className="overflow-hidden panel-insight">
             <div className="flex flex-col gap-3 border-b border-white/10 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-xs font-semibold text-white/75">{modeLabel}</p>
@@ -312,7 +312,7 @@ export default function WatchTogetherResults({
               </div>
               <label className="flex items-center gap-2 text-xs text-white/45">
                 Sort by
-                <select value={sort} onChange={(event) => setSort(event.target.value as ResultSort)} className="rounded-lg border border-white/12 bg-noir-900 px-3 py-2 text-xs font-medium text-white outline-none focus:border-cinema-400/45">
+                <select value={sort} onChange={(event) => setSort(event.target.value as ResultSort)} className="rounded-lg border border-white/10 bg-noir-900 px-3 py-2 text-xs font-medium text-white outline-none focus:border-cinema-400/45">
                   <option value="group_fit">Best group fit</option>
                   <option value="watchlists">Most watchlists</option>
                   <option value="runtime">Shortest runtime</option>
@@ -348,7 +348,7 @@ export default function WatchTogetherResults({
           </section>
 
           {blindSpots.length > 0 && (
-            <section className="rounded-xl border border-white/12 bg-white/[0.02] p-4">
+            <section className="panel-insight p-4">
               <div className="flex items-center justify-between gap-3">
                 <div>
                   <h2 className="flex items-center gap-2 text-sm font-semibold text-white"><Heart className="h-4 w-4 text-cinema-400" /> Mutual blind spots</h2>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -80,6 +80,13 @@
            transition-all duration-500;
   }
 
+  /* Dense insight-workspace panels share the cinema card language without
+     the hover lift of card-cinema. */
+  .panel-insight {
+    @apply rounded-2xl border border-cinema-400/20 bg-gradient-to-br
+           from-cinema-500/10 to-cinema-600/5;
+  }
+
   /* Stable treatment for tall, non-interactive analysis panels. */
   .analysis-panel {
     @apply rounded-2xl border border-cinema-400/20 bg-gradient-to-br

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -74,7 +74,7 @@ function PairProfileField({
 }) {
   const selected = profiles.find((profile) => profile.username === value);
   return (
-    <label className="block min-w-0 rounded-xl border border-white/15 bg-white/[0.025] px-4 py-3 transition-colors focus-within:border-cinema-400/45">
+    <label className="block min-w-0 rounded-xl border border-white/10 bg-black/20 px-4 py-3 transition-colors focus-within:border-cinema-400/45">
       <span className="block text-xs font-medium text-white/45">{label}</span>
       <span className="mt-2 flex items-center gap-3">
         <ProfileAvatar profile={selected} size="lg" />
@@ -192,7 +192,7 @@ export default function Compare() {
   if (profilesQuery.error) return <FeatureState title="Profiles unavailable" message="The profile directory could not be loaded." />;
   if (completedProfiles.length < 2) {
     return (
-      <div className="mx-auto max-w-[92rem] space-y-5">
+      <div className="space-y-6">
         <div className="flex justify-end"><AdminScopeToggle /></div>
         <FeatureState title="Track two profiles to compare" message="Add or request at least two Letterboxd profiles in My Profiles before opening Compare." actionHref="/profiles" actionLabel="Open My Profiles" />
       </div>
@@ -201,19 +201,19 @@ export default function Compare() {
 
   return (
     <motion.div
-      className="mx-auto max-w-[92rem] space-y-5"
+      className="space-y-6"
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
     >
       <header className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Compare Profiles</h1>
-          <p className="mt-2 text-sm text-white/55">Understand how two people&apos;s movie lives overlap.</p>
+          <h1 className="text-4xl font-bold text-white text-glow">Compare Profiles</h1>
+          <p className="mt-2 text-white/60">Understand how two people&apos;s movie lives overlap.</p>
         </div>
         <div className="flex flex-wrap items-center gap-3 self-start">
         <AdminScopeToggle />
-        <div className="flex items-center gap-1 rounded-xl border border-white/12 bg-black/15 p-1" aria-label="Comparison time window">
+        <div className="flex items-center gap-1 rounded-xl border border-white/10 bg-black/20 p-1" aria-label="Comparison time window">
           {[1, 7, 30].map((value) => (
             <button
               key={value}

--- a/frontend/src/views/WatchTogether.tsx
+++ b/frontend/src/views/WatchTogether.tsx
@@ -83,7 +83,7 @@ function FilterField({ icon: Icon, label, children }: {
   return (
     <label className="min-w-0">
       <span className="mb-2 block text-xs font-medium text-white/45">{label}</span>
-      <span className="flex min-h-11 items-center gap-2 rounded-xl border border-white/12 bg-black/15 px-3 focus-within:border-cinema-400/45">
+      <span className="flex min-h-11 items-center gap-2 rounded-xl border border-white/10 bg-black/20 px-3 focus-within:border-cinema-400/45">
         <Icon className="h-4 w-4 shrink-0 text-white/45" />
         {children}
       </span>
@@ -200,7 +200,7 @@ export default function WatchTogether() {
   if (profilesQuery.error) return <FeatureState title="Profiles unavailable" message="The profile directory could not be loaded." />;
   if (completedProfiles.length < 2) {
     return (
-      <div className="mx-auto max-w-[92rem] space-y-4">
+      <div className="space-y-6">
         <div className="flex justify-end"><AdminScopeToggle /></div>
         <FeatureState title="Track two profiles for a group pick" message="Add or request at least two Letterboxd profiles in My Profiles before asking for a group movie pick." actionHref="/profiles" actionLabel="Open My Profiles" />
       </div>
@@ -209,15 +209,15 @@ export default function WatchTogether() {
 
   return (
     <motion.div
-      className="mx-auto max-w-[92rem] space-y-4"
+      className="space-y-6"
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
     >
       <header className="relative z-40 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h1 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">Watch Together</h1>
-          <p className="mt-2 text-sm text-white/55">Find the best film for this group tonight.</p>
+          <h1 className="text-4xl font-bold text-white text-glow">Watch Together</h1>
+          <p className="mt-2 text-white/60">Find the best film for this group tonight.</p>
         </div>
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center lg:w-auto">
           <AdminScopeToggle />
@@ -233,7 +233,7 @@ export default function WatchTogether() {
         </div>
       </header>
 
-      <nav className="grid min-w-0 grid-cols-2 gap-1 rounded-xl border border-white/12 bg-black/15 p-1 sm:flex sm:overflow-x-auto" aria-label="Watch Together mode">
+      <nav className="grid min-w-0 grid-cols-2 gap-1 rounded-xl border border-white/10 bg-black/20 p-1 sm:flex sm:overflow-x-auto" aria-label="Watch Together mode">
         {WATCH_MODES.map((item) => {
           const Icon = item.icon;
           return (
@@ -250,7 +250,7 @@ export default function WatchTogether() {
         })}
       </nav>
 
-      <section className="relative z-20 grid gap-3 rounded-xl border border-white/12 bg-white/[0.02] p-3 sm:grid-cols-2 xl:grid-cols-[.8fr_.9fr_1fr_.9fr_auto] xl:items-end">
+      <section className="relative z-20 grid gap-3 panel-insight p-3 sm:grid-cols-2 xl:grid-cols-[.8fr_.9fr_1fr_.9fr_auto] xl:items-end">
         <FilterField icon={Clock3} label="Runtime">
           <select
             value={draftFilters.maxRuntime ?? ''}
@@ -294,7 +294,7 @@ export default function WatchTogether() {
       </section>
 
       {mode === 'list_mission' && (
-        <section className="rounded-xl border border-white/12 bg-white/[0.02] p-3">
+        <section className="panel-insight p-3">
           <label className="grid gap-2 lg:grid-cols-[14rem_minmax(0,1fr)] lg:items-center">
             <span>
               <span className="flex items-center gap-2 text-sm font-semibold text-white"><ListChecks className="h-4 w-4 text-cinema-400" /> Public list mission</span>
@@ -304,7 +304,7 @@ export default function WatchTogether() {
               value={draftListId ?? ''}
               onChange={(event) => setDraftListId(event.target.value ? Number(event.target.value) : undefined)}
               disabled={publicListsQuery.isLoading || publicLists.length === 0}
-              className="min-h-11 w-full cursor-pointer rounded-xl border border-white/12 bg-noir-900 px-3 text-sm font-medium text-white/80 outline-none focus:border-cinema-400/45 disabled:cursor-not-allowed disabled:opacity-50"
+              className="min-h-11 w-full cursor-pointer rounded-xl border border-white/10 bg-noir-900 px-3 text-sm font-medium text-white/80 outline-none focus:border-cinema-400/45 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {publicListsQuery.isLoading ? <option value="">Loading public lists…</option> : publicLists.length === 0 ? <option value="">No imported public lists for this group</option> : publicLists.map((list) => (
                 <option key={list.id} value={list.id}>{list.owner} · {list.name} ({list.movie_count.toLocaleString()} films)</option>


### PR DESCRIPTION
The two insight-workspace pages used a separate flat visual system from the rest of the app. This unifies them:

- **New `panel-insight` utility** in the design system: the cinema gradient and warm border of `card-cinema` without the hover lift, suited to dense data panels. All workspace panels (Pair Dossier, Taste DNA, Timeline, Signal Calendar, Watch Together results, Rewatch Echoes) now use it in place of the flat `border-white/12 bg-white/[0.02]` look.
- **Headings**: both pages get the standard glowing `text-4xl` page title and `text-white/60` subtitle used everywhere else.
- **Control chrome**: selectors, tab bars, and filter fields align on the `border-white/10 bg-black/20` tokens the dashboard controls use.
- **Layout**: dropped the centered `max-w-[92rem]` constraint so both pages flow full-width like every other page, with the app's standard vertical rhythm.
- **Empty states**: `FeatureState` renders as a cinema card, matching the empty states on Spy Signals and Analysis.

No behavioral changes — purely presentational. Type-check and lint clean; visually verified via full-page screenshots of both pages against the mocked API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh)_