### PR TITLE
Raise python-multipart, pytest, and httpx requirement floors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements-scraper.txt
 
-httpx>=0.27.0
+httpx>=0.28.1
 pip-audit>=2.9.0
-pytest>=8.0.0
+pytest>=9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]>=0.23.0
 sqlalchemy>=2.0.0
 alembic>=1.13.0
 psycopg[binary]>=3.1.0
-python-multipart>=0.0.6
+python-multipart>=0.0.32
 
 # Auth — Clerk JWT verification
 PyJWT[crypto]>=2.8.0


### PR DESCRIPTION
Batches the remaining three Dependabot floor bumps into one change so they ship in a single CI and deploy cycle instead of three serialized rebase cycles:

- `python-multipart>=0.0.6` → `>=0.0.32` (requirements.txt)
- `pytest>=8.0.0` → `>=9.1.1` (requirements-dev.txt)
- `httpx>=0.27.0` → `>=0.28.1` (requirements-dev.txt)

All three are range widenings — builds already resolve to the latest versions, so installed behavior is unchanged; this codifies the floors.

Supersedes and closes #40, #39, and #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh)_