### PR TITLE
Replace the duplicated top-bar page title with a utility bar

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,6 +21,7 @@ import {
 } from '@heroicons/react/24/solid';
 import { LogOut, Menu, UsersRound, X } from 'lucide-react';
 import { useCurrentUser } from '../hooks/useCurrentUser';
+import AdminScopeToggle from './AdminScopeToggle';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -85,7 +86,6 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   }, []);
 
   const isActive = (path: string) => pathname === path || pathname.startsWith(`${path}/`);
-  const activeItem = NAVIGATION_ITEMS.find((item) => isActive(item.path));
   const signInHref = `/sign-in?redirect_url=${encodeURIComponent(pathname)}`;
   const accountLabel = currentUserQuery.data?.letterboxd_username
     ? `@${currentUserQuery.data.letterboxd_username}`
@@ -276,30 +276,16 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       <main className="flex min-w-0 flex-1 flex-col min-h-screen lg:min-h-auto">
         {/* Top Header */}
         <motion.header 
-          className="hidden border-b border-white/10 bg-black/10 px-6 py-4 backdrop-blur-md lg:block"
+          className="hidden border-b border-white/10 bg-black/10 px-6 py-3 backdrop-blur-md lg:block"
           initial={{ y: -50, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.3 }}
         >
-          <div className="flex items-center justify-between">
-            <div>
-              <motion.h2 
-                className="text-2xl font-bold text-white text-glow"
-                initial={{ x: -20, opacity: 0 }}
-                animate={{ x: 0, opacity: 1 }}
-                transition={{ delay: 0.5 }}
-              >
-                {activeItem?.label || 'My Dashboard'}
-              </motion.h2>
-              <motion.p 
-                className="text-white/60 text-sm mt-1"
-                initial={{ x: -20, opacity: 0 }}
-                animate={{ x: 0, opacity: 1 }}
-                transition={{ delay: 0.6 }}
-              >
-                {activeItem?.description || 'Welcome to Spyboxd'}
-              </motion.p>
-            </div>
+          <div className="flex min-h-11 items-center justify-between gap-4">
+            {/* Pages render their own heading, so the bar carries utilities
+                only: the admin data-scope lens and the account controls. */}
+            <AdminScopeToggle />
+            <div aria-hidden="true" />
             {isSignedIn ? (
               <div className="flex items-center gap-3">
                 <UserButton />

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -81,7 +81,7 @@ const Analysis: React.FC = () => {
             Single-profile deep dives over the profiles you track.
           </p>
         </div>
-        <AdminScopeToggle />
+        <div className="lg:hidden"><AdminScopeToggle /></div>
       </div>
 
       {profilesArray.length === 0 ? (

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -193,7 +193,7 @@ export default function Compare() {
   if (completedProfiles.length < 2) {
     return (
       <div className="space-y-6">
-        <div className="flex justify-end"><AdminScopeToggle /></div>
+        <div className="flex justify-end"><div className="lg:hidden"><AdminScopeToggle /></div></div>
         <FeatureState title="Track two profiles to compare" message="Add or request at least two Letterboxd profiles in My Profiles before opening Compare." actionHref="/profiles" actionLabel="Open My Profiles" />
       </div>
     );
@@ -212,7 +212,7 @@ export default function Compare() {
           <p className="mt-2 text-white/60">Understand how two people&apos;s movie lives overlap.</p>
         </div>
         <div className="flex flex-wrap items-center gap-3 self-start">
-        <AdminScopeToggle />
+        <div className="lg:hidden"><AdminScopeToggle /></div>
         <div className="flex items-center gap-1 rounded-xl border border-white/10 bg-black/20 p-1" aria-label="Comparison time window">
           {[1, 7, 30].map((value) => (
             <button

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -116,7 +116,7 @@ const Dashboard: React.FC = () => {
             {isGlobalAdminView ? 'Analytics across the complete managed profile library.' : 'Analytics across the Letterboxd profiles you monitor.'}
           </p>
           </div>
-          <AdminScopeToggle />
+          <div className="lg:hidden"><AdminScopeToggle /></div>
         </div>
         <section className="card-cinema flex min-h-80 flex-col items-center justify-center px-6 text-center">
           <motion.div
@@ -199,7 +199,7 @@ const Dashboard: React.FC = () => {
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: 0.3 }}
         >
-          <AdminScopeToggle />
+          <div className="lg:hidden"><AdminScopeToggle /></div>
           <motion.button 
             onClick={handleRefreshAll}
             className="btn-secondary flex items-center space-x-2"

--- a/frontend/src/views/SpySignals.tsx
+++ b/frontend/src/views/SpySignals.tsx
@@ -158,7 +158,7 @@ const SpySignals: React.FC = () => {
             Find people who watched the same film on the same day or within a chosen time gap.
           </p>
         </div>
-        <AdminScopeToggle />
+        <div className="lg:hidden"><AdminScopeToggle /></div>
       </header>
 
       {profilesLoading ? (

--- a/frontend/src/views/WatchTogether.tsx
+++ b/frontend/src/views/WatchTogether.tsx
@@ -201,7 +201,7 @@ export default function WatchTogether() {
   if (completedProfiles.length < 2) {
     return (
       <div className="space-y-6">
-        <div className="flex justify-end"><AdminScopeToggle /></div>
+        <div className="flex justify-end"><div className="lg:hidden"><AdminScopeToggle /></div></div>
         <FeatureState title="Track two profiles for a group pick" message="Add or request at least two Letterboxd profiles in My Profiles before asking for a group movie pick." actionHref="/profiles" actionLabel="Open My Profiles" />
       </div>
     );
@@ -220,7 +220,7 @@ export default function WatchTogether() {
           <p className="mt-2 text-white/60">Find the best film for this group tonight.</p>
         </div>
         <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center lg:w-auto">
-          <AdminScopeToggle />
+          <div className="lg:hidden"><AdminScopeToggle /></div>
           <ProfileMultiSelect
             profiles={completedProfiles}
             selectedUsernames={selection.draftProfiles}


### PR DESCRIPTION
Every page rendered a double heading: the desktop top bar repeated the page's own title and description ("My Dashboard / Your Profile Overview" directly above "Dashboard / Analytics across…"). 

The top bar is now a slim utility bar:
- **Left**: the admin Monitored/Global scope toggle (renders nothing for non-admins)
- **Right**: account controls (avatar, username, sign out), unchanged
- No title/description — pages keep their single big heading

Since the bar is desktop-only, page headers keep a **mobile-only** (`lg:hidden`) copy of the scope toggle, so exactly one instance is visible and interactable per viewport — which also keeps the existing admin toggle E2E tests passing unchanged on both desktop and mobile projects.

Visually verified via screenshots as admin (toggle in bar) and non-admin (account-only bar) against the mocked API. Type-check and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNLNTTTGgVy16NpCj6wgwh)_