### PR TITLE
Complete the environment configuration contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Database Configuration
 # Preferred local setup
 DATABASE_URL=postgresql+psycopg://localhost/spyboxd
+# Docker Compose uses this password for its isolated local PostgreSQL service.
+POSTGRES_PASSWORD=spyboxd-local
 
 # API Configuration
 API_HOST=localhost
@@ -10,27 +12,49 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # Clerk Auth (backend token verification)
 # Prefer CLERK_JWKS_URL for direct key discovery, or set CLERK_FRONTEND_API and let API derive JWKS URL.
-# CLERK_JWKS_URL=https://your-instance.clerk.accounts.dev/.well-known/jwks.json
-# CLERK_FRONTEND_API=https://your-instance.clerk.accounts.dev
-# CLERK_ISSUER=https://your-instance.clerk.accounts.dev
-# CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+CLERK_JWKS_URL=
+CLERK_FRONTEND_API=
+CLERK_ISSUER=
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
 # Server-side fallback for admins; comma-separate exact Clerk user IDs.
-# CLERK_ADMIN_USER_IDS=user_abc123
+CLERK_ADMIN_USER_IDS=
 # Per-user abuse bounds for shared-profile tracking and residential-sync requests.
 SPYBOXD_MAX_TRACKED_PROFILES_PER_USER=25
 SPYBOXD_MAX_PENDING_PROFILE_REQUESTS_PER_USER=10
 
-# Optional trusted uploader token for residential-IP companion syncs
-# INGESTION_API_TOKEN=replace-with-a-long-random-secret
-# Optional default API URL for local sync scripts
-# SPYBOXD_API_BASE_URL=https://api.spyboxd.com
+# Frontend and Docker Compose. Copy the matching Clerk development-instance
+# values from frontend/.env.local when running the complete stack locally.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+
+# Residential full-sync uploader. scripts/local_full_sync.py and
+# scripts/batch_full_sync.py load these values from the ignored root .env.
+SPYBOXD_API_BASE_URL=https://api.spyboxd.com
+SPYBOXD_SYNC_CONFIG=sync-profiles.json
+# Keep the real token only in the ignored local .env and /etc/spyboxd/api.env.
+INGESTION_API_TOKEN=
+# Alternative to INGESTION_API_TOKEN for an interactive Clerk-authenticated upload.
+SPYBOXD_BEARER_TOKEN=
 
 # Optional TMDB enrichment. Letterboxd ingestion and every legacy feature work without it.
 # Prefer a v4 read access token; the v3 API key remains supported by the enrichment command.
 # TMDB_API_TOKEN=replace-with-your-tmdb-read-access-token
 # TMDB_API_KEY=replace-with-your-tmdb-v3-api-key
 TMDB_DEFAULT_REGION=DE
+TMDB_LANGUAGE=en-US
 TMDB_CACHE_DAYS=30
+TMDB_REQUEST_PAUSE_SECONDS=0.25
+TMDB_ENRICHMENT_LIMIT=100
+TMDB_ENRICHMENT_BATCH_SIZE=10
+
+# Residential upload safety limits.
+UPLOAD_MAX_ARCHIVE_MEMBERS=50000
+UPLOAD_MAX_UNCOMPRESSED_BYTES=2147483648
 
 # Conservative incremental activity checks after an authoritative full sync.
 # RSS is additions/upserts only; it never replaces full Letterboxd history.
@@ -40,6 +64,7 @@ SPYBOXD_RSS_REQUEST_PAUSE_SECONDS=3
 SPYBOXD_RSS_MAX_BACKOFF_SECONDS=86400
 SPYBOXD_RSS_BATCH_SIZE=50
 SPYBOXD_RSS_USER_AGENT=Spyboxd/1.0 (+https://spyboxd.com)
+SPYBOXD_RSS_HEALTH_STALE_AFTER_SECONDS=2400
 
 # Debug Settings
 DEBUG_MODE=false

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 build/
 .venv/
 .env
+.env.*
+!.env.example
+*.env
 venv/
 env/
 !deploy/env/
@@ -28,6 +31,9 @@ data/backups/
 
 # Frontend
 frontend/node_modules/
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
 frontend/.env.local
 frontend/.env.production.local
 frontend/build/

--- a/backend/tests/test_local_sync_environment.py
+++ b/backend/tests/test_local_sync_environment.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from scripts.local_full_sync import load_local_environment
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_local_sync_loads_ignored_root_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "SPYBOXD_API_BASE_URL=https://api.example.test\n"
+        "INGESTION_API_TOKEN=local-upload-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("SPYBOXD_API_BASE_URL", raising=False)
+    monkeypatch.delenv("INGESTION_API_TOKEN", raising=False)
+
+    load_local_environment(env_file)
+
+    assert os.environ["SPYBOXD_API_BASE_URL"] == "https://api.example.test"
+    assert os.environ["INGESTION_API_TOKEN"] == "local-upload-token"
+
+
+def test_local_sync_does_not_override_explicit_shell_values(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("INGESTION_API_TOKEN=file-token\n", encoding="utf-8")
+    monkeypatch.setenv("INGESTION_API_TOKEN", "shell-token")
+
+    load_local_environment(env_file)
+
+    assert os.environ["INGESTION_API_TOKEN"] == "shell-token"
+
+
+def test_root_example_covers_compose_and_residential_sync() -> None:
+    values = dotenv_values(REPO_ROOT / ".env.example")
+    expected_names = {
+        "POSTGRES_PASSWORD",
+        "NEXT_PUBLIC_API_BASE_URL",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "CLERK_SECRET_KEY",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL",
+        "SPYBOXD_API_BASE_URL",
+        "SPYBOXD_SYNC_CONFIG",
+        "INGESTION_API_TOKEN",
+        "SPYBOXD_BEARER_TOKEN",
+    }
+
+    assert expected_names <= values.keys()
+
+
+def test_tmdb_example_stays_within_the_runner_limit() -> None:
+    values = dotenv_values(REPO_ROOT / "deploy/env/api.env.example")
+
+    assert 1 <= int(values["TMDB_ENRICHMENT_LIMIT"]) <= 100

--- a/deploy/env/api.env.example
+++ b/deploy/env/api.env.example
@@ -29,7 +29,7 @@ TMDB_REQUEST_PAUSE_SECONDS=0.25
 # The scheduled GitHub workflow processes only stale/missing cache entries and
 # never forces refresh. Keep this bounded; at most this many candidate movies
 # are handled per run.
-TMDB_ENRICHMENT_LIMIT=200
+TMDB_ENRICHMENT_LIMIT=100
 TMDB_ENRICHMENT_BATCH_SIZE=10
 
 UPLOAD_MAX_ARCHIVE_MEMBERS=50000

--- a/scripts/local_full_sync.py
+++ b/scripts/local_full_sync.py
@@ -9,10 +9,20 @@ import zipfile
 from pathlib import Path
 
 import requests
+from dotenv import load_dotenv
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BACKEND_DIR = REPO_ROOT / "backend"
+
+
+def load_local_environment(env_file: Path = REPO_ROOT / ".env") -> None:
+    """Load ignored local credentials without overriding the caller's shell."""
+    load_dotenv(env_file, override=False)
+
+
+load_local_environment()
+
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 


### PR DESCRIPTION
## Summary
- load the ignored repository environment file in both residential full-sync entry points
- make the root example cover Docker Compose, Clerk, residential upload, TMDB, and RSS configuration
- prevent accidental commits of additional environment files
- correct the TMDB enrichment example so it respects the worker limit

## Verification
- backend suite: 247 passed and 19 subtests passed
- Docker Compose configuration rendered successfully from the example environment
- focused environment-contract tests: 4 passed

Real credentials remain untracked: production values stay in the root-owned server environment, GitHub-only values stay encrypted in the production environment, and residential upload credentials belong in the ignored local environment file.