### PR TITLE
Move the supersession exit-code mapping into the activation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,6 +828,16 @@ jobs:
             SPYBOXD_CLERK_BRIDGE_EDGE="${CLERK_BRIDGE_EDGE}" \
               "${release_runner}" "${RELEASE_SHA}" "${REMOTE_BUNDLE}"
           REMOTE
+          if [ "${activation_status}" -eq 75 ]; then
+            # The release yielded because main moved past it mid-flight; the
+            # newer deploy owns production. Record a clean skip so the failed
+            # -activation reconciliation and public verification never run
+            # against a release that deliberately stood down.
+            echo "superseded=true" >>"${GITHUB_OUTPUT}"
+            echo "Release ${RELEASE_SHA} was superseded on main before activation; yielding to the newer deploy." >&2
+            exit 0
+          fi
+          exit "${activation_status}"
 
       - name: Reconcile an interrupted or failed activation
         if: >-
@@ -1427,16 +1437,6 @@ jobs:
           [ "$(read_state_revision active)" = "${previous_target}" ]
           echo "Restored healthy previous release ${previous_target} after interrupted activation."
           REMOTE
-          if [ "${activation_status}" -eq 75 ]; then
-            # The release yielded because main moved past it mid-flight; the
-            # newer deploy owns production. Record a clean skip so the failed
-            # -activation reconciliation and public verification never run
-            # against a release that deliberately stood down.
-            echo "superseded=true" >>"${GITHUB_OUTPUT}"
-            echo "Release ${RELEASE_SHA} was superseded on main before activation; yielding to the newer deploy." >&2
-            exit 0
-          fi
-          exit "${activation_status}"
 
       - name: Verify public release from GitHub runner
         id: external_smoke

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -211,6 +211,24 @@ class WorkflowControlsTests(unittest.TestCase):
         )
         self.assertIn("Retaining the historical previous-release marker", reconcile)
 
+        # The exit-code mapping must live inside the activation step itself:
+        # the workflow has several identical heredoc terminators, and a
+        # mapping stranded in a later step leaves the activation step
+        # swallowing every failure while the superseded output never gets
+        # written, so spurious external-smoke rollbacks fire instead.
+        activate_step = ci[
+            ci.index("name: Release validated commit to Hetzner")
+            : ci.index("name: Reconcile an interrupted or failed activation")
+        ]
+        reconcile_step = ci[
+            ci.index("name: Reconcile an interrupted or failed activation")
+            : ci.index("name: Verify public release from GitHub runner")
+        ]
+        self.assertIn('|| activation_status=$?', activate_step)
+        self.assertIn('if [ "${activation_status}" -eq 75 ]; then', activate_step)
+        self.assertIn('exit "${activation_status}"', activate_step)
+        self.assertNotIn("activation_status", reconcile_step)
+
     def test_dependabot_groups_nonmajor_updates_for_every_runtime_source(self) -> None:
         cases = (
             ("npm", "/frontend", "npm-minor-and-patch"),


### PR DESCRIPTION
Fixes the placement bug in the supersession handling shipped in #58.

## What went wrong
The exit-75 mapping block was appended after the wrong heredoc terminator — it landed at the end of the **reconcile** step instead of the **activation** step (the workflow has several identical `REMOTE` terminators, and the edit anchored on the wrong one). Consequences, observed on the #59 and #38 deploys:

- The activation step captured the remote exit code (`|| activation_status=$?`) but never acted on it, so every remote outcome — including a deliberate yield — read as step success.
- The `superseded=true` output was never written, so the gated public-verification step ran against a release that had stood down, failed on the inevitable revision mismatch, and triggered the external-smoke rollback.
- Two consecutive superseded deploys each rolled production back one release (`5624a5c` → `0f100c1`). Production stayed healthy throughout, just on an older revision, and the newest deploy heals it.

## Changes
- The mapping now lives inside the activation step, immediately after its heredoc; real failures propagate again and yields record the clean skip.
- The reconcile step is restored to its original shape (it had inherited a dangling reference to an unset variable that would have broken it on next use).
- The workflow contract test now pins **placement**, not just string presence: it slices the activate and reconcile step regions and asserts the mapping is inside the former and absent from the latter.

## Testing
Full `deploy/` unittest suite passes (16 tests); workflow YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh)_