### PR TITLE
Capture Letterboxd tags, list flags, review rewatch; add profile rename endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Database Configuration
 # Preferred local setup
 DATABASE_URL=postgresql+psycopg://localhost/spyboxd
+# Docker Compose uses this password for its isolated local PostgreSQL service.
+POSTGRES_PASSWORD=spyboxd-local
 
 # API Configuration
 API_HOST=localhost
@@ -10,27 +12,49 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # Clerk Auth (backend token verification)
 # Prefer CLERK_JWKS_URL for direct key discovery, or set CLERK_FRONTEND_API and let API derive JWKS URL.
-# CLERK_JWKS_URL=https://your-instance.clerk.accounts.dev/.well-known/jwks.json
-# CLERK_FRONTEND_API=https://your-instance.clerk.accounts.dev
-# CLERK_ISSUER=https://your-instance.clerk.accounts.dev
-# CLERK_AUTHORIZED_PARTIES=http://localhost:3000
+CLERK_JWKS_URL=
+CLERK_FRONTEND_API=
+CLERK_ISSUER=
+CLERK_AUTHORIZED_PARTIES=http://localhost:3000
 # Server-side fallback for admins; comma-separate exact Clerk user IDs.
-# CLERK_ADMIN_USER_IDS=user_abc123
+CLERK_ADMIN_USER_IDS=
 # Per-user abuse bounds for shared-profile tracking and residential-sync requests.
 SPYBOXD_MAX_TRACKED_PROFILES_PER_USER=25
 SPYBOXD_MAX_PENDING_PROFILE_REQUESTS_PER_USER=10
 
-# Optional trusted uploader token for residential-IP companion syncs
-# INGESTION_API_TOKEN=replace-with-a-long-random-secret
-# Optional default API URL for local sync scripts
-# SPYBOXD_API_BASE_URL=https://api.spyboxd.com
+# Frontend and Docker Compose. Copy the matching Clerk development-instance
+# values from frontend/.env.local when running the complete stack locally.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/
+NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/
+
+# Residential full-sync uploader. scripts/local_full_sync.py and
+# scripts/batch_full_sync.py load these values from the ignored root .env.
+SPYBOXD_API_BASE_URL=https://api.spyboxd.com
+SPYBOXD_SYNC_CONFIG=sync-profiles.json
+# Keep the real token only in the ignored local .env and /etc/spyboxd/api.env.
+INGESTION_API_TOKEN=
+# Alternative to INGESTION_API_TOKEN for an interactive Clerk-authenticated upload.
+SPYBOXD_BEARER_TOKEN=
 
 # Optional TMDB enrichment. Letterboxd ingestion and every legacy feature work without it.
 # Prefer a v4 read access token; the v3 API key remains supported by the enrichment command.
 # TMDB_API_TOKEN=replace-with-your-tmdb-read-access-token
 # TMDB_API_KEY=replace-with-your-tmdb-v3-api-key
 TMDB_DEFAULT_REGION=DE
+TMDB_LANGUAGE=en-US
 TMDB_CACHE_DAYS=30
+TMDB_REQUEST_PAUSE_SECONDS=0.25
+TMDB_ENRICHMENT_LIMIT=100
+TMDB_ENRICHMENT_BATCH_SIZE=10
+
+# Residential upload safety limits.
+UPLOAD_MAX_ARCHIVE_MEMBERS=50000
+UPLOAD_MAX_UNCOMPRESSED_BYTES=2147483648
 
 # Conservative incremental activity checks after an authoritative full sync.
 # RSS is additions/upserts only; it never replaces full Letterboxd history.
@@ -40,6 +64,7 @@ SPYBOXD_RSS_REQUEST_PAUSE_SECONDS=3
 SPYBOXD_RSS_MAX_BACKOFF_SECONDS=86400
 SPYBOXD_RSS_BATCH_SIZE=50
 SPYBOXD_RSS_USER_AGENT=Spyboxd/1.0 (+https://spyboxd.com)
+SPYBOXD_RSS_HEALTH_STALE_AFTER_SECONDS=2400
 
 # Debug Settings
 DEBUG_MODE=false

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 build/
 .venv/
 .env
+.env.*
+!.env.example
+*.env
 venv/
 env/
 !deploy/env/
@@ -28,6 +31,9 @@ data/backups/
 
 # Frontend
 frontend/node_modules/
+frontend/.env
+frontend/.env.*
+!frontend/.env.example
 frontend/.env.local
 frontend/.env.production.local
 frontend/build/

--- a/SOCIAL_GRAPH_DESIGN.md
+++ b/SOCIAL_GRAPH_DESIGN.md
@@ -1,0 +1,330 @@
+# Social Graph Feature Spec — Letterboxd Following/Followers for Tracked Profiles
+
+Repo: `/Users/yash/code/letterboxd-reviewer` (Spyboxd). Status: design only, no code changes made. All conventions below were verified against the current codebase (`backend/database/models.py`, `backend/services/ingestion.py`, `backend/services/profile_changes.py`, `backend/scraper_html.py`, `backend/services/profile_loader.py`, `backend/services/profile_access.py`, `alembic/versions/*`, `backend/tests/test_additive_migrations.py`).
+
+---
+
+## 1. Schema
+
+### 1.1 One table, direction column (recommended)
+
+Create a single table `profile_follow_edges` rather than separate `profile_following` / `profile_followers` tables.
+
+Rationale:
+- Both surfaces have an identical shape: "tracked profile X has a social relationship with Letterboxd user Y, observed on one of X's people pages." Two tables would duplicate the counterpart-identity columns, the lineage columns, the soft-removal machinery, the ingestion upsert, and the change-event plumbing.
+- The house already uses discriminator columns for same-shaped variants (`movie_watch_providers.provider_type` with a CHECK constraint; `profile_source_activities.activity_type` / `date_semantics`).
+- Mutual-follow and suggestion queries want both directions in one scan; a `direction` predicate on an indexed column is cheaper and simpler than a UNION across two tables.
+
+Semantics: each row is an **observation from the scanned profile's own pages**, not a canonical graph edge. `direction = 'following'` means "profile follows counterpart" (from `/{username}/following/`); `direction = 'follower'` means "counterpart follows profile" (from `/{username}/followers/`). When two tracked profiles follow each other, the same underlying relationship legitimately appears as up to four rows (A-following-B, B-follower-A, B-following-A, A-follower-B). This is intentional: each row's lifecycle (authoritative removal, lineage) is owned by the sync of the profile whose page produced it, exactly like every other per-profile dataset in this codebase. Deduplication happens at query time.
+
+### 1.2 Counterpart representation: username-keyed with an opportunistic nullable FK (recommended)
+
+Most followed/follower accounts will never be imported profiles. Do **not** create stub `profiles` rows for them:
+- `profiles` rows are heavyweight canonical datasets with `scraping_status`, sync history, catalog visibility, and access-request fulfillment semantics (`fulfill_pending_requests` keys off `profiles.username`). Thousands of stub rows would pollute the admin library and complicate every `scraping_status == 'completed'` filter.
+- The house precedent is exactly this problem already solved: `profile_access_requests` stores `requested_username` + `normalized_username` with a **nullable** `fulfilled_profile_id` FK that is attached when a canonical profile exists.
+
+So: store `counterpart_username` (display case) + `counterpart_username_normalized` (casefolded, the identity key), plus a nullable `counterpart_profile_id` FK (`ondelete="SET NULL"`) resolved opportunistically — at ingestion time via `lower(profiles.username)` match, and backfilled when a new profile later completes (hook alongside `fulfill_pending_requests` in the upload/import completion path). Also snapshot lightweight recognition fields (`counterpart_display_name`, `counterpart_avatar_url`), mirroring what `list_profile_catalog` calls "recognition fields".
+
+### 1.3 Model (house style)
+
+```python
+class ProfileFollowEdge(Base):
+    """One observed social edge from a tracked profile's following/followers pages."""
+
+    __tablename__ = "profile_follow_edges"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    profile_id = Column(Integer, ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False)
+    direction = Column(String(10), nullable=False)  # 'following' | 'follower'
+    counterpart_username = Column(String(50), nullable=False)
+    counterpart_username_normalized = Column(String(50), nullable=False)
+    counterpart_display_name = Column(String(200), nullable=True)
+    counterpart_avatar_url = Column(String(500), nullable=True)
+    counterpart_profile_url = Column(String(500), nullable=True)
+    counterpart_profile_id = Column(
+        Integer, ForeignKey("profiles.id", ondelete="SET NULL"), nullable=True
+    )
+    position = Column(Integer, nullable=True)  # source page order (approx. recency); semantics not guaranteed
+    first_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    last_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    removed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    profile = relationship("Profile", back_populates="follow_edges", foreign_keys=[profile_id])
+    counterpart_profile = relationship("Profile", foreign_keys=[counterpart_profile_id])
+
+    __table_args__ = (
+        UniqueConstraint(
+            "profile_id", "direction", "counterpart_username_normalized",
+            name="unique_profile_follow_edge",
+        ),
+        CheckConstraint("direction IN ('following', 'follower')", name="ck_profile_follow_edges_direction"),
+        CheckConstraint("position IS NULL OR position > 0", name="ck_profile_follow_edges_position_positive"),
+        CheckConstraint(
+            "counterpart_username_normalized = lower(counterpart_username_normalized)",
+            name="ck_profile_follow_edges_normalized_lower",
+        ),
+        Index("ix_profile_follow_edges_profile_removed", "profile_id", "removed_at"),
+        Index(  # reverse lookups: "who among tracked profiles follows user X"
+            "ix_profile_follow_edges_counterpart_active",
+            "counterpart_username_normalized", "direction", "profile_id",
+            postgresql_where=sql_text("removed_at IS NULL"),
+        ),
+        Index("ix_profile_follow_edges_counterpart_profile", "counterpart_profile_id"),
+    )
+```
+
+Also add `follow_edges` to `Profile.__mapper__` relationships (`cascade="all, delete-orphan"`, `foreign_keys="ProfileFollowEdge.profile_id"`).
+
+Key semantics:
+- **Uniqueness** is global (not partial on active rows), matching `unique_profile_watchlist_movie`: an unfollow soft-removes the row (`removed_at = now`), a re-follow resurrects it (`removed_at = None`, `last_seen_profile_sync_id = sync.id`), and the change feed correctly emits a fresh added event because `capture_profile_state` filters `removed_at IS NULL`.
+- **Lineage** matches house style exactly: `first_seen_profile_sync_id` set once at insert, `last_seen_profile_sync_id` updated every sync that observes the row, both `BigInteger` FK to `profile_syncs.id` with `ondelete="SET NULL"`.
+- **Unfollow semantics**: when the corresponding dataset is authoritative in a sync (its CSV was present in the bundle), any existing active edge for that `(profile_id, direction)` not present in the snapshot gets `removed_at = now` — identical to `_upsert_watchlist`. When the dataset is unavailable (private/forbidden/capped), prior state is preserved untouched, per the "prior imported state was preserved" convention.
+- `profiles.following_count` / `followers_count` already exist (with non-negative CHECKs) and continue to be the header-reported totals; edges are the enumerated membership.
+
+---
+
+## 2. Scraper (`backend/scraper_html.py`)
+
+### 2.1 New methods: `scrape_following()` / `scrape_followers()`
+
+Both share one implementation (`_scrape_people(dataset: str)`) parameterized by dataset name and start URL (`self.urls['following']` / `self.urls['followers']` — both URLs already exist in `self.urls`). Storage target: the existing `self.social_data['following']` / `self.social_data['followers']` lists.
+
+Per-page loop, following every house validation convention:
+
+1. `response = self.fetch_with_retry(page_url, allow_private_forbidden=True)`.
+2. If `self._is_private_forbidden_response(response)`: clear the partial list, `self._mark_unavailable(dataset, 'forbidden/private')`, print the "preserving prior imported state" warning, and return `[]` — mirroring `scrape_watchlist`. (A fully private profile 403s on people pages; the profile header itself may still have rendered counts.)
+3. `response = self._require_response(response, dataset, page_url)`.
+4. Parse person rows. Letterboxd renders people pages as a person table; use a grouped selector with fallbacks in the house style, e.g. `main.select('table.person-table td.table-person, .person-summary, li.listitem .person-summary')` — **selectors must be verified against live HTML during implementation**, same as the LazyPoster work was.
+5. Empty state: if page 1 yields no person rows, accept only when `self._declares_empty(soup, dataset)`; otherwise `raise ScrapeValidationError(f"{dataset} page {page_num} returned HTML but no recognized person rows")`. Extend the `_declares_empty` phrases dict:
+   - `'following': ("isn't following anyone", "is not following anyone", "not following any members", "isn\u2019t following anyone")`
+   - `'followers': ("no followers", "doesn't have any followers", "has no followers", "doesn\u2019t have any followers")`
+   (Exact phrases to be confirmed against live pages; the mechanism is the point.)
+6. Per row, extract: username (from the `/username/` href), display name (`a.name` text), avatar URL (`img src`/`data-src`). A recognized row lacking username or URL raises `ScrapeValidationError` (mirrors "Recognized film poster lacked title or URL"). Deduplicate by casefolded username across pages; assign `position` as running source order.
+7. `page_url = self._next_page_url(soup, page_url)`; `time.sleep(1)` between pages ("Be respectful" convention).
+8. On completion: `self._finish_dataset(dataset)`.
+
+### 2.2 Page-count expectations from the profile header
+
+`scrape_profile_info()` already extracts `following_count` and `followers_count` from the header stat links. Use them two ways:
+
+- **Pre-flight estimate and cap**: people pages hold 25 entries per page, so expected pages = `ceil(count / 25)`. If `count > SPYBOXD_MAX_FOLLOW_EDGES_PER_SURFACE` (env, default e.g. 5,000 ≈ 200 pages), do not partially scrape: `self._mark_unavailable(dataset, f"count {count} exceeds configured cap")`. Fail-closed-or-skip beats silently partial data — this repo never records an unproven-complete dataset.
+- **Post-scrape validation**: after pagination completes, compare `len(entries)` with the header count, mirroring the list-membership check ("reported N films but only M were captured"). Because follower counts can drift between the header fetch and the last page, allow a small tolerance (recommend: exact match OR within `max(2, 1%)`; outside tolerance, raise `ScrapeValidationError`). Document the tolerance in the manifest metadata for the dataset.
+
+### 2.3 CSV contract
+
+Two new scraper-owned files in the bundle:
+
+`following.csv` — one row per account the profile follows, in source order:
+
+| Column | Notes |
+|---|---|
+| `Position` | 1-based source order across pages |
+| `Username` | Letterboxd username as displayed in URL |
+| `Display_Name` | may be empty |
+| `Avatar_URL` | may be empty |
+| `Profile_URL` | absolute `https://letterboxd.com/{username}/` |
+
+`followers.csv` — identical columns, one row per follower.
+
+Writers `_save_following()` / `_save_followers()` follow the existing pattern: gated on `dataset in self.completed_datasets`, written via `self._write_csv`. Add both datasets to `_remove_stale_unavailable_files`'s `dataset_files` map (`'following': ('following.csv',)`, `'followers': ('followers.csv',)`) so a previously-public surface that went private has its stale CSV removed.
+
+Manifest: add `'following', 'followers'` to `self.requested_datasets` in `scrape_all()`, and to the `counts` dict in `save_all_data()`. Bump `schema_version` to **3** (see §3.1 for why).
+
+Call order in `scrape_all()`: after `scrape_profile_info()` (so header counts exist) — recommend immediately after profile info, before the heavy film surfaces, since people pages are cheap and fail fast.
+
+---
+
+## 3. Loader / contracts / ingestion
+
+### 3.1 `backend/services/profile_loader.py`
+
+- `LoadedProfileData` gains `following: pd.DataFrame` and `followers: pd.DataFrame`; `load_profile_data` reads `following.csv` / `followers.csv` via `read_source` when present (they land in `source_files` with sha256 + row_count automatically).
+- `validate_import_bundle`: **do not** add the new datasets to `FULL_SCRAPE_REQUIRED_DATASETS` unconditionally — that would retroactively invalidate every existing schema-v2 bundle ("Full scrape manifest did not request datasets"). Instead gate on manifest version: for `schema_version >= 3`, require `following`/`followers` to be requested and accounted (completed or unavailable), extend the observed-counts check (`"following": len(loaded.following)` etc.), and extend the `dataset_files` map (`"following": "following.csv"`, `"followers": "followers.csv"`). v2 bundles remain valid without them. Neither dataset joins the `mandatory` set (they can legitimately be unavailable for private profiles).
+- Official Letterboxd account exports do **not** include a social graph, so `letterboxd_export` bundles simply never carry these files; nothing to do there.
+
+### 3.2 `backend/services/ingestion.py`
+
+New `_upsert_follow_edges(...)` modeled directly on `_upsert_watchlist`:
+
+```python
+def _upsert_follow_edges(*, analyzer_profile, profile_id, sync, direction, frame, authoritative, db) -> int:
+    existing = {edge.counterpart_username_normalized: edge
+                for edge in db.query(ProfileFollowEdge).filter(
+                    ProfileFollowEdge.profile_id == profile_id,
+                    ProfileFollowEdge.direction == direction).all()}
+    seen = set()
+    for source_position, row in enumerate(frame_records(frame), start=1):
+        username = clean_text(first_value(row, ("Username",)), max_length=50)
+        if not username:
+            continue
+        normalized = username.casefold()
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        edge = existing.get(normalized)
+        if edge is None:
+            edge = ProfileFollowEdge(profile_id=profile_id, direction=direction,
+                                     counterpart_username_normalized=normalized,
+                                     first_seen_profile_sync_id=sync.id)
+            db.add(edge)
+        edge.counterpart_username = username
+        edge.counterpart_display_name = clean_text(first_value(row, ("Display_Name", "Display Name")), max_length=200)
+        edge.counterpart_avatar_url = clean_text(first_value(row, ("Avatar_URL", "Avatar URL")), max_length=500)
+        edge.counterpart_profile_url = normalize_letterboxd_url(first_value(row, ("Profile_URL", "Profile URL")))
+        edge.position = parse_integer(first_value(row, ("Position",)), minimum=1) or source_position
+        edge.counterpart_profile_id = counterpart_ids.get(normalized)  # bulk lower(username) lookup
+        edge.last_seen_profile_sync_id = sync.id
+        edge.removed_at = None
+    if authoritative:
+        now = _utcnow()
+        for normalized, edge in existing.items():
+            if normalized not in seen and edge.removed_at is None:
+                edge.removed_at = now
+    db.flush()
+    return len(seen)
+```
+
+Wiring inside `unified_data_loader`:
+- `following_authoritative = _source_present(analyzer_profile, "following.csv")`; likewise `followers_authoritative` — same rule as every other surface: file present in bundle ⇒ authoritative snapshot; file absent (including `_mark_unavailable`, whose CSVs are deleted) ⇒ non-authoritative, prior state preserved.
+- Add `"following"` / `"followers"` to the `authoritative` dict, `imported_counts`, `_dataset_file_names` mapping (`"following": ["following.csv"]`, `"followers": ["followers.csv"]`), and the dataset-name tuple in `_upsert_sync_datasets` — this produces the required **`sync_datasets` rows** with `source_filename`, `source_sha256`, `source_row_count`, `imported_row_count`, `is_authoritative`, and `unavailable_reason` in `metadata_payload`, for free.
+- `_build_coverage`: add `following_available` / `followers_available` flags and limitation strings ("Social graph unavailable (forbidden/private); prior imported state was preserved." / "Following/follower data was not included in this sync.").
+- Counterpart backfill hook: after a sync completes for a *new* profile (the same code path that calls `fulfill_pending_requests`), run one UPDATE attaching `counterpart_profile_id` on active edges whose `counterpart_username_normalized = lower(new_profile.username)`.
+
+### 3.3 Change events (`backend/services/profile_changes.py`)
+
+- `capture_profile_state` gains two surfaces, keyed by counterpart:
+  - `"following"`: `{f"user:{normalized}": {"username", "display_name", "profile_url", "counterpart_profile_id"}}` over active `direction='following'` edges.
+  - `"followers"`: same over `direction='follower'` edges.
+- `record_profile_changes` gains two `membership_changes` calls gated on `authoritative.get("following")` / `authoritative.get("followers")`:
+  - `follow_added` / `follow_removed` (entity_type `'follow'`, dataset `'following'`) — the profile followed/unfollowed someone.
+  - `follower_gained` / `follower_lost` (entity_type `'follow'`, dataset `'followers'`).
+- `movie_id` / `movie_list_id` stay NULL; the payloads carry the counterpart identity. `change_key = f"{change_type}|{entity_key}"` stays well under 600 chars.
+- **Constraint change required**: `ck_profile_data_changes_entity_type` currently enumerates `('film','watchlist','favorite','diary','review','list','list_item')`. The migration must drop and recreate it with `'follow'` appended (safe: new list is a superset, existing rows all satisfy it).
+- The existing baseline rule applies untouched: a first import (`has_baseline == False`) records no events, so onboarding a profile with 3,000 followers does not flood the feed. `GET /api/recent-changes` (`backend/api/routes/activity.py`) serves the new change types with zero route changes.
+
+---
+
+## 4. Migration
+
+### 4.1 Alembic revision (additive, house pattern)
+
+`alembic/versions/20260731_0010_add_profile_follow_edges.py`:
+- `revision = "20260731_0010"`, `down_revision = "20260730_0009"`.
+- `op.create_table("profile_follow_edges", ...)` using `sa.BigInteger(), sa.Identity()` PK (matching `20260729_0004`), all columns/FKs/CHECKs/unique constraint from §1.3, then `op.create_index` for the three indexes (the partial one via `postgresql_where=sa.text("removed_at IS NULL")`).
+- Widen the change-feed constraint in the same revision (or defer to the phase-3 revision if phase 1 ships standalone — either is acceptable; one revision is simpler):
+  ```python
+  op.drop_constraint("ck_profile_data_changes_entity_type", "profile_data_changes", type_="check")
+  op.create_check_constraint(
+      "ck_profile_data_changes_entity_type", "profile_data_changes",
+      "entity_type IN ('film','watchlist','favorite','diary','review','list','list_item','follow')",
+  )
+  ```
+- `downgrade()` reverses: restore the original CHECK, drop indexes, drop table.
+- The table is empty at migration time; existing profile snapshots become the baseline on their next v3 sync — same statement the `20260729_0004` docstring makes.
+- Also add `"profile_follow_edges"` to `TABLE_COPY_ORDER` in `backend/database/migrate.py` (after `"profile_favorite_movies"`, before `"profile_source_activities"` — anywhere after `profiles`/`profile_syncs` works) so SQLite-import tooling and truncation ordering stay correct.
+
+### 4.2 Tests mirroring `backend/tests/test_additive_migrations.py`
+
+- Bump `HEAD_REVISION = "20260731_0010"`; extend `test_revision_chain_has_one_expected_head` with the new link (`down_revision == "20260730_0009"`).
+- `test_model_metadata_exposes_the_foundation_contract`: add `"profile_follow_edges"` to `expected_tables`; add expected columns (`profile_id`, `direction`, `counterpart_username_normalized`, `counterpart_profile_id`, `first_seen_profile_sync_id`, `last_seen_profile_sync_id`, `removed_at`); add `{"profile_follow_edges": {"unique_profile_follow_edge"}}` to the unique-constraint contract; assert the widened entity-type CHECK in `Base.metadata` includes `'follow'`; optionally assert the migration source contains the recreated constraint string (matches the source-grep style used for `0008`/`0009`).
+- `AdditiveMigrationPostgresTests` (isolated loopback schema, `SPYBOXD_TEST_DATABASE_URL`-gated): upgrade chain now ends at the new head; add assertions that (a) legacy application reads snapshotted at `LEGACY_REVISION` are unchanged, (b) inserting a duplicate `(profile_id, direction, counterpart_username_normalized)` raises, (c) a `profile_data_changes` row with `entity_type='follow'` inserts cleanly post-migration and fails pre-migration.
+- Ingestion behavior tests live beside `test_profile_changes.py` / `test_import_contracts.py`: authoritative removal sets `removed_at`; unavailable dataset preserves prior edges; re-follow resurrects and re-emits `follow_added`; first import emits nothing.
+
+---
+
+## 5. API
+
+New module `backend/api/routes/follow_graph.py`, `router = APIRouter(prefix="/api", tags=["follow graph"])`, registered in `backend/main.py` next to the existing three routers. All scoping reuses `backend/services/profile_access.py` primitives — no new auth logic.
+
+### 5.1 Per-profile graph
+
+```
+GET /api/profiles/{username}/follow-graph
+    ?direction=following|followers|both (default both)
+    &include_removed=false
+    &limit=100&offset=0
+```
+- Access: `require_profile_access(db, user, username)` — admins see any profile, ordinary users only tracked ones (403 with the standard "Track this profile" detail otherwise).
+- Response per edge: `counterpart_username`, `counterpart_display_name`, `counterpart_avatar_url`, `counterpart_profile_url`, `position`, `is_imported_profile` (counterpart_profile_id attached and that profile `is_active` + `completed`), `removed_at`, plus `following_count`/`followers_count` header totals and per-dataset coverage (from the latest sync's `sync_datasets` rows) so the UI can say "followers unavailable: private".
+
+### 5.2 Mutual follows across tracked profiles
+
+```
+GET /api/follow-graph/mutuals?profiles=a&profiles=b...
+```
+- Access: `authorize_profile_usernames(db, user, profiles)` — omitted selection expands to the caller's completed tracked set; explicit untracked names 403; admin may name any profiles (admin with no selection uses `accessible_profiles`).
+- For each ordered pair (A, B) in the selection: `a_follows_b` is true iff an active edge `(A, 'following', lower(B))` exists, with fallback corroboration from `(B, 'follower', lower(A))` when A's following surface is unavailable; symmetric for `b_follows_a`; `mutual = both`. Response is a pair matrix plus per-profile "follows N / followed by M of this group" rollups. This slots naturally beside `pair_dossier` in the insights family.
+
+### 5.3 "Who to track next" suggestions
+
+```
+GET /api/follow-graph/suggestions?limit=20&min_overlap=2
+```
+- Scope: ordinary users — aggregated only over their own tracked profiles (per-user tracking cap of 25 keeps this tiny); admins in global scope — over all active profiles.
+- Core ranking query (uses `ix_profile_follow_edges_counterpart_active`):
+
+```sql
+SELECT counterpart_username_normalized,
+       max(counterpart_username)        AS username,
+       count(DISTINCT profile_id)       AS followed_by_count,
+       bool_or(counterpart_profile_id IS NOT NULL) AS already_imported
+FROM profile_follow_edges
+WHERE direction = 'following' AND removed_at IS NULL
+  AND profile_id = ANY(:scoped_profile_ids)
+GROUP BY counterpart_username_normalized
+HAVING count(DISTINCT profile_id) >= :min_overlap
+ORDER BY followed_by_count DESC, username ASC
+LIMIT :limit
+```
+- Exclude counterparts already in the caller's tracked set; annotate each suggestion with `followed_by` (the tracked usernames producing the overlap), `follows_back_count` (active `direction='follower'` edges naming this counterpart — a reciprocity tiebreaker), `already_imported` (one-click `track_profile_by_id`) versus not-imported (routes to the existing `track_or_request_profile` request flow). Ordinary users see only usernames drawn from profiles they already track — no cross-user data leakage, consistent with the "global cache cannot leak hidden-profile aggregates" integrity note in `DATABASE.md`.
+- Add coverage to `backend/tests/test_route_access_matrix.py` for all three endpoints (admin / tracked / untracked / anonymous).
+
+---
+
+## 6. Frontend touchpoints (later phase)
+
+All pages already consume scope via `frontend/src/hooks/useAdminScope.tsx` (tracked vs global admin view) and `frontend/src/hooks/useScopedProfiles.ts`; the new endpoints are scoped server-side, so the frontend only chooses which usernames to ask about.
+
+- **Profiles** (`frontend/src/app/(app)/profiles/page.tsx`): per-profile following/followers counts already exist on `Profile.to_dict()`; add a follow-graph drawer (per-profile endpoint) and a "Who to track next" panel backed by `/api/follow-graph/suggestions`, with the existing track/request affordances (`profileApi` in `frontend/src/services/api.ts` gains three functions).
+- **Compare** (`frontend/src/app/(app)/compare/page.tsx`): mutual/one-way follow badge for the selected pair/group from `/api/follow-graph/mutuals`; natural companion to the pair dossier.
+- **Spy Signals** (`frontend/src/app/(app)/spy-signals/page.tsx`): follow/unfollow/follower-gained/lost events arrive automatically through the existing `/api/recent-changes` feed once change types exist; the feed renderer needs cases for the four new `change_type` values (counterpart avatar + username instead of a poster).
+
+---
+
+## 7. Risks and constraints
+
+- **Page volume**: people pages hold 25 entries. A profile following 2,000 accounts is 80 pages; both surfaces for a 10k-follower account is ~800 requests. With the mandatory 1s inter-page sleep that is ~13+ minutes added to a full sync for one popular profile. Mitigations: the header-count pre-flight cap (§2.2, `_mark_unavailable` on exceed rather than partial capture), scraping people pages only (a) on first import and (b) on a configurable cadence (e.g. every Nth full sync or a `--skip-social` flag on `scripts/local_full_sync.py` / `scripts/batch_full_sync.py`), since a v3 bundle without the CSVs is simply non-authoritative for those surfaces and preserves prior edges.
+- **Rate limiting / politeness**: `fetch_with_retry` already handles 429 with long exponential backoff; keep the 1s sleep, and consider raising it to 2s for people pages since they contribute no film data urgency. All scraping remains on the residential machine — the server runtime never scrapes (unchanged architecture).
+- **Count drift**: follower counts move while paginating; the tolerance rule in §2.2 prevents both false failures and silently-partial data. Record observed-vs-header counts in the dataset `metadata_payload`.
+- **Privacy / ethics**: this is public-page data, but a *diffed social graph over time* (who unfollowed whom, when) is materially more sensitive than film lists — it is exactly the "spy" surface. Constraints: never scrape past a 403 (`_is_private_forbidden_response` handling is mandatory, not best-effort); store only recognition fields for counterparts (username/display/avatar), never enumerate or crawl counterpart profiles themselves; unfollow events are visible only to users who track the observed profile (enforced by existing `recent-changes` scoping); suggestions never reveal which *other app users* track anyone. Letterboxd ToS discourages scraping — the existing residential, throttled, fail-closed posture applies; the social surfaces roughly double request volume, which strengthens the cadence-throttling mitigation above.
+- **Why RSS cannot help**: `profile_feed_states` polls `letterboxd.com/{user}/rss/`, which contains only diary/review/list activity items — Letterboxd publishes no feed of follow/unfollow events and no per-user social-graph feed at all. Follow churn is therefore invisible to the conservative RSS poller by construction; the only observation channel is re-paginating the HTML people pages, which is why this feature rides the full-sync bundle path and why edge freshness is bounded by full-sync cadence, not the RSS window. (Consistent with the repo's rule that RSS is never authoritative and can never remove data.)
+
+---
+
+## 8. Phased implementation plan
+
+| Phase | Scope | Effort |
+|---|---|---|
+| 1 | Schema + migration + model + migration tests + docs | ~0.5–1 day |
+| 2 | Scraper surfaces + CSV + manifest v3 + loader/validation (incl. live-HTML selector verification) | ~1.5–2 days |
+| 3 | Ingestion (`_upsert_follow_edges`, sync_datasets, coverage) + change events + counterpart backfill + tests | ~1.5–2 days |
+| 4 | API endpoints + access-matrix tests | ~1–1.5 days |
+| 5 | Frontend (Profiles drawer + suggestions panel, Compare badge, Spy Signals renderers) | ~2–3 days |
+
+Phases 1–3 are independently shippable and inert (empty table; old bundles unaffected; v3 bundles only appear once the residential scraper updates). Phase 4 requires 3; phase 5 requires 4.
+
+### Phase 1 file-by-file change list
+
+1. `backend/database/models.py` — add `ProfileFollowEdge` model (§1.3) and the `follow_edges` relationship on `Profile` (with explicit `foreign_keys` since the table has two FKs to `profiles`).
+2. `alembic/versions/20260731_0010_add_profile_follow_edges.py` — new revision (§4.1): create table + indexes, widen `ck_profile_data_changes_entity_type` to include `'follow'`, full `downgrade()`.
+3. `backend/database/migrate.py` — add `"profile_follow_edges"` to `TABLE_COPY_ORDER`.
+4. `backend/tests/test_additive_migrations.py` — `HEAD_REVISION = "20260731_0010"`; extend revision-chain assertions, `expected_tables`, `expected_columns`, `expected_unique_constraints`; Postgres-schema assertions for the new table and widened CHECK (§4.2).
+5. `DATABASE.md` — new "### `profile_follow_edges`" subsection under the Normalized Data Foundation, an entry in the Relationships tree (`profiles ├─ profile_follow_edges`), and a Data Integrity note that edges are per-profile observations with soft removal and that the first social sync is a baseline emitting no change events.
+
+Later-phase file map (for reference): phase 2 → `backend/scraper_html.py`, `backend/services/profile_loader.py`; phase 3 → `backend/services/ingestion.py`, `backend/services/profile_changes.py`, upload-completion hook (same module that calls `fulfill_pending_requests`), `backend/tests/test_profile_changes.py` + a new `backend/tests/test_follow_edges_ingestion.py`; phase 4 → `backend/api/routes/follow_graph.py`, `backend/main.py`, `backend/tests/test_route_access_matrix.py`; phase 5 → `frontend/src/services/api.ts`, `frontend/src/app/(app)/{profiles,compare,spy-signals}/page.tsx`.

--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -4,12 +4,14 @@ from itertools import combinations
 from sqlalchemy.orm import Session
 from sqlalchemy import and_, case, desc, extract, false, func, or_
 from .models import (
+    AppUser,
     Movie,
     MovieList,
     MovieListItem,
     Profile,
     ProfileDataChange,
     ProfileFavoriteMovie,
+    ProfileFeedState,
     ProfileFilm,
     ProfileSourceActivity,
     ProfileSync,
@@ -632,6 +634,38 @@ class ProfileRepository:
             .filter(func.lower(Profile.username) == username.strip().casefold())
             .one_or_none()
         )
+
+    def rename_profile(self, profile: Profile, new_username: str) -> bool:
+        """Carry a canonical profile to a new Letterboxd username in place.
+
+        Letterboxd 404s old profile URLs without a redirect after a username
+        change, so the imported dataset keeps its identity and the RSS feed
+        state is repointed at the new feed URL with its failure backoff
+        cleared. App users whose account mirrors the old username follow it.
+        Returns whether a feed state row was repointed.
+        """
+        old_username = profile.username
+        profile.username = new_username
+
+        feed_state = self.db.get(ProfileFeedState, profile.id)
+        if feed_state is not None:
+            # Mirrors services.rss_incremental._default_feed_url; usernames
+            # are restricted to [A-Za-z0-9_-] so no quoting is required.
+            feed_state.feed_url = f"https://letterboxd.com/{new_username}/rss/"
+            feed_state.consecutive_failures = 0
+            feed_state.last_error = None
+            feed_state.last_http_status = None
+            feed_state.next_poll_at = datetime.now(timezone.utc)
+
+        self.db.query(AppUser).filter(
+            func.lower(AppUser.letterboxd_username) == old_username.strip().casefold()
+        ).update(
+            {AppUser.letterboxd_username: new_username},
+            synchronize_session=False,
+        )
+
+        self.db.commit()
+        return feed_state is not None
     
     def get_profile_by_id(self, profile_id: int) -> Optional[Profile]:
         return self.db.query(Profile).filter(Profile.id == profile_id).first()

--- a/backend/main.py
+++ b/backend/main.py
@@ -117,6 +117,10 @@ class ProfileUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
+class ProfileRename(BaseModel):
+    new_username: str
+
+
 class PublicSystemStats(BaseModel):
     total_profiles: int = Field(ge=0)
     total_movies_tracked: int = Field(ge=0)
@@ -807,6 +811,46 @@ async def update_profile(
     _refresh_dashboard_snapshot_cache(db)
     
     return {"message": f"Profile updated for {username}", "profile": updated_profile.to_dict()}
+
+@app.post("/profiles/{username}/rename")
+async def rename_profile(
+    username: str,
+    payload: ProfileRename,
+    db: Session = Depends(get_db),
+    _user: ClerkUser = Depends(get_active_upload_user),
+):
+    """Carry a profile to a renamed Letterboxd account.
+
+    Letterboxd 404s the old URLs without a redirect, so the residential sync
+    workflow needs to rename the canonical profile in place (keeping every
+    imported dataset and tracking mapping) before uploading a fresh bundle
+    under the new username — otherwise the upload would create a duplicate.
+    Shares the ingestion-token trust model with /upload/.
+    """
+    new_username = payload.new_username.strip()
+    if not re.fullmatch(r"[A-Za-z0-9_-]{1,50}", new_username):
+        raise HTTPException(status_code=422, detail="Invalid Letterboxd username")
+
+    profile_repo = ProfileRepository(db)
+    profile = profile_repo.get_profile_by_username(username)
+    if not profile:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+    existing = profile_repo.get_profile_by_username(new_username)
+    if existing is not None and existing.id != profile.id:
+        raise HTTPException(status_code=409, detail="Target username already exists")
+
+    old_username = profile.username
+    feed_repointed = profile_repo.rename_profile(profile, new_username)
+    _refresh_dashboard_snapshot_cache(db)
+
+    return {
+        "message": f"Profile renamed from {old_username} to {new_username}",
+        "old_username": old_username,
+        "new_username": new_username,
+        "feed_repointed": feed_repointed,
+    }
+
 
 @app.delete("/profiles/{username}")
 async def delete_profile(

--- a/backend/scraper_html.py
+++ b/backend/scraper_html.py
@@ -101,7 +101,9 @@ class EnhancedLetterboxdScraper:
             'lists': f"https://letterboxd.com/{username}/lists/",
             'following': f"https://letterboxd.com/{username}/following/",
             'followers': f"https://letterboxd.com/{username}/followers/",
-            'stats': f"https://letterboxd.com/{username}/films/stats/",
+            # NOTE: /films/stats/ is a 404; the live stats page is /stats/.
+            'stats': f"https://letterboxd.com/{username}/stats/",
+            'tags': f"https://letterboxd.com/{username}/tags/",
         }
         
         # Letterboxd currently challenges ordinary requests/cloudscraper on paginated
@@ -269,6 +271,12 @@ class EnhancedLetterboxdScraper:
                 'hasn\u2019t selected any favourite films',
                 "hasn't selected any favourite films",
             ),
+            # Tag index pages render "No <kind> tags yet" and omit the
+            # ul.js-tags-section entirely when a kind has no tags.
+            'tags_films': ('no film tags yet',),
+            'tags_diary': ('no diary tags yet',),
+            'tags_reviews': ('no review tags yet',),
+            'tags_lists': ('no list tags yet',),
         }
         return any(phrase in text for phrase in phrases.get(dataset, ()))
 
@@ -316,6 +324,47 @@ class EnhancedLetterboxdScraper:
             return False
         cell_classes = set(rewatch_cell.get('class', []))
         return 'icon-status-on' in cell_classes or 'icon-status-off' not in cell_classes
+
+    @staticmethod
+    def _extract_viewing_id(element) -> str:
+        """Numeric viewing id from data-object-id="viewing:<id>" or data-viewing-id."""
+        if element is None:
+            return ''
+        direct = str(element.get('data-viewing-id', '') or '').strip()
+        if direct:
+            return direct
+        match = re.search(r'viewing:(\d+)', str(element.get('data-object-id', '') or ''))
+        return match.group(1) if match else ''
+
+    @staticmethod
+    def _extract_review_rewatch(review_elem) -> bool:
+        """Review listings mark rewatches only via the attribution context text."""
+        if review_elem is None:
+            return False
+        context = review_elem.select_one('span.attribution-detail a.context, a.context')
+        if context is None:
+            return False
+        return context.get_text(' ', strip=True).casefold().startswith('rewatched')
+
+    @staticmethod
+    def _serialize_tags(tags) -> str:
+        """Tags travel as a JSON array so tags containing delimiters survive CSV."""
+        return json.dumps(sorted(tags or []), ensure_ascii=False)
+
+    @staticmethod
+    def _extract_list_detail_metadata(soup: BeautifulSoup) -> Dict:
+        """Ranked flag and publish/update timestamps only exist on list detail pages."""
+        published = soup.select_one('p.list-date span.published time[datetime]')
+        updated = soup.select_one('p.list-date span.updated time[datetime]')
+        is_ranked = soup.select_one(
+            'li.posteritem.numbered-list-item, p.list-number, '
+            'article.list-detailed-entry span.position'
+        ) is not None
+        return {
+            'is_ranked': is_ranked,
+            'published_date': published.get('datetime', '') if published else '',
+            'updated_date': updated.get('datetime', '') if updated else '',
+        }
 
     @staticmethod
     def _extract_display_name(soup: BeautifulSoup) -> str:
@@ -661,6 +710,8 @@ class EnhancedLetterboxdScraper:
                         'review_date': review_date,
                         'review_likes': review_likes,
                         'contains_spoilers': contains_spoilers,
+                        'is_rewatch': self._extract_review_rewatch(review_elem),
+                        'viewing_id': self._extract_viewing_id(review_elem),
                         'film_url': identity['film_url'],
                         'film_id': identity['film_id'],
                         'slug': identity['slug'],
@@ -816,11 +867,225 @@ class EnhancedLetterboxdScraper:
             raise ScrapeValidationError("Custom lists resolved to zero without an explicit empty state")
         self.lists_data = lists
         self.list_items_data = self._scrape_list_memberships(lists)
-        self._finish_dataset('lists')
+        if 'lists' in self.unavailable_datasets:
+            # A private list detail aborted the membership crawl; preserve
+            # prior imported state instead of saving partial metadata.
+            self.lists_data = []
+        else:
+            self._finish_dataset('lists')
         if 'list_items' not in self.unavailable_datasets:
             self._finish_dataset('list_items')
         print(f"✓ Found {len(lists)} custom lists")
         return lists
+
+    @staticmethod
+    def _extract_tag_entries(soup: BeautifulSoup) -> List[Dict]:
+        """Parse a /tags/<kind>/ index into [{'name', 'slug', 'count'}].
+
+        A count of exactly 1 renders as an empty span.detail.-has-no-count;
+        abbreviated counts (e.g. "2.1K") disable the exact-count validation.
+        """
+        entries = []
+        for item in soup.select('ul.js-tags-section li.hoverable'):
+            link = item.select_one('a[href*="/tag/"]')
+            if link is None:
+                raise ScrapeValidationError("Recognized tag item lacked a tag link")
+            slug_match = re.search(r'/tag/([^/]+)/', link.get('href', ''))
+            name = (link.get('title') or link.get_text(' ', strip=True) or '').strip()
+            if not slug_match or not name:
+                raise ScrapeValidationError("Recognized tag link lacked slug or name")
+            detail = item.select_one('span.detail')
+            count_text = detail.get_text(strip=True).replace(',', '') if detail else ''
+            if not count_text:
+                count = 1
+            elif count_text.isdigit():
+                count = int(count_text)
+            else:
+                count = None  # abbreviated ("2.1K"); skip exact validation
+            entries.append({'name': name, 'slug': slug_match.group(1), 'count': count})
+        return entries
+
+    def _extract_tagged_keys(self, soup: BeautifulSoup, kind: str) -> List:
+        """Matching keys for one per-tag page: film identity, viewing id, or list path."""
+        main = soup.select_one('main') or soup
+        if kind == 'films':
+            keys = []
+            for poster in self._lazy_posters(main):
+                identity = self._poster_identity(poster)
+                if not identity['film_id'] and not identity['slug']:
+                    raise ScrapeValidationError("Tagged film poster lacked id and slug")
+                keys.append((identity['film_id'], identity['slug']))
+            return keys
+        if kind == 'diary':
+            rows = main.select('tr.diary-entry-row[data-viewing-id], tbody tr[data-viewing-id]')
+            return [self._extract_viewing_id(row) for row in rows]
+        if kind == 'reviews':
+            articles = [
+                article for article in main.select('article')
+                if self._extract_viewing_id(article)
+            ]
+            return [self._extract_viewing_id(article) for article in articles]
+        if kind == 'lists':
+            keys = []
+            for summary in main.select('article.list-summary'):
+                link = summary.select_one('h2.name a, h2 a')
+                if link is None or not link.get('href'):
+                    raise ScrapeValidationError("Tagged list summary lacked a list link")
+                keys.append(self._normalize_list_path(link['href']))
+            return keys
+        raise ValueError(f"Unknown tag kind: {kind}")
+
+    @staticmethod
+    def _normalize_list_path(url: str) -> str:
+        path = urlparse(urljoin('https://letterboxd.com/', url or '')).path
+        return path if path.endswith('/') else f"{path}/"
+
+    def scrape_tags(self) -> Dict[str, Dict]:
+        """Crawl the public tags surfaces and attach tags to already-scraped rows.
+
+        Letterboxd never renders tags on the diary table or review listings; the
+        only complete public surfaces are /<user>/tags/<kind>/ indexes plus the
+        per-tag pages, whose markup matches surfaces we already parse (LazyPoster
+        grid, diary rows with data-viewing-id, review articles with
+        data-object-id="viewing:<id>", list summaries). Tags ride existing CSVs
+        as an authoritative Tags column, so an unproven crawl must fail the
+        scrape rather than silently emit an authoritative-empty column.
+        """
+        print(f"🏷️  Scraping tags for {self.username}...")
+
+        kinds = ['films', 'diary', 'reviews']
+        if 'lists' not in self.unavailable_datasets:
+            kinds.append('lists')
+
+        index: Dict[str, List[Dict]] = {}
+        for kind in kinds:
+            # Tag indexes paginate at 120 tags per page with the standard
+            # next link; only page 1 renders the empty-state copy.
+            page_url = urljoin(self.urls['tags'], f'{kind}/')
+            entries: List[Dict] = []
+            first_page_soup = None
+            while page_url:
+                response = self._require_response(
+                    self.fetch_with_retry(page_url), f'tags {kind} index', page_url
+                )
+                soup = BeautifulSoup(response.content, 'html.parser')
+                if first_page_soup is None:
+                    first_page_soup = soup
+                page_entries = self._extract_tag_entries(soup)
+                if not page_entries and entries:
+                    raise ScrapeValidationError(
+                        f"Tags index for {kind} paginated to a page with no recognized tags"
+                    )
+                entries.extend(page_entries)
+                page_url = self._next_page_url(soup, page_url)
+                time.sleep(1)
+            if not entries and not self._declares_empty(first_page_soup, f'tags_{kind}'):
+                raise ScrapeValidationError(
+                    f"Tags index for {kind} returned no recognized tags or explicit empty state"
+                )
+            index[kind] = entries
+
+        collected_tags = {kind: {} for kind in kinds}
+        for kind in kinds:
+            for entry in index[kind]:
+                name, slug, expected = entry['name'], entry['slug'], entry['count']
+                page_url = f"https://letterboxd.com/{self.username}/tag/{slug}/{kind}/"
+                collected = 0
+                page_num = 1
+                while page_url:
+                    response = self._require_response(
+                        self.fetch_with_retry(page_url), f'tag {name!r} {kind}', page_url
+                    )
+                    soup = BeautifulSoup(response.content, 'html.parser')
+                    keys = self._extract_tagged_keys(soup, kind)
+                    if not keys:
+                        raise ScrapeValidationError(
+                            f"Tag {name!r} {kind} page {page_num} returned no recognized entries"
+                        )
+                    for key in keys:
+                        collected_tags[kind].setdefault(key, set()).add(name)
+                    collected += len(keys)
+                    page_url = self._next_page_url(soup, page_url)
+                    page_num += 1
+                    time.sleep(1)
+                if expected is not None and collected != expected:
+                    raise ScrapeValidationError(
+                        f"Tag {name!r} {kind} reported {expected} entries "
+                        f"but {collected} were captured"
+                    )
+
+        self._attach_tags(
+            collected_tags.get('films', {}),
+            collected_tags.get('diary', {}),
+            collected_tags.get('reviews', {}),
+            collected_tags.get('lists', {}),
+        )
+        print(
+            "✓ Attached tags to "
+            f"{len(collected_tags.get('films', {}))} films, "
+            f"{len(collected_tags.get('diary', {}))} diary entries, "
+            f"{len(collected_tags.get('reviews', {}))} reviews, "
+            f"{len(collected_tags.get('lists', {}))} lists"
+        )
+        return collected_tags
+
+    def _attach_tags(self, film_tags, diary_tags, review_tags, list_tags) -> None:
+        """Attach crawled tags onto scraped rows; every tagged key must resolve."""
+        by_film_id = {}
+        by_slug = {}
+        for film in self.films_data:
+            if film.get('film_id'):
+                by_film_id[str(film['film_id'])] = film
+            if film.get('slug'):
+                by_slug[film['slug']] = film
+        for (film_id, slug), tags in film_tags.items():
+            film = by_film_id.get(str(film_id)) if film_id else None
+            if film is None and slug:
+                film = by_slug.get(slug)
+            if film is None:
+                raise ScrapeValidationError(
+                    f"Tagged film (id={film_id!r}, slug={slug!r}) not found in scraped films"
+                )
+            film['tags'] = sorted(set(film.get('tags', [])) | tags)
+
+        by_viewing = {
+            str(entry.get('source_entry_id', '')): entry
+            for entry in self.diary_entries
+            if entry.get('source_entry_id')
+        }
+        for viewing_id, tags in diary_tags.items():
+            entry = by_viewing.get(str(viewing_id))
+            if entry is None:
+                raise ScrapeValidationError(
+                    f"Tagged diary viewing {viewing_id!r} not found in scraped diary"
+                )
+            entry['tags'] = sorted(set(entry.get('tags', [])) | tags)
+
+        by_review_viewing = {
+            str(review.get('viewing_id', '')): review
+            for review in self.reviews_data
+            if review.get('viewing_id')
+        }
+        for viewing_id, tags in review_tags.items():
+            review = by_review_viewing.get(str(viewing_id))
+            if review is None:
+                raise ScrapeValidationError(
+                    f"Tagged review viewing {viewing_id!r} not found in scraped reviews"
+                )
+            review['tags'] = sorted(set(review.get('tags', [])) | tags)
+
+        by_list_path = {
+            self._normalize_list_path(list_data.get('url', '')): list_data
+            for list_data in self.lists_data
+            if list_data.get('url')
+        }
+        for list_path, tags in list_tags.items():
+            list_data = by_list_path.get(list_path)
+            if list_data is None:
+                raise ScrapeValidationError(
+                    f"Tagged list {list_path!r} not found in scraped lists"
+                )
+            list_data['tags'] = sorted(set(list_data.get('tags', [])) | tags)
 
     def _scrape_list_memberships(self, lists: List[Dict]) -> List[Dict]:
         """Fetch every public list page and retain ordered canonical film identity."""
@@ -836,15 +1101,19 @@ class EnhancedLetterboxdScraper:
             while page_url:
                 response = self.fetch_with_retry(page_url, allow_private_forbidden=True)
                 if self._is_private_forbidden_response(response):
-                    self._mark_unavailable(
-                        'list_items',
-                        f"forbidden/private list: {list_data.get('title', '')}",
-                    )
+                    # An unfetched detail page also means unknown Ranked/Published
+                    # metadata for the remaining lists, so the whole lists surface
+                    # must be preserved rather than saved with defaulted values.
+                    reason = f"forbidden/private list: {list_data.get('title', '')}"
+                    self._mark_unavailable('lists', reason)
+                    self._mark_unavailable('list_items', reason)
                     return []
                 response = self._require_response(
                     response, f"list {list_data.get('title', '')}", page_url
                 )
                 soup = BeautifulSoup(response.content, 'html.parser')
+                if page_num == 1:
+                    list_data.update(self._extract_list_detail_metadata(soup))
                 main = soup.select_one('main') or soup
                 posters = main.select(
                     'ul.poster-list div.react-component[data-component-class="LazyPoster"], '
@@ -924,12 +1193,13 @@ class EnhancedLetterboxdScraper:
             return
         fieldnames = [
             'Name', 'Year', 'Watched Date', 'Rating', 'Is_Rewatch', 'Is_Liked',
-            'Has_Review', 'Film_ID', 'Slug', 'Diary_Entry_ID', 'Film_URL'
+            'Has_Review', 'Tags', 'Film_ID', 'Slug', 'Diary_Entry_ID', 'Film_URL'
         ]
         data = [{
             'Name': entry['title'], 'Year': entry['year'], 'Watched Date': entry['watch_date'],
             'Rating': entry['rating'], 'Is_Rewatch': 'Yes' if entry['is_rewatch'] else 'No',
             'Is_Liked': 'Yes' if entry['is_liked'] else 'No', 'Has_Review': 'Yes' if entry['has_review'] else 'No',
+            'Tags': self._serialize_tags(entry.get('tags')),
             'Film_ID': entry.get('film_id', ''), 'Slug': entry.get('slug', ''),
             'Diary_Entry_ID': entry.get('source_entry_id', ''),
             'Film_URL': entry['film_url']
@@ -942,13 +1212,15 @@ class EnhancedLetterboxdScraper:
             return
         fieldnames = [
             'Name', 'Year', 'Rating', 'Review', 'Review_Date', 'Review_Likes',
-            'Contains_Spoilers', 'Film_ID', 'Slug', 'Film_URL'
+            'Contains_Spoilers', 'Rewatch', 'Tags', 'Film_ID', 'Slug', 'Film_URL'
         ]
         data = [{
             'Name': review['title'], 'Year': review['year'], 'Rating': review['rating'],
             'Review': review['review_text'], 'Review_Date': review['review_date'],
             'Review_Likes': review['review_likes'],
             'Contains_Spoilers': 'Yes' if review.get('contains_spoilers', False) else 'No',
+            'Rewatch': 'Yes' if review.get('is_rewatch', False) else 'No',
+            'Tags': self._serialize_tags(review.get('tags')),
             'Film_ID': review.get('film_id', ''),
             'Slug': review.get('slug', ''), 'Film_URL': review['film_url']
         } for review in self.reviews_data]
@@ -970,10 +1242,19 @@ class EnhancedLetterboxdScraper:
         """Saves custom lists."""
         if 'lists' not in self.completed_datasets:
             return
-        fieldnames = ['Title', 'Description', 'Film_Count', 'URL']
+        # Updated_Date is captured in _extract_list_detail_metadata but not yet
+        # emitted: movie_lists has no updated-date column, and an unconsumed
+        # CSV column would misrepresent the import contract.
+        fieldnames = [
+            'Title', 'Description', 'Film_Count', 'URL',
+            'Ranked', 'Published_Date', 'Tags'
+        ]
         data = [{
             'Title': li['title'], 'Description': li['description'],
-            'Film_Count': li['film_count'], 'URL': li['url']
+            'Film_Count': li['film_count'], 'URL': li['url'],
+            'Ranked': 'Yes' if li.get('is_ranked', False) else 'No',
+            'Published_Date': li.get('published_date', ''),
+            'Tags': self._serialize_tags(li.get('tags')),
         } for li in self.lists_data]
         self._write_csv("lists.csv", data, fieldnames)
 
@@ -1119,7 +1400,7 @@ class EnhancedLetterboxdScraper:
             return
         fieldnames = [
             'Title', 'Year', 'Rating', 'Film_ID', 'Slug', 'Poster_URL',
-            'Film_URL', 'Has_Review', 'Is_Liked', 'Movie_ID'
+            'Film_URL', 'Has_Review', 'Is_Liked', 'Tags', 'Movie_ID'
         ]
         data = [{
             'Title': film.get('title', ''), 'Year': film.get('year', ''), 'Rating': film.get('rating', ''),
@@ -1127,6 +1408,7 @@ class EnhancedLetterboxdScraper:
             'Poster_URL': film.get('poster_url', ''), 'Film_URL': film.get('film_url', ''),
             'Has_Review': 'Yes' if film.get('has_review') else 'No',
             'Is_Liked': 'Yes' if film.get('is_liked') else 'No',
+            'Tags': self._serialize_tags(film.get('tags')),
             'Movie_ID': film.get('movie_id', '')
         } for film in self.films_data]
         self._write_csv("films_comprehensive.csv", data, fieldnames)
@@ -1204,6 +1486,9 @@ class EnhancedLetterboxdScraper:
         self.scrape_reviews()
         self.scrape_watchlist()
         self.scrape_custom_lists()
+        # Tags ride the films/diary/reviews/lists CSVs as an authoritative
+        # column, so the crawl runs after those surfaces are proven complete.
+        self.scrape_tags()
 
         # These source-of-truth counts are only known after their complete surfaces
         # have passed pagination and parse validation.

--- a/backend/services/import_contracts.py
+++ b/backend/services/import_contracts.py
@@ -85,26 +85,36 @@ def parse_date(value: Any) -> Optional[date]:
 def parse_tags(value: Any) -> List[str]:
     if is_missing(value):
         return []
-    if isinstance(value, (list, tuple, set)):
+    # Structured inputs (lists and JSON arrays) carry literal user text: a tag
+    # genuinely named "nan"/"none"/"null" must survive. The missing-value
+    # sentinels only apply to the legacy delimiter-split path, where such
+    # strings indicate empty spreadsheet cells.
+    literal_elements = isinstance(value, (list, tuple, set))
+    if literal_elements:
         raw_values = value
     else:
         raw = str(value).strip()
+        decoded = None
         if raw.startswith("["):
             try:
                 decoded = json.loads(raw)
             except (TypeError, ValueError, json.JSONDecodeError):
                 decoded = None
-            if isinstance(decoded, list):
-                raw_values = decoded
-            else:
-                raw_values = re.split(r"\s*[,;|]\s*", raw)
+        if isinstance(decoded, list):
+            raw_values = decoded
+            literal_elements = True
         else:
             raw_values = re.split(r"\s*[,;|]\s*", raw)
 
     tags: List[str] = []
     seen = set()
     for candidate in raw_values:
-        tag = clean_text(candidate, max_length=100)
+        if literal_elements:
+            if candidate is None or (isinstance(candidate, float) and math.isnan(candidate)):
+                continue
+            tag = str(candidate).strip()[:100] or None
+        else:
+            tag = clean_text(candidate, max_length=100)
         if not tag:
             continue
         key = tag.casefold()

--- a/backend/services/ingestion.py
+++ b/backend/services/ingestion.py
@@ -892,13 +892,23 @@ def _upsert_lists(
         if row is not None:
             movie_list.description = clean_text(first_value(row, ("Description", "Notes")))
             movie_list.movie_count = parse_integer(first_value(row, ("Film_Count", "Film Count", "Count")), minimum=0) or 0
-            movie_list.is_ranked = parse_boolean(first_value(row, ("Ranked", "Is_Ranked", "Is Ranked")))
+            # Ranked/published/tags mirror the is_public presence guard below:
+            # a metadata row from a source that does not carry these columns
+            # (pre-upgrade scraper bundles, official exports) must preserve
+            # previously imported values instead of resetting to defaults.
+            ranked_value = first_value(row, ("Ranked", "Is_Ranked", "Is Ranked"))
+            if ranked_value is not None:
+                movie_list.is_ranked = parse_boolean(ranked_value)
             if first_value(row, ("Private", "Is_Private")) is not None:
                 movie_list.is_public = not parse_boolean(first_value(row, ("Private", "Is_Private")))
             elif first_value(row, ("Public", "Is_Public")) is not None:
                 movie_list.is_public = parse_boolean(first_value(row, ("Public", "Is_Public")), default=True)
-            movie_list.published_date = parse_date(first_value(row, ("Published Date", "Published_Date", "Date")))
-            movie_list.tags = parse_tags(first_value(row, ("Tags", "List_Tags", "List Tags")))
+            published_value = first_value(row, ("Published Date", "Published_Date", "Date"))
+            if published_value is not None:
+                movie_list.published_date = parse_date(published_value)
+            tags_value = first_value(row, ("Tags", "List_Tags", "List Tags"))
+            if tags_value is not None:
+                movie_list.tags = parse_tags(tags_value)
         seen_list_ids.add(movie_list.id)
         return movie_list
 

--- a/backend/tests/test_import_contracts.py
+++ b/backend/tests/test_import_contracts.py
@@ -11,13 +11,14 @@ from types import SimpleNamespace
 import pandas as pd
 from bs4 import BeautifulSoup
 
-from scraper_html import EnhancedLetterboxdScraper
+from scraper_html import EnhancedLetterboxdScraper, ScrapeValidationError
 from database.models import Movie
 from services.import_contracts import (
     MovieIdentity,
     diary_event_key,
     movie_identity_from_row,
     parse_boolean,
+    parse_tags,
 )
 from services.profile_loader import load_profile_data, validate_import_bundle
 from services.movie_resolver import MovieResolver
@@ -696,6 +697,438 @@ class CoverageUnavailableTests(unittest.TestCase):
         self.assertTrue(coverage["is_partial"])
         self.assertEqual(coverage["unavailable_datasets"]["watchlist"], "forbidden/private")
         self.assertTrue(any("prior imported state was preserved" in item for item in coverage["limitations"]))
+
+
+class TagScrapingTests(unittest.TestCase):
+    """Public tags-surface crawl: index parsing, per-tag matching, CSV contract."""
+
+    TAG_INDEX_MARKUP = """
+        <main>
+          <ul class="js-tags-section tags tags-columns" data-check-action="/ajax/tag/check/films/">
+            <li class="hoverable">
+              <a href="/viewer/tag/mood-eerie/films/" title="mood, eerie">mood, eerie</a>
+              <span class="detail -has-count"> 2 </span>
+            </li>
+            <li class="hoverable">
+              <a href="/viewer/tag/profile/films/" title="profile">profile</a>
+              <span class="detail -has-no-count"> </span>
+            </li>
+            <li class="hoverable">
+              <a href="/viewer/tag/marathon/films/" title="marathon">marathon</a>
+              <span class="detail -has-count"> 2.1K </span>
+            </li>
+            <li style="visibility:hidden"></li>
+          </ul>
+        </main>
+    """
+
+    @staticmethod
+    def _tags_scraper() -> EnhancedLetterboxdScraper:
+        scraper = EnhancedLetterboxdScraper.__new__(EnhancedLetterboxdScraper)
+        scraper.username = "viewer"
+        scraper.urls = {"tags": "https://letterboxd.com/viewer/tags/"}
+        scraper.completed_datasets = set()
+        scraper.unavailable_datasets = {}
+        scraper.films_data = []
+        scraper.diary_entries = []
+        scraper.reviews_data = []
+        scraper.lists_data = []
+        return scraper
+
+    def test_tag_index_parses_counts_including_singletons_and_abbreviations(self) -> None:
+        soup = BeautifulSoup(self.TAG_INDEX_MARKUP, "html.parser")
+
+        entries = EnhancedLetterboxdScraper._extract_tag_entries(soup)
+
+        self.assertEqual(
+            entries,
+            [
+                {"name": "mood, eerie", "slug": "mood-eerie", "count": 2},
+                {"name": "profile", "slug": "profile", "count": 1},
+                {"name": "marathon", "slug": "marathon", "count": None},
+            ],
+        )
+
+    def test_tagless_kind_declares_empty_without_tags_section(self) -> None:
+        soup = BeautifulSoup(
+            "<main><section><p>No film tags yet</p></section></main>", "html.parser"
+        )
+        scraper = self._tags_scraper()
+
+        self.assertEqual(EnhancedLetterboxdScraper._extract_tag_entries(soup), [])
+        self.assertTrue(scraper._declares_empty(soup, "tags_films"))
+        self.assertFalse(scraper._declares_empty(soup, "tags_diary"))
+
+    def test_scrape_tags_attaches_across_surfaces_and_survives_csv_round_trip(self) -> None:
+        scraper = self._tags_scraper()
+        scraper.films_data = [
+            {"title": "Challengers", "year": 2024, "film_id": "842301", "slug": "challengers"},
+            {"title": "Heat", "year": 1995, "film_id": "51818", "slug": "heat-1995"},
+        ]
+        scraper.diary_entries = [
+            {"title": "Challengers", "source_entry_id": "459597569", "is_rewatch": False,
+             "is_liked": False, "has_review": True, "watch_date": "2026-07-01",
+             "rating": 4.0, "year": 2024, "film_id": "842301", "slug": "challengers",
+             "film_url": "/film/challengers/"},
+        ]
+        scraper.reviews_data = [
+            {"title": "Challengers", "viewing_id": "459597569", "year": 2024,
+             "rating": 4.0, "review_text": "x", "review_date": "2026-07-01",
+             "review_likes": 0, "contains_spoilers": False, "is_rewatch": True,
+             "film_id": "842301", "slug": "challengers", "film_url": "/film/challengers/"},
+        ]
+        scraper.lists_data = [
+            {"title": "Best", "description": "", "film_count": 1, "url": "/viewer/list/best/"},
+        ]
+
+        index_films = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/mood-eerie/films/" title="mood, eerie">mood, eerie</a>
+                <span class="detail -has-no-count"></span></li>
+            </ul></main>
+        """
+        empty_diary = "<main><p>No diary tags yet</p></main>"
+        index_reviews = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/mood-eerie/reviews/" title="mood, eerie">mood, eerie</a>
+                <span class="detail -has-no-count"></span></li>
+            </ul></main>
+        """
+        index_lists = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/favorites/lists/" title="favorites">favorites</a>
+                <span class="detail -has-no-count"></span></li>
+            </ul></main>
+        """
+        tag_films_page = """
+            <main><ul class="poster-list">
+              <li><div class="react-component" data-component-class="LazyPoster"
+                   data-item-name="Challengers (2024)" data-item-slug="challengers"
+                   data-item-link="/film/challengers/"
+                   data-postered-identifier='{"uid":"film:842301"}'></div></li>
+            </ul></main>
+        """
+        tag_reviews_page = """
+            <main>
+              <article class="production-viewing" data-object-id="viewing:459597569"
+                       data-object-name="review"></article>
+            </main>
+        """
+        tag_lists_page = """
+            <main>
+              <article class="list-summary js-list-summary">
+                <h2 class="name prettify"><a href="/viewer/list/best/">Best</a></h2>
+              </article>
+            </main>
+        """
+        pages = {
+            "https://letterboxd.com/viewer/tags/films/": index_films,
+            "https://letterboxd.com/viewer/tags/diary/": empty_diary,
+            "https://letterboxd.com/viewer/tags/reviews/": index_reviews,
+            "https://letterboxd.com/viewer/tags/lists/": index_lists,
+            "https://letterboxd.com/viewer/tag/mood-eerie/films/": tag_films_page,
+            "https://letterboxd.com/viewer/tag/mood-eerie/reviews/": tag_reviews_page,
+            "https://letterboxd.com/viewer/tag/favorites/lists/": tag_lists_page,
+        }
+        scraper.fetch_with_retry = Mock(
+            side_effect=lambda url, **kwargs: SimpleNamespace(content=pages[url].encode("utf-8"))
+        )
+
+        with patch("scraper_html.time.sleep"):
+            scraper.scrape_tags()
+
+        self.assertEqual(scraper.films_data[0]["tags"], ["mood, eerie"])
+        self.assertNotIn("tags", scraper.films_data[1])
+        self.assertNotIn("tags", scraper.diary_entries[0])
+        self.assertEqual(scraper.reviews_data[0]["tags"], ["mood, eerie"])
+        self.assertEqual(scraper.lists_data[0]["tags"], ["favorites"])
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            scraper.output_dir = temp_dir
+            scraper.completed_datasets = {"films", "reviews", "lists"}
+            scraper._save_comprehensive_films()
+            scraper._save_reviews()
+            scraper._save_custom_lists()
+            films_csv = pd.read_csv(Path(temp_dir) / "films_comprehensive.csv", keep_default_na=False)
+            reviews_csv = pd.read_csv(Path(temp_dir) / "reviews.csv", keep_default_na=False)
+            lists_csv = pd.read_csv(Path(temp_dir) / "lists.csv", keep_default_na=False)
+
+        # A tag containing a comma must survive the CSV round trip through the
+        # same parser ingestion uses; delimiter-splitting would corrupt it.
+        self.assertEqual(parse_tags(films_csv.loc[0, "Tags"]), ["mood, eerie"])
+        self.assertEqual(parse_tags(films_csv.loc[1, "Tags"]), [])
+        self.assertEqual(parse_tags(reviews_csv.loc[0, "Tags"]), ["mood, eerie"])
+        self.assertEqual(reviews_csv.loc[0, "Rewatch"], "Yes")
+        self.assertEqual(parse_tags(lists_csv.loc[0, "Tags"]), ["favorites"])
+
+    def test_tags_index_pagination_collects_all_pages(self) -> None:
+        # Live tag indexes paginate at 120 tags per page; tags on page 2+ must
+        # not be silently dropped (they would authoritatively erase DB tags).
+        scraper = self._tags_scraper()
+        scraper.films_data = [
+            {"title": "Alpha", "year": 2020, "film_id": "1", "slug": "alpha"},
+            {"title": "Beta", "year": 2021, "film_id": "2", "slug": "beta"},
+        ]
+        index_page_1 = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/one/films/" title="one">one</a>
+                <span class="detail -has-no-count"></span></li>
+            </ul>
+            <div class="pagination"><a class="next" href="/viewer/tags/films/page/2/">Next</a></div>
+            </main>
+        """
+        index_page_2 = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/two/films/" title="two">two</a>
+                <span class="detail -has-no-count"></span></li>
+            </ul></main>
+        """
+        def film_page(film_id, slug, name):
+            return f"""
+                <main><ul class="poster-list">
+                  <li><div class="react-component" data-component-class="LazyPoster"
+                       data-item-name="{name}" data-item-slug="{slug}"
+                       data-item-link="/film/{slug}/"
+                       data-postered-identifier='{{"uid":"film:{film_id}"}}'></div></li>
+                </ul></main>
+            """
+        pages = {
+            "https://letterboxd.com/viewer/tags/films/": index_page_1,
+            "https://letterboxd.com/viewer/tags/films/page/2/": index_page_2,
+            "https://letterboxd.com/viewer/tags/diary/": "<main><p>No diary tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/reviews/": "<main><p>No review tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/lists/": "<main><p>No list tags yet</p></main>",
+            "https://letterboxd.com/viewer/tag/one/films/": film_page("1", "alpha", "Alpha (2020)"),
+            "https://letterboxd.com/viewer/tag/two/films/": film_page("2", "beta", "Beta (2021)"),
+        }
+        scraper.fetch_with_retry = Mock(
+            side_effect=lambda url, **kwargs: SimpleNamespace(content=pages[url].encode("utf-8"))
+        )
+
+        with patch("scraper_html.time.sleep"):
+            scraper.scrape_tags()
+
+        self.assertEqual(scraper.films_data[0]["tags"], ["one"])
+        self.assertEqual(scraper.films_data[1]["tags"], ["two"])
+
+    def test_per_tag_pagination_and_slug_fallback_matching(self) -> None:
+        scraper = self._tags_scraper()
+        scraper.films_data = [
+            {"title": "Alpha", "year": 2020, "film_id": "1", "slug": "alpha"},
+            {"title": "Beta", "year": 2021, "film_id": "2", "slug": "beta"},
+        ]
+        index_films = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/marathon/films/" title="marathon">marathon</a>
+                <span class="detail -has-count">2</span></li>
+            </ul></main>
+        """
+        tag_page_1 = """
+            <main><ul class="poster-list">
+              <li><div class="react-component" data-component-class="LazyPoster"
+                   data-item-name="Alpha (2020)" data-item-slug="alpha"
+                   data-item-link="/film/alpha/"
+                   data-postered-identifier='{"uid":"film:1"}'></div></li>
+            </ul>
+            <div class="pagination"><a class="next" href="/viewer/tag/marathon/films/page/2/">Next</a></div>
+            </main>
+        """
+        # Page 2's poster carries no numeric id anywhere: slug matching must apply.
+        tag_page_2 = """
+            <main><ul class="poster-list">
+              <li><div class="react-component" data-component-class="LazyPoster"
+                   data-item-name="Beta (2021)" data-item-slug="beta"
+                   data-item-link="/film/beta/"></div></li>
+            </ul></main>
+        """
+        pages = {
+            "https://letterboxd.com/viewer/tags/films/": index_films,
+            "https://letterboxd.com/viewer/tags/diary/": "<main><p>No diary tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/reviews/": "<main><p>No review tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/lists/": "<main><p>No list tags yet</p></main>",
+            "https://letterboxd.com/viewer/tag/marathon/films/": tag_page_1,
+            "https://letterboxd.com/viewer/tag/marathon/films/page/2/": tag_page_2,
+        }
+        scraper.fetch_with_retry = Mock(
+            side_effect=lambda url, **kwargs: SimpleNamespace(content=pages[url].encode("utf-8"))
+        )
+
+        with patch("scraper_html.time.sleep"):
+            scraper.scrape_tags()
+
+        self.assertEqual(scraper.films_data[0]["tags"], ["marathon"])
+        self.assertEqual(scraper.films_data[1]["tags"], ["marathon"])
+
+    def test_per_tag_diary_pages_attach_by_viewing_id(self) -> None:
+        scraper = self._tags_scraper()
+        scraper.diary_entries = [
+            {"title": "Alpha", "source_entry_id": "77"},
+            {"title": "Beta", "source_entry_id": "88"},
+        ]
+        index_diary = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/cinema/diary/" title="cinema">cinema</a>
+                <span class="detail -has-count">2</span></li>
+            </ul></main>
+        """
+        tag_diary_page = """
+            <main><table class="diary-table"><tbody>
+              <tr class="diary-entry-row" data-viewing-id="77"></tr>
+              <tr class="diary-entry-row" data-viewing-id="88"></tr>
+            </tbody></table></main>
+        """
+        pages = {
+            "https://letterboxd.com/viewer/tags/films/": "<main><p>No film tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/diary/": index_diary,
+            "https://letterboxd.com/viewer/tags/reviews/": "<main><p>No review tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/lists/": "<main><p>No list tags yet</p></main>",
+            "https://letterboxd.com/viewer/tag/cinema/diary/": tag_diary_page,
+        }
+        scraper.fetch_with_retry = Mock(
+            side_effect=lambda url, **kwargs: SimpleNamespace(content=pages[url].encode("utf-8"))
+        )
+
+        with patch("scraper_html.time.sleep"):
+            scraper.scrape_tags()
+
+        self.assertEqual(scraper.diary_entries[0]["tags"], ["cinema"])
+        self.assertEqual(scraper.diary_entries[1]["tags"], ["cinema"])
+
+    def test_parse_tags_json_arrays_keep_sentinel_like_tag_names(self) -> None:
+        # A tag literally named "null"/"nan" is real user text when it arrives
+        # via the structured JSON path; only delimiter-split cells treat those
+        # strings as missing values.
+        self.assertEqual(parse_tags('["null", "nan", "NULL"]'), ["null", "nan"])
+        self.assertEqual(parse_tags(["None"]), ["None"])
+        self.assertEqual(parse_tags("nan, horror"), ["horror"])
+        self.assertEqual(parse_tags("[]"), [])
+
+    def test_forbidden_list_detail_marks_lists_surface_unavailable(self) -> None:
+        scraper = self._tags_scraper()
+        forbidden = SimpleNamespace(
+            status_code=403,
+            text="Letterboxd - Forbidden: the page you are attempting to access is classified. "
+                 "You do not have the correct clearance.",
+        )
+        scraper.fetch_with_retry = Mock(return_value=forbidden)
+
+        result = scraper._scrape_list_memberships(
+            [{"title": "Secret", "url": "/viewer/list/secret/", "film_count": 3}]
+        )
+
+        self.assertEqual(result, [])
+        self.assertIn("lists", scraper.unavailable_datasets)
+        self.assertIn("list_items", scraper.unavailable_datasets)
+
+    def test_scrape_tags_count_mismatch_fails_closed(self) -> None:
+        scraper = self._tags_scraper()
+        scraper.films_data = [
+            {"title": "Challengers", "year": 2024, "film_id": "842301", "slug": "challengers"},
+        ]
+        index_films = """
+            <main><ul class="js-tags-section">
+              <li class="hoverable"><a href="/viewer/tag/watched-twice/films/" title="watched-twice">watched-twice</a>
+                <span class="detail -has-count">2</span></li>
+            </ul></main>
+        """
+        tag_films_page = """
+            <main><ul class="poster-list">
+              <li><div class="react-component" data-component-class="LazyPoster"
+                   data-item-name="Challengers (2024)" data-item-slug="challengers"
+                   data-item-link="/film/challengers/"
+                   data-postered-identifier='{"uid":"film:842301"}'></div></li>
+            </ul></main>
+        """
+        pages = {
+            "https://letterboxd.com/viewer/tags/films/": index_films,
+            "https://letterboxd.com/viewer/tags/diary/": "<main><p>No diary tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/reviews/": "<main><p>No review tags yet</p></main>",
+            "https://letterboxd.com/viewer/tags/lists/": "<main><p>No list tags yet</p></main>",
+            "https://letterboxd.com/viewer/tag/watched-twice/films/": tag_films_page,
+        }
+        scraper.fetch_with_retry = Mock(
+            side_effect=lambda url, **kwargs: SimpleNamespace(content=pages[url].encode("utf-8"))
+        )
+
+        with patch("scraper_html.time.sleep"):
+            with self.assertRaisesRegex(ScrapeValidationError, "reported 2 entries"):
+                scraper.scrape_tags()
+
+    def test_attach_tags_rejects_unknown_viewing_and_list(self) -> None:
+        scraper = self._tags_scraper()
+
+        with self.assertRaisesRegex(ScrapeValidationError, "not found in scraped diary"):
+            scraper._attach_tags({}, {"999": {"tag"}}, {}, {})
+        with self.assertRaisesRegex(ScrapeValidationError, "not found in scraped lists"):
+            scraper._attach_tags({}, {}, {}, {"/viewer/list/gone/": {"tag"}})
+
+    def test_review_listing_rewatch_and_viewing_id_extraction(self) -> None:
+        article = BeautifulSoup(
+            """
+            <article class="production-viewing" data-object-id="viewing:1421719449">
+              <span class="attribution-detail">
+                <a href="/viewer/film/elysium-2013/" class="context"> Rewatched </a>
+                <span class="date"><time class="timestamp" datetime="2026-07-29">29 Jul 2026</time></span>
+              </span>
+            </article>
+            """,
+            "html.parser",
+        ).article
+        watched = BeautifulSoup(
+            '<article><a class="context"> Watched </a></article>', "html.parser"
+        ).article
+
+        self.assertEqual(EnhancedLetterboxdScraper._extract_viewing_id(article), "1421719449")
+        self.assertTrue(EnhancedLetterboxdScraper._extract_review_rewatch(article))
+        self.assertFalse(EnhancedLetterboxdScraper._extract_review_rewatch(watched))
+        self.assertEqual(EnhancedLetterboxdScraper._extract_viewing_id(watched), "")
+
+    def test_list_detail_metadata_extraction(self) -> None:
+        ranked = BeautifulSoup(
+            """
+            <main>
+              <p class="list-date">
+                <span class="published is-updated">Published
+                  <time datetime="2026-01-11T07:15:06.720Z" class="timeago"></time></span>
+                <span class="updated">Updated
+                  <time datetime="2026-07-25T14:25:26.004Z" class="timeago"></time></span>
+              </p>
+              <ul class="poster-list -grid">
+                <li class="posteritem numbered-list-item" data-owner-rating="10">
+                  <p class="list-number">1</p>
+                </li>
+              </ul>
+            </main>
+            """,
+            "html.parser",
+        )
+        unranked = BeautifulSoup(
+            """
+            <main>
+              <p class="list-date"><span class="published">Published
+                <time datetime="2024-02-01T00:00:00Z" class="timeago"></time></span></p>
+              <ul class="poster-list"><li class="posteritem"></li></ul>
+            </main>
+            """,
+            "html.parser",
+        )
+
+        ranked_meta = EnhancedLetterboxdScraper._extract_list_detail_metadata(ranked)
+        unranked_meta = EnhancedLetterboxdScraper._extract_list_detail_metadata(unranked)
+
+        self.assertEqual(
+            ranked_meta,
+            {
+                "is_ranked": True,
+                "published_date": "2026-01-11T07:15:06.720Z",
+                "updated_date": "2026-07-25T14:25:26.004Z",
+            },
+        )
+        self.assertEqual(
+            unranked_meta,
+            {"is_ranked": False, "published_date": "2024-02-01T00:00:00Z", "updated_date": ""},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_local_sync_environment.py
+++ b/backend/tests/test_local_sync_environment.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+from scripts.local_full_sync import load_local_environment
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_local_sync_loads_ignored_root_environment(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "SPYBOXD_API_BASE_URL=https://api.example.test\n"
+        "INGESTION_API_TOKEN=local-upload-token\n",
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("SPYBOXD_API_BASE_URL", raising=False)
+    monkeypatch.delenv("INGESTION_API_TOKEN", raising=False)
+
+    load_local_environment(env_file)
+
+    assert os.environ["SPYBOXD_API_BASE_URL"] == "https://api.example.test"
+    assert os.environ["INGESTION_API_TOKEN"] == "local-upload-token"
+
+
+def test_local_sync_does_not_override_explicit_shell_values(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("INGESTION_API_TOKEN=file-token\n", encoding="utf-8")
+    monkeypatch.setenv("INGESTION_API_TOKEN", "shell-token")
+
+    load_local_environment(env_file)
+
+    assert os.environ["INGESTION_API_TOKEN"] == "shell-token"
+
+
+def test_root_example_covers_compose_and_residential_sync() -> None:
+    values = dotenv_values(REPO_ROOT / ".env.example")
+    expected_names = {
+        "POSTGRES_PASSWORD",
+        "NEXT_PUBLIC_API_BASE_URL",
+        "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY",
+        "CLERK_SECRET_KEY",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL",
+        "NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL",
+        "SPYBOXD_API_BASE_URL",
+        "SPYBOXD_SYNC_CONFIG",
+        "INGESTION_API_TOKEN",
+        "SPYBOXD_BEARER_TOKEN",
+    }
+
+    assert expected_names <= values.keys()
+
+
+def test_tmdb_example_stays_within_the_runner_limit() -> None:
+    values = dotenv_values(REPO_ROOT / "deploy/env/api.env.example")
+
+    assert 1 <= int(values["TMDB_ENRICHMENT_LIMIT"]) <= 100

--- a/backend/tests/test_profile_rename.py
+++ b/backend/tests/test_profile_rename.py
@@ -1,0 +1,87 @@
+"""Rename semantics: profile identity, feed repointing, and app-user mirroring."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest import TestCase
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database.models import AppUser, Profile, ProfileFeedState
+from backend.database.repository import ProfileRepository
+
+
+class ProfileRenameTests(TestCase):
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        for table in (Profile.__table__, ProfileFeedState.__table__, AppUser.__table__):
+            table.create(self.engine, checkfirst=True)
+        self.db = sessionmaker(bind=self.engine)()
+
+        self.profile = Profile(username="gowri_sriya", scraping_status="completed")
+        self.db.add(self.profile)
+        self.db.flush()
+        self.db.add(
+            ProfileFeedState(
+                profile_id=self.profile.id,
+                feed_url="https://letterboxd.com/gowri_sriya/rss/",
+                activity_guids=[],
+                consecutive_failures=7,
+                last_error="HTTP 404",
+                last_http_status=404,
+            )
+        )
+        self.db.add(
+            AppUser(
+                clerk_user_id="user_1",
+                letterboxd_username="gowri_sriya",
+            )
+        )
+        self.db.add(
+            AppUser(
+                clerk_user_id="user_2",
+                letterboxd_username="someone_else",
+            )
+        )
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+        self.engine.dispose()
+
+    def test_rename_carries_profile_feed_and_app_user(self):
+        repo = ProfileRepository(self.db)
+
+        feed_repointed = repo.rename_profile(self.profile, "mnigsm")
+
+        self.assertTrue(feed_repointed)
+        self.assertEqual(self.profile.username, "mnigsm")
+
+        feed = self.db.get(ProfileFeedState, self.profile.id)
+        self.assertEqual(feed.feed_url, "https://letterboxd.com/mnigsm/rss/")
+        self.assertEqual(feed.consecutive_failures, 0)
+        self.assertIsNone(feed.last_error)
+        self.assertIsNone(feed.last_http_status)
+        self.assertIsNotNone(feed.next_poll_at)
+
+        mirrored = (
+            self.db.query(AppUser).filter(AppUser.clerk_user_id == "user_1").one()
+        )
+        untouched = (
+            self.db.query(AppUser).filter(AppUser.clerk_user_id == "user_2").one()
+        )
+        self.assertEqual(mirrored.letterboxd_username, "mnigsm")
+        self.assertEqual(untouched.letterboxd_username, "someone_else")
+
+        # Old username no longer resolves; the new one does, case-insensitively.
+        self.assertIsNone(repo.get_profile_by_username("gowri_sriya"))
+        self.assertEqual(repo.get_profile_by_username("MNIGSM").id, self.profile.id)
+
+    def test_rename_without_feed_state_reports_no_repoint(self):
+        repo = ProfileRepository(self.db)
+        bare = Profile(username="lonely", scraping_status="completed")
+        self.db.add(bare)
+        self.db.commit()
+
+        self.assertFalse(repo.rename_profile(bare, "still_lonely"))
+        self.assertEqual(bare.username, "still_lonely")

--- a/backend/tests/test_route_access_matrix.py
+++ b/backend/tests/test_route_access_matrix.py
@@ -72,4 +72,7 @@ def test_existing_mutations_keep_admin_or_ingestion_auth():
     for method, path in admin_routes:
         assert "get_admin_user" in _dependency_names(_route(method, path))
     assert "get_active_upload_user" in _dependency_names(_route("POST", "/upload/"))
+    assert "get_active_upload_user" in _dependency_names(
+        _route("POST", "/profiles/{username}/rename")
+    )
     assert "get_current_user" in _dependency_names(_route("POST", "/profiles/{profile_id}/tracking"))

--- a/backend/tests/test_scraped_tags_flow.py
+++ b/backend/tests/test_scraped_tags_flow.py
@@ -1,0 +1,298 @@
+"""End-to-end: the upgraded scraper CSV contract (Tags columns, list flags)
+flows through load_profile_data + unified_data_loader into the models, and
+bundles from pre-upgrade scrapers keep preserving previously imported tags.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+
+from backend.database.models import (
+    Movie,
+    MovieList,
+    MovieListItem,
+    Profile,
+    ProfileDataChange,
+    ProfileFavoriteMovie,
+    ProfileFeedState,
+    ProfileFilm,
+    ProfileSourceActivity,
+    ProfileSync,
+    Rating,
+    Review,
+    SyncDataset,
+    WatchEvent,
+    WatchlistItem,
+)
+from backend.services.ingestion import unified_data_loader
+from backend.services.profile_loader import load_profile_data, validate_import_bundle
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    ProfileSync.__table__,
+    ProfileFeedState.__table__,
+    SyncDataset.__table__,
+    Movie.__table__,
+    Rating.__table__,
+    ProfileFilm.__table__,
+    WatchEvent.__table__,
+    Review.__table__,
+    WatchlistItem.__table__,
+    MovieList.__table__,
+    MovieListItem.__table__,
+    ProfileFavoriteMovie.__table__,
+    ProfileDataChange.__table__,
+    ProfileSourceActivity.__table__,
+)
+
+FILM_TAGS = '["comma, tag", "mood: eerie"]'
+DIARY_TAGS = '["rewatch club"]'
+REVIEW_TAGS = '["spoiler-review"]'
+LIST_TAGS = '["favorites"]'
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def _write_frame(path: Path, rows: list[dict], columns: list[str]) -> None:
+    pd.DataFrame(rows, columns=columns).to_csv(path, index=False)
+
+
+def _write_bundle(root: Path, *, with_tags: bool) -> None:
+    """Write a full-html bundle in the current (with_tags) or legacy scraper contract."""
+    root.mkdir()
+
+    film = {
+        "Title": "Challengers",
+        "Year": 2024,
+        "Rating": 4.0,
+        "Film_ID": "842301",
+        "Slug": "challengers",
+        "Poster_URL": "",
+        "Film_URL": "https://letterboxd.com/film/challengers/",
+        "Has_Review": "Yes",
+        "Is_Liked": "No",
+        "Movie_ID": "842301",
+    }
+    film_columns = [
+        "Title", "Year", "Rating", "Film_ID", "Slug", "Poster_URL",
+        "Film_URL", "Has_Review", "Is_Liked", "Movie_ID",
+    ]
+    if with_tags:
+        film["Tags"] = FILM_TAGS
+        film_columns.insert(9, "Tags")
+
+    diary_row = {
+        "Name": "Challengers",
+        "Year": 2024,
+        "Watched Date": "2026-07-01",
+        "Rating": 4.0,
+        "Is_Rewatch": "No",
+        "Is_Liked": "No",
+        "Has_Review": "Yes",
+        "Film_ID": "842301",
+        "Slug": "challengers",
+        "Diary_Entry_ID": "459597569",
+        "Film_URL": "https://letterboxd.com/film/challengers/",
+    }
+    diary_columns = [
+        "Name", "Year", "Watched Date", "Rating", "Is_Rewatch", "Is_Liked",
+        "Has_Review", "Film_ID", "Slug", "Diary_Entry_ID", "Film_URL",
+    ]
+    if with_tags:
+        diary_row["Tags"] = DIARY_TAGS
+        diary_columns.insert(7, "Tags")
+
+    review_row = {
+        "Name": "Challengers",
+        "Year": 2024,
+        "Rating": 4.0,
+        "Review": "Electric.",
+        "Review_Date": "2026-07-01",
+        "Review_Likes": 3,
+        "Contains_Spoilers": "No",
+        "Film_ID": "842301",
+        "Slug": "challengers",
+        "Film_URL": "https://letterboxd.com/film/challengers/",
+    }
+    review_columns = [
+        "Name", "Year", "Rating", "Review", "Review_Date", "Review_Likes",
+        "Contains_Spoilers", "Film_ID", "Slug", "Film_URL",
+    ]
+    if with_tags:
+        review_row["Rewatch"] = "Yes"
+        review_row["Tags"] = REVIEW_TAGS
+        review_columns[7:7] = ["Rewatch", "Tags"]
+
+    list_row = {
+        "Title": "Best",
+        "Description": "Ranked favorites",
+        "Film_Count": 1,
+        "URL": "/viewer/list/best/",
+    }
+    list_columns = ["Title", "Description", "Film_Count", "URL"]
+    if with_tags:
+        list_row.update({
+            "Ranked": "Yes",
+            "Published_Date": "2026-01-11T07:15:06.720Z",
+            "Tags": LIST_TAGS,
+        })
+        list_columns += ["Ranked", "Published_Date", "Tags"]
+
+    _write_frame(
+        root / "profile.csv",
+        [{
+            "Username": "viewer",
+            "Display_Name": "Viewer",
+            "Join_Date": None,
+            "Total_Films": 1,
+            "Total_Reviews": 1,
+            "Total_Lists": 1,
+            "Following_Count": 1,
+            "Followers_Count": 2,
+        }],
+        [
+            "Username", "Display_Name", "Join_Date", "Total_Films",
+            "Total_Reviews", "Total_Lists", "Following_Count", "Followers_Count",
+        ],
+    )
+    _write_frame(root / "films_comprehensive.csv", [film], film_columns)
+    _write_frame(root / "ratings.csv", [{"Name": "Challengers", "Year": 2024, "Rating": 4.0}], ["Name", "Year", "Rating"])
+    _write_frame(root / "diary.csv", [diary_row], diary_columns)
+    _write_frame(
+        root / "likes.csv",
+        [],
+        ["Name", "Year", "Date", "Is_Liked", "Film_ID", "Slug", "Film_URL", "Poster_URL"],
+    )
+    _write_frame(root / "reviews.csv", [review_row], review_columns)
+    _write_frame(root / "watchlist.csv", [], ["Name", "Year", "Film_ID", "Slug", "Film_URL", "Poster_URL"])
+    _write_frame(root / "lists.csv", [list_row], list_columns)
+    _write_frame(
+        root / "list_items.csv",
+        [{
+            "List_Name": "Best",
+            "List_URL": "/viewer/list/best/",
+            "Position": 1,
+            "Name": "Challengers",
+            "Year": 2024,
+            "Film_ID": "842301",
+            "Slug": "challengers",
+            "Film_URL": "https://letterboxd.com/film/challengers/",
+            "Poster_URL": "",
+            "Notes": "",
+        }],
+        ["List_Name", "List_URL", "Position", "Name", "Year", "Film_ID", "Slug", "Film_URL", "Poster_URL", "Notes"],
+    )
+    _write_frame(root / "favorites.csv", [], ["Position", "Name", "Year", "Film_ID", "Slug", "Film_URL", "Poster_URL"])
+
+    datasets = [
+        "profile", "favorites", "films", "diary", "likes",
+        "reviews", "watchlist", "lists", "list_items",
+    ]
+    (root / "manifest.json").write_text(
+        json.dumps({
+            "schema_version": 2,
+            "source_kind": "full_html_upload",
+            "username": "viewer",
+            "requested_datasets": datasets,
+            "completed_datasets": datasets,
+            "counts": {
+                "films": 1,
+                "diary": 1,
+                "likes": 0,
+                "reviews": 1,
+                "watchlist": 0,
+                "lists": 1,
+                "list_items": 1,
+                "favorites": 0,
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def _import_bundle(tmp_path: Path, name: str, db: Session, *, with_tags: bool) -> Profile:
+    root = tmp_path / name
+    _write_bundle(root, with_tags=with_tags)
+    loaded = load_profile_data(str(root), "viewer")
+    validate_import_bundle(loaded, require_full_manifest=True)
+    profile = db.query(Profile).filter(Profile.username == "viewer").one_or_none()
+    if profile is None:
+        profile = Profile(username="viewer", scraping_status="pending")
+        db.add(profile)
+        db.commit()
+    unified_data_loader(loaded, profile.id, db)
+    db.commit()
+    return profile
+
+
+def test_tagged_scraper_bundle_flows_into_all_tag_columns(tmp_path: Path, database: Session) -> None:
+    _import_bundle(tmp_path, "bundle", database, with_tags=True)
+
+    rating = database.query(Rating).one()
+    # Legacy payloads union tags across every contributing frame (films + diary).
+    assert sorted(rating.tags or []) == ["comma, tag", "mood: eerie", "rewatch club"]
+
+    profile_film = database.query(ProfileFilm).one()
+    # Film-level and diary tags are unioned on the current-state row.
+    assert set(profile_film.tags or []) == {"comma, tag", "mood: eerie", "rewatch club"}
+
+    event = database.query(WatchEvent).one()
+    assert event.tags == ["rewatch club"]
+    assert event.watched_date == date(2026, 7, 1)
+
+    review = database.query(Review).one()
+    assert review.tags == ["spoiler-review"]
+    assert review.likes_count == 3
+
+    movie_list = database.query(MovieList).one()
+    assert movie_list.is_ranked is True
+    assert movie_list.published_date == date(2026, 1, 11)
+    assert movie_list.tags == ["favorites"]
+
+
+def test_legacy_bundle_without_tag_columns_preserves_previous_tags(tmp_path: Path, database: Session) -> None:
+    _import_bundle(tmp_path, "tagged", database, with_tags=True)
+    # A residential machine still running the pre-tags scraper uploads next.
+    _import_bundle(tmp_path, "legacy", database, with_tags=False)
+
+    assert sorted(database.query(Rating).one().tags or []) == [
+        "comma, tag", "mood: eerie", "rewatch club",
+    ]
+    assert set(database.query(ProfileFilm).one().tags or []) == {
+        "comma, tag", "mood: eerie", "rewatch club",
+    }
+    assert database.query(WatchEvent).filter(WatchEvent.superseded_at.is_(None)).one().tags == [
+        "rewatch club"
+    ]
+    assert database.query(Review).one().tags == ["spoiler-review"]
+
+    # Lists metadata from a pre-upgrade bundle (no Ranked/Published_Date/Tags
+    # columns) must also preserve prior values, not reset them to defaults.
+    movie_list = database.query(MovieList).one()
+    assert movie_list.is_ranked is True
+    assert movie_list.published_date == date(2026, 1, 11)
+    assert movie_list.tags == ["favorites"]

--- a/deploy/env/api.env.example
+++ b/deploy/env/api.env.example
@@ -29,7 +29,7 @@ TMDB_REQUEST_PAUSE_SECONDS=0.25
 # The scheduled GitHub workflow processes only stale/missing cache entries and
 # never forces refresh. Keep this bounded; at most this many candidate movies
 # are handled per run.
-TMDB_ENRICHMENT_LIMIT=200
+TMDB_ENRICHMENT_LIMIT=100
 TMDB_ENRICHMENT_BATCH_SIZE=10
 
 UPLOAD_MAX_ARCHIVE_MEMBERS=50000

--- a/scripts/local_full_sync.py
+++ b/scripts/local_full_sync.py
@@ -9,10 +9,20 @@ import zipfile
 from pathlib import Path
 
 import requests
+from dotenv import load_dotenv
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BACKEND_DIR = REPO_ROOT / "backend"
+
+
+def load_local_environment(env_file: Path = REPO_ROOT / ".env") -> None:
+    """Load ignored local credentials without overriding the caller's shell."""
+    load_dotenv(env_file, override=False)
+
+
+load_local_environment()
+
 if str(BACKEND_DIR) not in sys.path:
     sys.path.insert(0, str(BACKEND_DIR))
 


### PR DESCRIPTION
## What

**Full Letterboxd tag capture** — the HTML scraper now crawls the public tags surfaces (`/u/tags/{films,diary,reviews,lists}/` indexes + per-tag pages, index pagination at 120 tags handled) and attaches tags to scraped rows via film id/slug, diary viewing id, review viewing id, and list URL. Tags ride the existing CSVs as JSON-array `Tags` columns — the deployed ingestion consumes them with its existing `parse_tags` sites and authoritative gates, no schema change.

Also captured per full sync:
- List `Ranked` + `Published_Date` (detail pages were already fetched for memberships)
- Review rewatch flag + viewing id
- Fixed dead stats URL (`/films/stats/` → `/stats/`)

**Ingestion hardening** surfaced by adversarial review:
- lists.csv metadata now preserves previously imported `is_ranked`/`published_date`/`tags` when a bundle lacks those columns (pre-upgrade scrapers, official exports) — mirrors the existing `is_public` guard
- `parse_tags` keeps tags literally named "nan"/"none"/"null" on the structured JSON path
- A private list detail mid-crawl marks the whole lists surface unavailable instead of saving defaulted metadata

**`POST /profiles/{username}/rename`** (ingestion-token or Clerk-admin auth): carries a profile to a renamed Letterboxd account in place — same profile id, datasets and tracking intact, RSS feed repointed with backoff cleared, mirroring app users updated. Needed live today (`gowri_sriya` → `mnigsm`); previously required manual SQL on the host.

`SOCIAL_GRAPH_DESIGN.md` documents the next feature (following/followers) end to end.

## Verification

- 262 backend tests pass (11 new: parser units incl. index/per-tag pagination + slug fallback, an end-to-end bundle→models tags test, legacy-bundle preservation for every surface, rename semantics, route-auth matrix)
- Live end-to-end: fresh scrape of a tagged profile → CSVs → ingestion → DB verified (tags on Rating/ProfileFilm/WatchEvent/Review, ranked lists with real publish dates)
- Index pagination fix verified live against a 136-tag profile (2 pages, all tags collected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)