### PR TITLE
Letterboxd completeness: person-id auto-rename, log dates, comment counts, tags UI, follow network

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -25,6 +25,12 @@ Key columns:
 - `website`
 - `profile_image_url`
 - `enhanced_metrics`
+- `letterboxd_person_id` — Letterboxd's stable numeric member id; survives
+  username renames, so an upload under an unknown username with a known person
+  id renames the existing profile in place instead of duplicating it
+- `member_badge` — Patron/Pro/Crew when observed
+- `reported_watchlist_count` — profile-sidebar count, observable even when the
+  watchlist itself is private
 
 Notes:
 
@@ -94,7 +100,10 @@ One current-state row per `(profile_id, movie_id)` containing the profile's late
 
 ### `watch_events`
 
-Authoritative diary imports store one row per occurrence. Stable Letterboxd viewing IDs are preferred for `event_key`; deterministic occurrence-aware keys are the fallback. Repeat watches on the same title and date remain separate events. Superseded rows are retained during normal ingestion while insight queries use only active rows.
+Authoritative diary imports store one row per occurrence. `logged_date`
+preserves the official-export log date next to `watched_date`; public HTML
+only exposes the watch date, so scraper syncs never overwrite a known log
+date with their own unknown. Stable Letterboxd viewing IDs are preferred for `event_key`; deterministic occurrence-aware keys are the fallback. Repeat watches on the same title and date remain separate events. Superseded rows are retained during normal ingestion while insight queries use only active rows.
 
 The normalization backfill also created non-authoritative `legacy_rating_snapshot` events from the one retained date on each legacy rating. `GET /api/spy-signals` therefore keeps ratings as its compatibility default. With `event_source=events`, it uses active WatchEvents only for profiles with a completed authoritative diary and falls back per profile to `ratings.watched_date` when no such diary exists.
 

--- a/alembic/versions/20260731_0011_add_completeness_columns.py
+++ b/alembic/versions/20260731_0011_add_completeness_columns.py
@@ -1,0 +1,63 @@
+"""Add the Letterboxd completeness columns.
+
+- profiles.letterboxd_person_id: the stable numeric member id (survives
+  username renames; uploads under an unknown username can be recognized and
+  renamed in place instead of duplicated), with a unique index.
+- profiles.member_badge, profiles.reported_watchlist_count: profile header
+  facts the scraper can observe (the watchlist count matters most when the
+  watchlist itself is private).
+- watch_events.logged_date: official exports carry both the log date and the
+  watch date; previously the log date was discarded.
+- movie_lists.updated_date: list detail pages expose the last-updated
+  timestamp next to the published one.
+
+All additive and nullable; every column stays NULL until a source observes it.
+
+Revision ID: 20260731_0011
+Revises: 20260731_0010
+Create Date: 2026-07-31 23:10:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260731_0011"
+down_revision: Union[str, None] = "20260731_0010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("profiles", sa.Column("letterboxd_person_id", sa.BigInteger(), nullable=True))
+    op.add_column("profiles", sa.Column("member_badge", sa.String(length=20), nullable=True))
+    op.add_column(
+        "profiles", sa.Column("reported_watchlist_count", sa.Integer(), nullable=True)
+    )
+    op.create_check_constraint(
+        "ck_profiles_reported_watchlist_nonnegative",
+        "profiles",
+        "reported_watchlist_count IS NULL OR reported_watchlist_count >= 0",
+    )
+    op.create_index(
+        "uq_profiles_letterboxd_person_id",
+        "profiles",
+        ["letterboxd_person_id"],
+        unique=True,
+    )
+    op.add_column("watch_events", sa.Column("logged_date", sa.Date(), nullable=True))
+    op.add_column("movie_lists", sa.Column("updated_date", sa.Date(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("movie_lists", "updated_date")
+    op.drop_column("watch_events", "logged_date")
+    op.drop_index("uq_profiles_letterboxd_person_id", table_name="profiles")
+    op.drop_constraint(
+        "ck_profiles_reported_watchlist_nonnegative", "profiles", type_="check"
+    )
+    op.drop_column("profiles", "reported_watchlist_count")
+    op.drop_column("profiles", "member_badge")
+    op.drop_column("profiles", "letterboxd_person_id")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -69,6 +69,12 @@ class Profile(Base):
     reported_total_films = Column(Integer, nullable=True)
     reported_total_reviews = Column(Integer, nullable=True)
     reported_total_lists = Column(Integer, nullable=True)
+    reported_watchlist_count = Column(Integer, nullable=True)
+    # Letterboxd's stable numeric member id: survives username renames, so an
+    # upload under an unknown username can be recognized as an existing
+    # profile and renamed in place instead of duplicated.
+    letterboxd_person_id = Column(BigInteger, nullable=True)
+    member_badge = Column(String(20), nullable=True)  # 'Patron' | 'Pro' | 'Crew'
     metadata_synced_at = Column(DateTime(timezone=True), nullable=True)
     last_profile_sync_id = Column(
         BigInteger,
@@ -152,8 +158,13 @@ class Profile(Base):
             "reported_total_lists IS NULL OR reported_total_lists >= 0",
             name="ck_profiles_reported_lists_nonnegative",
         ),
+        CheckConstraint(
+            "reported_watchlist_count IS NULL OR reported_watchlist_count >= 0",
+            name="ck_profiles_reported_watchlist_nonnegative",
+        ),
+        Index("uq_profiles_letterboxd_person_id", "letterboxd_person_id", unique=True),
     )
-    
+
     def to_dict(self):
         return {
             "id": self.id,
@@ -704,6 +715,9 @@ class WatchEvent(Base):
     )
     event_key = Column(String(600), nullable=False)
     watched_date = Column(Date, nullable=False)
+    # Official exports carry both the log date and the watch date; public HTML
+    # only exposes the watch date, so this stays NULL for scraper events.
+    logged_date = Column(Date, nullable=True)
     rating = Column(Float, nullable=True)
     is_rewatch = Column(Boolean, nullable=False, server_default=sql_text("false"))
     is_liked = Column(Boolean, nullable=False, server_default=sql_text("false"))
@@ -828,6 +842,7 @@ class MovieList(Base):
     source_list_key = Column(String(600), nullable=True)
     letterboxd_url = Column(String(500), nullable=True)
     published_date = Column(Date, nullable=True)
+    updated_date = Column(Date, nullable=True)
     first_seen_profile_sync_id = Column(
         BigInteger,
         ForeignKey("profile_syncs.id", ondelete="SET NULL"),

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from api.routes.insights import router as insights_router
 from api.routes.profile_access import router as profile_access_router
 from auth import ClerkUser, get_admin_user, get_current_user, get_upload_user
 from database.connection import engine, get_db, init_db
+from database.models import Profile
 from database.repository import (
     ProfileRepository, RatingRepository, ReviewRepository, AnalyticsRepository
 )
@@ -287,6 +288,19 @@ def _get_cors_origins() -> List[str]:
     return deduped
 
 
+def _safe_tag_list(value) -> List[str]:
+    """Coerce a stored tags JSON value into a clean list of tag strings."""
+    if not isinstance(value, list):
+        return []
+    tags: List[str] = []
+    for tag in value:
+        if isinstance(tag, str):
+            cleaned = tag.strip()
+            if cleaned:
+                tags.append(cleaned)
+    return tags
+
+
 def _safe_json_float(value, default: Optional[float] = None) -> Optional[float]:
     if value is None:
         return default
@@ -307,6 +321,17 @@ def _refresh_dashboard_snapshot_cache(db: Session) -> None:
         )
     except Exception as exc:
         print(f"Warning: failed to refresh dashboard analytics snapshot: {exc}")
+
+
+def _bundle_person_id(analyzer_profile) -> Optional[int]:
+    """The stable Letterboxd member id claimed by a bundle's profile.csv."""
+    info = getattr(analyzer_profile, "profile_info", {}) or {}
+    raw = info.get("Person_ID") or info.get("Person ID")
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
 
 
 def _record_owner_export_publication_consent(analyzer_profile, publish_owner_data: bool) -> None:
@@ -700,7 +725,18 @@ async def get_analysis(
     total_films = len(all_entries)
     rated_films = len([r for r in all_entries if r.rating is not None and r.rating > 0])
     liked_films = len([r for r in all_entries if r.is_liked])
-    
+
+    # Aggregate film-level tag usage across every entry for this profile
+    tag_usage: dict = {}
+    for entry in all_entries:
+        for tag in _safe_tag_list(entry.tags):
+            tag_usage[tag] = tag_usage.get(tag, 0) + 1
+    tag_counts = [
+        {"tag": tag, "count": count}
+        for tag, count in sorted(tag_usage.items(), key=lambda item: (-item[1], item[0].lower()))
+    ]
+
+
     analysis = {
         "username": profile.username,
         "total_films": total_films,
@@ -715,13 +751,15 @@ async def get_analysis(
         "data_coverage": extract_data_coverage(profile.enhanced_metrics),
         "rating_distribution": rating_distribution,
         "monthly_stats": monthly_stats,
+        "tag_counts": tag_counts,
         "recent_ratings": [
             {
                 "movie_title": r.movie_title,
                 "movie_year": r.movie_year,
                 "rating": _safe_json_float(r.rating),
                 "watched_date": r.watched_date.isoformat() if r.watched_date else None,
-                "is_rewatch": r.is_rewatch
+                "is_rewatch": r.is_rewatch,
+                "tags": _safe_tag_list(r.tags)
             } for r in recent_ratings
         ],
         "recent_reviews": [
@@ -732,7 +770,8 @@ async def get_analysis(
                 "review_text": r.review_text[:200] + "..." if r.review_text and len(r.review_text) > 200 else r.review_text,
                 "contains_spoilers": bool(r.contains_spoilers),
                 "published_date": r.published_date.isoformat() if r.published_date else None,
-                "likes_count": r.likes_count
+                "likes_count": r.likes_count,
+                "tags": _safe_tag_list(r.tags)
             } for r in recent_reviews
         ],
         "recent_watching_trend": [
@@ -741,7 +780,8 @@ async def get_analysis(
                 "movie_year": r.movie_year,
                 "watched_date": r.watched_date.isoformat() if r.watched_date else None,
                 "rating": _safe_json_float(r.rating),
-                "is_rewatch": r.is_rewatch
+                "is_rewatch": r.is_rewatch,
+                "tags": _safe_tag_list(r.tags)
             } for r in recent_watching_sorted
         ]
     }
@@ -926,6 +966,26 @@ async def upload_files(
                 # The unified loader owns snapshot metadata updates so an
                 # already-completed source replay remains a true no-op.
                 existing_profile = profile_repo.get_profile_by_username(username)
+                if not existing_profile:
+                    # Letterboxd renames leave the stable person id intact: a
+                    # bundle under an unknown username that carries a known
+                    # person id is an existing profile to rename in place, not
+                    # a new account to duplicate.
+                    person_id = _bundle_person_id(analyzer_profile)
+                    if person_id is not None:
+                        renamed_profile = (
+                            db.query(Profile)
+                            .filter(Profile.letterboxd_person_id == person_id)
+                            .one_or_none()
+                        )
+                        if renamed_profile is not None:
+                            old_name = renamed_profile.username
+                            profile_repo.rename_profile(renamed_profile, username)
+                            LOGGER.info(
+                                "Auto-renamed profile %s -> %s via person id %s",
+                                old_name, username, person_id,
+                            )
+                            existing_profile = renamed_profile
                 if existing_profile:
                     profile = existing_profile
                 else:

--- a/backend/scraper_html.py
+++ b/backend/scraper_html.py
@@ -52,6 +52,10 @@ class ProfileInfo:
     # tell "unknown" from "empty".
     following_count: Optional[int] = None
     followers_count: Optional[int] = None
+    # Letterboxd's stable numeric member id — survives username renames.
+    person_id: Optional[int] = None
+    badge: str = ""
+    watchlist_count: Optional[int] = None
     favorite_films: List[Dict] = None
 
     def __post_init__(self):
@@ -592,6 +596,27 @@ class EnhancedLetterboxdScraper:
                 elif target == 'followers':
                     self.profile_info.followers_count = value
             
+            # Stable member id: rendered in several page URLs (report link,
+            # bio full-text). Verified present on profiles with and without
+            # bios, badges, and custom avatars.
+            page_text = getattr(response, 'text', None) or response.content.decode('utf-8', 'ignore')
+            person_match = re.search(r'person:(\d+)', page_text)
+            if person_match:
+                self.profile_info.person_id = int(person_match.group(1))
+
+            # Patron/Pro/Crew badge next to the display name.
+            badge = soup.select_one('h1.person-display-name span.badge')
+            if badge is not None:
+                self.profile_info.badge = badge.get_text(' ', strip=True)
+
+            # Sidebar watchlist count — observable even when the watchlist
+            # page itself is private.
+            watchlist_link = soup.select_one('section.watchlist-aside a.all-link')
+            if watchlist_link is not None:
+                digits = re.findall(r'[\d,]+', watchlist_link.get_text())
+                if digits:
+                    self.profile_info.watchlist_count = int(digits[0].replace(',', ''))
+
             # Favorite films (top 4)
             favorite_root = soup.select_one('#favourites, #favorites, .profile-favorites, .profile-favourites')
             if favorite_root is not None:
@@ -893,9 +918,38 @@ class EnhancedLetterboxdScraper:
         if not reviews and not self._declares_empty(soup, 'reviews'):
             raise ScrapeValidationError("Reviews resolved to zero without an explicit empty state")
         self.reviews_data = reviews
+        if self._review_comments_enabled() and reviews:
+            self._fetch_review_comment_counts()
         self._finish_dataset('reviews')
         print(f"✓ Found {len(reviews)} reviews")
         return reviews
+
+    @staticmethod
+    def _review_comments_enabled() -> bool:
+        """Comment counts need one CSI request per review, so they are opt-in."""
+        raw = os.environ.get('SPYBOXD_SCRAPE_REVIEW_COMMENTS', '').strip().casefold()
+        return raw in {'1', 'true', 'yes', 'on'}
+
+    def _fetch_review_comment_counts(self) -> None:
+        """Fetch each review's comment count from its CSI comments include.
+
+        The include's heading ("98 Comments") is the authoritative count; a
+        zero-comment review renders only the comment prompt. A failed fetch
+        leaves the count unknown (blank in the CSV) so ingestion preserves any
+        previously imported value instead of zeroing it.
+        """
+        print(f"💬 Fetching comment counts for {len(self.reviews_data)} reviews...")
+        for review in self.reviews_data:
+            viewing_id = review.get('viewing_id', '')
+            if not viewing_id:
+                continue
+            url = f"https://letterboxd.com/csi/viewing/{viewing_id}/comments-section/?esiAllowUser=true"
+            response = self.fetch_with_retry(url, max_retries=2)
+            if response is None:
+                continue
+            match = re.search(r'([\d,]+)\s+Comments?', response.text)
+            review['comments_count'] = int(match.group(1).replace(',', '')) if match else 0
+            time.sleep(0.5)
     
     def scrape_watchlist(self) -> List[Dict]:
         """Scrape complete watchlist."""
@@ -1326,7 +1380,8 @@ class EnhancedLetterboxdScraper:
         fieldnames = [
             'Username', 'Display_Name', 'Bio', 'Location', 'Website', 'Join_Date',
             'Avatar_URL', 'Total_Films', 'Total_Reviews', 'Total_Lists',
-            'Following_Count', 'Followers_Count'
+            'Following_Count', 'Followers_Count', 'Person_ID', 'Badge',
+            'Watchlist_Count'
         ]
         data = [{
             'Username': self.profile_info.username,
@@ -1340,7 +1395,10 @@ class EnhancedLetterboxdScraper:
             'Total_Reviews': self.profile_info.total_reviews,
             'Total_Lists': self.profile_info.total_lists,
             'Following_Count': self.profile_info.following_count,
-            'Followers_Count': self.profile_info.followers_count
+            'Followers_Count': self.profile_info.followers_count,
+            'Person_ID': self.profile_info.person_id,
+            'Badge': self.profile_info.badge,
+            'Watchlist_Count': self.profile_info.watchlist_count,
         }]
         self._write_csv("profile.csv", data, fieldnames)
 
@@ -1369,12 +1427,16 @@ class EnhancedLetterboxdScraper:
             return
         fieldnames = [
             'Name', 'Year', 'Rating', 'Review', 'Review_Date', 'Review_Likes',
-            'Contains_Spoilers', 'Rewatch', 'Tags', 'Film_ID', 'Slug', 'Film_URL'
+            'Review_Comments', 'Contains_Spoilers', 'Rewatch', 'Tags',
+            'Film_ID', 'Slug', 'Film_URL'
         ]
         data = [{
             'Name': review['title'], 'Year': review['year'], 'Rating': review['rating'],
             'Review': review['review_text'], 'Review_Date': review['review_date'],
             'Review_Likes': review['review_likes'],
+            # Blank when comment fetching was disabled or failed: ingestion
+            # only overwrites comments_count for non-missing cells.
+            'Review_Comments': review.get('comments_count', ''),
             'Contains_Spoilers': 'Yes' if review.get('contains_spoilers', False) else 'No',
             'Rewatch': 'Yes' if review.get('is_rewatch', False) else 'No',
             'Tags': self._serialize_tags(review.get('tags')),
@@ -1399,18 +1461,16 @@ class EnhancedLetterboxdScraper:
         """Saves custom lists."""
         if 'lists' not in self.completed_datasets:
             return
-        # Updated_Date is captured in _extract_list_detail_metadata but not yet
-        # emitted: movie_lists has no updated-date column, and an unconsumed
-        # CSV column would misrepresent the import contract.
         fieldnames = [
             'Title', 'Description', 'Film_Count', 'URL',
-            'Ranked', 'Published_Date', 'Tags'
+            'Ranked', 'Published_Date', 'Updated_Date', 'Tags'
         ]
         data = [{
             'Title': li['title'], 'Description': li['description'],
             'Film_Count': li['film_count'], 'URL': li['url'],
             'Ranked': 'Yes' if li.get('is_ranked', False) else 'No',
             'Published_Date': li.get('published_date', ''),
+            'Updated_Date': li.get('updated_date', ''),
             'Tags': self._serialize_tags(li.get('tags')),
         } for li in self.lists_data]
         self._write_csv("lists.csv", data, fieldnames)

--- a/backend/services/ingestion.py
+++ b/backend/services/ingestion.py
@@ -33,6 +33,7 @@ from services.import_contracts import (
     diary_event_key,
     first_value,
     frame_records,
+    is_missing,
     movie_identity_from_row,
     normalize_letterboxd_url,
     normalize_title,
@@ -234,6 +235,27 @@ def _build_legacy_movies(
     # A row's presence in Letterboxd's likes.csv is itself the liked signal;
     # official exports do not include a redundant boolean column.
     ingest_frame(getattr(analyzer_profile, "likes", pd.DataFrame()), force_liked=True)
+
+    # Review tags apply to the reviewed film. Unioning them here makes both
+    # source kinds compute the same film-level tag union: an official export
+    # (whose diary rows lack review-only tags) no longer narrows the
+    # film-level tags an HTML sync previously established. Tags-only merge —
+    # a review row never creates a film-level payload on its own.
+    for row in frame_records(getattr(analyzer_profile, "reviews", pd.DataFrame())):
+        review_tags = parse_tags(first_value(row, ("Tags", "Tag")))
+        if not review_tags:
+            continue
+        identity = movie_identity_from_row(row)
+        if identity is None:
+            continue
+        identity = _enrich_identity(identity, identity_lookup)
+        payload = movies.get(_legacy_key(identity))
+        if payload is None:
+            continue
+        existing_tags = {tag.casefold() for tag in payload["tags"]}
+        payload["tags"].extend(
+            tag for tag in review_tags if tag.casefold() not in existing_tags
+        )
     return movies
 
 
@@ -526,11 +548,20 @@ def _prepare_diary_events(
             occurrence=occurrences[occurrence_key],
             source_entry_id=source_entry_id,
         )
+        # Official export diary rows carry both the log date ("Date") and the
+        # watch date ("Watched Date"). "Date" is only the log date when a
+        # distinct watched-date column exists; otherwise it IS the watch date.
+        logged_date = (
+            parse_date(row.get("Date"))
+            if "Watched Date" in row and not is_missing(row.get("Watched Date"))
+            else None
+        )
         prepared.append(
             {
                 "movie": movie,
                 "event_key": event_key,
                 "watched_date": watched_date,
+                "logged_date": logged_date,
                 "rating": _bounded_rating(first_value(row, ("Rating", "Stars"))),
                 "is_rewatch": parse_boolean(first_value(row, ("Rewatch", "Is_Rewatch", "Is Rewatch"))),
                 "is_liked": parse_boolean(first_value(row, ("Liked", "Is_Liked", "Is Liked"))),
@@ -693,6 +724,10 @@ def _upsert_watch_events(
         event.movie_id = payload["movie"].id
         event.profile_film = profile_films.get(payload["movie"].id)
         event.watched_date = payload["watched_date"]
+        # The log date only exists in official exports; an HTML sync must not
+        # erase a previously imported value with its own unknown.
+        if payload.get("logged_date") is not None:
+            event.logged_date = payload["logged_date"]
         if created_event or rating_authoritative:
             event.rating = payload["rating"]
         if created_event or rewatch_authoritative:
@@ -1000,6 +1035,9 @@ def _upsert_lists(
             published_value = first_value(row, ("Published Date", "Published_Date", "Date"))
             if published_value is not None:
                 movie_list.published_date = parse_date(published_value)
+            updated_value = first_value(row, ("Updated Date", "Updated_Date"))
+            if updated_value is not None:
+                movie_list.updated_date = parse_date(updated_value)
             tags_value = first_value(row, ("Tags", "List_Tags", "List Tags"))
             if tags_value is not None:
                 movie_list.tags = parse_tags(tags_value)
@@ -1227,10 +1265,18 @@ def _update_profile_metadata(profile: Profile, analyzer_profile, sync: ProfileSy
         "reported_total_films": parse_integer(first_value(info, ("Total_Films", "Total Films")), minimum=0),
         "reported_total_reviews": parse_integer(first_value(info, ("Total_Reviews", "Total Reviews")), minimum=0),
         "reported_total_lists": parse_integer(first_value(info, ("Total_Lists", "Total Lists")), minimum=0),
+        "reported_watchlist_count": parse_integer(first_value(info, ("Watchlist_Count", "Watchlist Count")), minimum=0),
+        "letterboxd_person_id": parse_integer(first_value(info, ("Person_ID", "Person ID")), minimum=1),
     }
     for attribute, value in integer_fields.items():
         if value is not None:
             setattr(profile, attribute, value)
+
+    # Badge presence is only meaningful from bundles that observed it: older
+    # bundles predate the column and must not clear a known badge.
+    badge_value = clean_text(first_value(info, ("Badge",)), max_length=20)
+    if badge_value is not None:
+        profile.member_badge = badge_value
     profile.metadata_synced_at = now
 
 
@@ -1523,7 +1569,14 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
         )
         tags_authoritative = any(
             _frame_has_any_column(frame, ("Tags", "Tag"))
-            for frame in (all_films, ratings_frame, watched_frame, diary_frame, likes_frame)
+            for frame in (
+                all_films,
+                ratings_frame,
+                watched_frame,
+                diary_frame,
+                likes_frame,
+                getattr(analyzer_profile, "reviews", pd.DataFrame()),
+            )
         )
         diary_rating_authoritative = _frame_has_any_column(
             diary_frame, ("Rating", "Stars")

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260731_0010"
+HEAD_REVISION = "20260731_0011"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260730_0009"
+            script.get_revision(HEAD_REVISION).down_revision, "20260731_0010"
+        )
+        self.assertEqual(
+            script.get_revision("20260731_0010").down_revision, "20260730_0009"
         )
         self.assertEqual(
             script.get_revision("20260730_0009").down_revision, "20260730_0008"
@@ -163,6 +166,9 @@ class AdditiveMigrationContractTests(unittest.TestCase):
                 "followers_count",
                 "following_count",
                 "last_profile_sync_id",
+                "letterboxd_person_id",
+                "member_badge",
+                "reported_watchlist_count",
             },
             "profile_follow_edges": {
                 "profile_id",
@@ -209,6 +215,7 @@ class AdditiveMigrationContractTests(unittest.TestCase):
                 "movie_id",
                 "event_key",
                 "watched_date",
+                "logged_date",
                 "superseded_at",
             },
             "profile_data_changes": {

--- a/backend/tests/test_import_contracts.py
+++ b/backend/tests/test_import_contracts.py
@@ -970,7 +970,8 @@ class SocialSurfaceScrapingTests(unittest.TestCase):
         scraper.profile_info = SimpleNamespace(
             username="viewer", display_name="Viewer", bio="", location="", website="",
             join_date=None, avatar_url="", total_films=1, total_reviews=0,
-            total_lists=0, following_count=1, followers_count=None, favorite_films=[],
+            total_lists=0, following_count=1, followers_count=None,
+            person_id=26275117, badge="", watchlist_count=None, favorite_films=[],
         )
         scraper.films_data = [{
             "title": "Challengers", "year": 2024, "rating": 4.0, "film_id": "842301",

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -427,6 +427,7 @@ def test_profile_analysis_exposes_review_spoiler_metadata(database):
             "contains_spoilers": True,
             "published_date": "2026-07-30",
             "likes_count": 0,
+            "tags": [],
         }
     ]
 

--- a/backend/tests/test_scraped_tags_flow.py
+++ b/backend/tests/test_scraped_tags_flow.py
@@ -110,6 +110,7 @@ def _write_bundle(root: Path, *, with_tags: bool) -> None:
     diary_row = {
         "Name": "Challengers",
         "Year": 2024,
+        "Date": "2026-07-05",
         "Watched Date": "2026-07-01",
         "Rating": 4.0,
         "Is_Rewatch": "No",
@@ -121,7 +122,7 @@ def _write_bundle(root: Path, *, with_tags: bool) -> None:
         "Film_URL": "https://letterboxd.com/film/challengers/",
     }
     diary_columns = [
-        "Name", "Year", "Watched Date", "Rating", "Is_Rewatch", "Is_Liked",
+        "Name", "Year", "Date", "Watched Date", "Rating", "Is_Rewatch", "Is_Liked",
         "Has_Review", "Film_ID", "Slug", "Diary_Entry_ID", "Film_URL",
     ]
     if with_tags:
@@ -160,9 +161,10 @@ def _write_bundle(root: Path, *, with_tags: bool) -> None:
         list_row.update({
             "Ranked": "Yes",
             "Published_Date": "2026-01-11T07:15:06.720Z",
+            "Updated_Date": "2026-07-25T14:25:26.004Z",
             "Tags": LIST_TAGS,
         })
-        list_columns += ["Ranked", "Published_Date", "Tags"]
+        list_columns += ["Ranked", "Published_Date", "Updated_Date", "Tags"]
 
     _write_frame(
         root / "profile.csv",
@@ -175,10 +177,14 @@ def _write_bundle(root: Path, *, with_tags: bool) -> None:
             "Total_Lists": 1,
             "Following_Count": 1,
             "Followers_Count": 2,
+            "Person_ID": 26275117 if with_tags else None,
+            "Badge": "Patron" if with_tags else None,
+            "Watchlist_Count": 88 if with_tags else None,
         }],
         [
             "Username", "Display_Name", "Join_Date", "Total_Films",
             "Total_Reviews", "Total_Lists", "Following_Count", "Followers_Count",
+            "Person_ID", "Badge", "Watchlist_Count",
         ],
     )
     _write_frame(root / "films_comprehensive.csv", [film], film_columns)
@@ -255,12 +261,17 @@ def test_tagged_scraper_bundle_flows_into_all_tag_columns(tmp_path: Path, databa
     _import_bundle(tmp_path, "bundle", database, with_tags=True)
 
     rating = database.query(Rating).one()
-    # Legacy payloads union tags across every contributing frame (films + diary).
-    assert sorted(rating.tags or []) == ["comma, tag", "mood: eerie", "rewatch club"]
+    # Legacy payloads union tags across every contributing frame
+    # (films + diary + reviews).
+    assert sorted(rating.tags or []) == [
+        "comma, tag", "mood: eerie", "rewatch club", "spoiler-review",
+    ]
 
     profile_film = database.query(ProfileFilm).one()
-    # Film-level and diary tags are unioned on the current-state row.
-    assert set(profile_film.tags or []) == {"comma, tag", "mood: eerie", "rewatch club"}
+    # Film-level, diary, and review tags are unioned on the current-state row.
+    assert set(profile_film.tags or []) == {
+        "comma, tag", "mood: eerie", "rewatch club", "spoiler-review",
+    }
 
     event = database.query(WatchEvent).one()
     assert event.tags == ["rewatch club"]
@@ -273,7 +284,16 @@ def test_tagged_scraper_bundle_flows_into_all_tag_columns(tmp_path: Path, databa
     movie_list = database.query(MovieList).one()
     assert movie_list.is_ranked is True
     assert movie_list.published_date == date(2026, 1, 11)
+    assert movie_list.updated_date == date(2026, 7, 25)
     assert movie_list.tags == ["favorites"]
+
+    # Completeness columns: stable person id, badge, watchlist header count,
+    # and the diary log date official exports carry alongside the watch date.
+    profile = database.query(Profile).one()
+    assert profile.letterboxd_person_id == 26275117
+    assert profile.member_badge == "Patron"
+    assert profile.reported_watchlist_count == 88
+    assert event.logged_date == date(2026, 7, 5)
 
 
 def test_legacy_bundle_without_tag_columns_preserves_previous_tags(tmp_path: Path, database: Session) -> None:
@@ -282,10 +302,10 @@ def test_legacy_bundle_without_tag_columns_preserves_previous_tags(tmp_path: Pat
     _import_bundle(tmp_path, "legacy", database, with_tags=False)
 
     assert sorted(database.query(Rating).one().tags or []) == [
-        "comma, tag", "mood: eerie", "rewatch club",
+        "comma, tag", "mood: eerie", "rewatch club", "spoiler-review",
     ]
     assert set(database.query(ProfileFilm).one().tags or []) == {
-        "comma, tag", "mood: eerie", "rewatch club",
+        "comma, tag", "mood: eerie", "rewatch club", "spoiler-review",
     }
     assert database.query(WatchEvent).filter(WatchEvent.superseded_at.is_(None)).one().tags == [
         "rewatch club"

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/FollowNetwork.tsx
+++ b/frontend/src/components/FollowNetwork.tsx
@@ -1,0 +1,350 @@
+'use client';
+
+import React, { useId, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { Share2 } from 'lucide-react';
+
+import { followGraphApi, type FollowMutualPair, type ProfileInfo } from '../services/api';
+
+const VIEW_WIDTH = 760;
+const VIEW_HEIGHT = 640;
+const CENTER_X = VIEW_WIDTH / 2;
+const CENTER_Y = VIEW_HEIGHT / 2;
+const RING_RADIUS = 232;
+const NODE_RADIUS = 26;
+const EDGE_GAP = NODE_RADIUS + 8;
+
+const MUTUAL_COLOR = '#34d399'; // emerald-400
+const ONEWAY_COLOR = '#f57c00'; // cinema-400
+
+interface NetworkNode {
+  username: string;
+  key: string;
+  x: number;
+  y: number;
+  cos: number;
+  avatarUrl: string | null;
+}
+
+interface NetworkEdge {
+  pair: FollowMutualPair;
+  from: NetworkNode;
+  to: NetworkNode;
+  mutual: boolean;
+}
+
+/** Trim a segment so it starts/ends at the node boundaries instead of centers. */
+function edgeSegment(from: NetworkNode, to: NetworkNode) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy) || 1;
+  const ux = dx / length;
+  const uy = dy / length;
+  return {
+    x1: from.x + ux * EDGE_GAP,
+    y1: from.y + uy * EDGE_GAP,
+    x2: to.x - ux * EDGE_GAP,
+    y2: to.y - uy * EDGE_GAP,
+  };
+}
+
+function NodeAvatar({ node, clipId }: { node: NetworkNode; clipId: string }) {
+  const [failed, setFailed] = useState(false);
+
+  if (node.avatarUrl && !failed) {
+    return (
+      <image
+        href={node.avatarUrl}
+        x={node.x - NODE_RADIUS}
+        y={node.y - NODE_RADIUS}
+        width={NODE_RADIUS * 2}
+        height={NODE_RADIUS * 2}
+        preserveAspectRatio="xMidYMid slice"
+        clipPath={`url(#${clipId})`}
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <>
+      <circle cx={node.x} cy={node.y} r={NODE_RADIUS} fill="rgba(229, 81, 0, 0.16)" />
+      <text
+        x={node.x}
+        y={node.y}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fill="#fbcd9a"
+        fontSize={18}
+        fontWeight={700}
+        style={{ textTransform: 'uppercase' }}
+      >
+        {node.username.slice(0, 2).toUpperCase()}
+      </text>
+    </>
+  );
+}
+
+/**
+ * SVG node-edge network of the tracked profiles' follow relationships.
+ * Nodes sit on a stable circle (deterministic order = the API's profiles
+ * array); mutual follows render as solid emerald lines, one-way follows as
+ * orange lines with an arrowhead toward the followed profile.
+ */
+export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] }) {
+  const reactId = useId();
+  const [hovered, setHovered] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // No explicit profiles: the endpoint defaults to the caller's full
+  // accessible/tracked set. Quiet by design on 404 (endpoint not deployed).
+  const networkQuery = useQuery({
+    queryKey: ['follow-mutuals', 'network'],
+    queryFn: () => followGraphApi.getMutuals([]),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  const avatarByUsername = useMemo(() => {
+    const map = new Map<string, string | null>();
+    profiles.forEach((profile) => {
+      map.set(profile.username.toLowerCase(), profile.profile_image_url ?? profile.avatar_url ?? null);
+    });
+    return map;
+  }, [profiles]);
+
+  const nodes = useMemo<NetworkNode[]>(() => {
+    const usernames = networkQuery.data?.profiles ?? [];
+    const count = usernames.length;
+    return usernames.map((username, index) => {
+      const angle = -Math.PI / 2 + (index * 2 * Math.PI) / Math.max(count, 1);
+      const cos = Math.cos(angle);
+      return {
+        username,
+        key: username.toLowerCase(),
+        x: CENTER_X + RING_RADIUS * cos,
+        y: CENTER_Y + RING_RADIUS * Math.sin(angle),
+        cos,
+        avatarUrl: avatarByUsername.get(username.toLowerCase()) ?? null,
+      };
+    });
+  }, [networkQuery.data?.profiles, avatarByUsername]);
+
+  const nodeByKey = useMemo(() => new Map(nodes.map((node) => [node.key, node])), [nodes]);
+
+  const edges = useMemo<NetworkEdge[]>(() => {
+    const pairs = networkQuery.data?.pairs ?? [];
+    const result: NetworkEdge[] = [];
+    pairs.forEach((pair) => {
+      if (!pair.a_follows_b && !pair.b_follows_a) return;
+      const nodeA = nodeByKey.get(pair.a.toLowerCase());
+      const nodeB = nodeByKey.get(pair.b.toLowerCase());
+      if (!nodeA || !nodeB) return;
+      // Orient one-way edges from follower to followed so the arrowhead
+      // always points at the followed profile.
+      const from = pair.mutual || pair.a_follows_b ? nodeA : nodeB;
+      const to = from === nodeA ? nodeB : nodeA;
+      result.push({ pair, from, to, mutual: pair.mutual });
+    });
+    return result;
+  }, [networkQuery.data?.pairs, nodeByKey]);
+
+  const neighborsByKey = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    edges.forEach((edge) => {
+      if (!map.has(edge.from.key)) map.set(edge.from.key, new Set());
+      if (!map.has(edge.to.key)) map.set(edge.to.key, new Set());
+      map.get(edge.from.key)!.add(edge.to.key);
+      map.get(edge.to.key)!.add(edge.from.key);
+    });
+    return map;
+  }, [edges]);
+
+  const mutualCount = edges.filter((edge) => edge.mutual).length;
+  const onewayCount = edges.length - mutualCount;
+  const activeKey = selected ?? hovered;
+  const activeNode = activeKey ? nodeByKey.get(activeKey) ?? null : null;
+  const activeRollup = useMemo(() => {
+    if (!activeNode) return null;
+    const rollups = networkQuery.data?.rollups ?? {};
+    const entry = Object.entries(rollups).find(([username]) => username.toLowerCase() === activeNode.key);
+    return entry ? entry[1] : null;
+  }, [activeNode, networkQuery.data?.rollups]);
+
+  if (networkQuery.error) return null;
+
+  return (
+    <motion.section
+      aria-label="Follow network"
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.1 }}
+      className="panel-insight p-5"
+      data-testid="follow-network"
+    >
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <Share2 className="h-4 w-4 text-cinema-300" aria-hidden="true" />
+          <h2 className="text-lg font-bold text-white">Network</h2>
+          {!networkQuery.isLoading && nodes.length > 0 && (
+            <span className="text-xs text-white/40">
+              {nodes.length} profiles &middot; {mutualCount} mutual &middot; {onewayCount} one-way
+            </span>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-4 text-[11px] text-white/50">
+          <span className="flex items-center gap-1.5">
+            <svg width="26" height="8" viewBox="0 0 26 8" aria-hidden="true">
+              <line x1="1" y1="4" x2="25" y2="4" stroke={MUTUAL_COLOR} strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            Mutual
+          </span>
+          <span className="flex items-center gap-1.5">
+            <svg width="26" height="8" viewBox="0 0 26 8" aria-hidden="true">
+              <line x1="1" y1="4" x2="19" y2="4" stroke={ONEWAY_COLOR} strokeWidth="2" strokeLinecap="round" />
+              <polygon points="19,0.5 25,4 19,7.5" fill={ONEWAY_COLOR} />
+            </svg>
+            Follows
+          </span>
+        </div>
+      </header>
+
+      {networkQuery.isLoading ? (
+        <p className="mt-6 pb-2 text-center text-sm text-white/40">Mapping who follows whom&hellip;</p>
+      ) : edges.length === 0 ? (
+        <p className="mt-6 pb-2 text-center text-sm text-white/40">
+          No follow connections between these profiles yet.
+        </p>
+      ) : (
+        <>
+          <div className="mx-auto mt-2 w-full max-w-3xl">
+            <svg
+              viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`}
+              className="h-auto w-full"
+              role="img"
+              aria-label={`Follow network of ${nodes.length} tracked profiles: ${mutualCount} mutual, ${onewayCount} one-way`}
+            >
+              <defs>
+                <marker
+                  id={`${reactId}-arrow`}
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="9"
+                  markerHeight="9"
+                  markerUnits="userSpaceOnUse"
+                  orient="auto-start-reverse"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill={ONEWAY_COLOR} />
+                </marker>
+                {nodes.map((node) => (
+                  <clipPath key={node.key} id={`${reactId}-clip-${node.key}`}>
+                    <circle cx={node.x} cy={node.y} r={NODE_RADIUS} />
+                  </clipPath>
+                ))}
+              </defs>
+
+              {/* Click-away target to clear a selected node. */}
+              <rect
+                x="0"
+                y="0"
+                width={VIEW_WIDTH}
+                height={VIEW_HEIGHT}
+                fill="transparent"
+                onClick={() => setSelected(null)}
+              />
+
+              <g>
+                {edges.map((edge) => {
+                  const segment = edgeSegment(edge.from, edge.to);
+                  const isActive = activeKey !== null && (edge.from.key === activeKey || edge.to.key === activeKey);
+                  const opacity = activeKey === null ? 0.55 : isActive ? 0.95 : 0.08;
+                  return (
+                    <line
+                      key={`${edge.pair.a}-${edge.pair.b}`}
+                      x1={segment.x1}
+                      y1={segment.y1}
+                      x2={segment.x2}
+                      y2={segment.y2}
+                      stroke={edge.mutual ? MUTUAL_COLOR : ONEWAY_COLOR}
+                      strokeWidth={isActive ? 2.5 : 1.75}
+                      strokeLinecap="round"
+                      opacity={opacity}
+                      markerEnd={edge.mutual ? undefined : `url(#${reactId}-arrow)`}
+                      style={{ transition: 'opacity 0.2s ease, stroke-width 0.2s ease' }}
+                    />
+                  );
+                })}
+              </g>
+
+              <g>
+                {nodes.map((node) => {
+                  const isActive = node.key === activeKey;
+                  const isNeighbor = activeKey !== null && (neighborsByKey.get(activeKey)?.has(node.key) ?? false);
+                  const dimmed = activeKey !== null && !isActive && !isNeighbor;
+                  const labelRadial = RING_RADIUS + NODE_RADIUS + 12;
+                  const labelX = CENTER_X + ((node.x - CENTER_X) / RING_RADIUS) * labelRadial;
+                  const labelY = CENTER_Y + ((node.y - CENTER_Y) / RING_RADIUS) * labelRadial;
+                  const anchor = node.cos > 0.35 ? 'start' : node.cos < -0.35 ? 'end' : 'middle';
+                  return (
+                    <g
+                      key={node.key}
+                      role="button"
+                      tabIndex={0}
+                      aria-pressed={selected === node.key}
+                      aria-label={`Highlight ${node.username}'s follow connections`}
+                      style={{ cursor: 'pointer', opacity: dimmed ? 0.25 : 1, transition: 'opacity 0.2s ease', outline: 'none' }}
+                      onMouseEnter={() => setHovered(node.key)}
+                      onMouseLeave={() => setHovered(null)}
+                      onFocus={() => setHovered(node.key)}
+                      onBlur={() => setHovered(null)}
+                      onClick={() => setSelected((current) => (current === node.key ? null : node.key))}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          setSelected((current) => (current === node.key ? null : node.key));
+                        }
+                      }}
+                    >
+                      <circle cx={node.x} cy={node.y} r={NODE_RADIUS + 3} fill="#0f172a" />
+                      <NodeAvatar node={node} clipId={`${reactId}-clip-${node.key}`} />
+                      <circle
+                        cx={node.x}
+                        cy={node.y}
+                        r={NODE_RADIUS + 1.5}
+                        fill="none"
+                        stroke={isActive ? '#ffffff' : isNeighbor ? MUTUAL_COLOR : 'rgba(245, 124, 0, 0.4)'}
+                        strokeWidth={isActive ? 2.5 : 1.5}
+                        style={{ transition: 'stroke 0.2s ease' }}
+                      />
+                      <text
+                        x={labelX}
+                        y={labelY}
+                        textAnchor={anchor}
+                        dominantBaseline="central"
+                        fill={isActive ? '#ffffff' : 'rgba(255, 255, 255, 0.55)'}
+                        fontSize={13}
+                        fontWeight={600}
+                      >
+                        {node.username}
+                      </text>
+                    </g>
+                  );
+                })}
+              </g>
+            </svg>
+          </div>
+          <p className="min-h-5 text-center text-xs text-white/45" aria-live="polite">
+            {activeNode && activeRollup
+              ? `@${activeNode.username} follows ${activeRollup.follows_in_group} in this group, followed by ${activeRollup.followed_by_in_group}`
+              : activeNode
+                ? `@${activeNode.username}`
+                : 'Hover or tap a profile to trace its connections.'}
+          </p>
+        </>
+      )}
+    </motion.section>
+  );
+}

--- a/frontend/src/components/insights/TagsPanel.tsx
+++ b/frontend/src/components/insights/TagsPanel.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { Tags } from 'lucide-react';
+
+import type { TagCount } from '../../services/api';
+
+const COLLAPSED_TAG_LIMIT = 24;
+
+export function TagChipList({ tags, className = '' }: { tags?: string[]; className?: string }) {
+  if (!tags || tags.length === 0) {
+    return null;
+  }
+  return (
+    <div className={`flex flex-wrap gap-1.5 ${className}`}>
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] font-medium text-white/45"
+        >
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function TagsPanel({
+  tagCounts,
+  username,
+  delay = 0,
+}: {
+  tagCounts?: TagCount[];
+  username: string;
+  delay?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  const sortedTags = [...(tagCounts ?? [])].sort(
+    (a, b) => b.count - a.count || a.tag.localeCompare(b.tag),
+  );
+  const visibleTags = expanded ? sortedTags : sortedTags.slice(0, COLLAPSED_TAG_LIMIT);
+
+  return (
+    <motion.div
+      className="analysis-panel"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <h2 className="flex items-center gap-2 text-xl font-semibold text-white">
+        <Tags className="h-5 w-5 text-cinema-400" aria-hidden="true" /> Tags
+      </h2>
+      <p className="mt-1 text-sm text-white/60">
+        Letterboxd tags @{username} has applied across synced films, sorted by usage.
+      </p>
+
+      {sortedTags.length > 0 ? (
+        <>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {visibleTags.map((entry) => (
+              <span
+                key={entry.tag}
+                className="inline-flex items-center gap-1.5 rounded-full border border-cinema-400/20 bg-cinema-500/10 px-3 py-1 text-xs font-medium text-cinema-300"
+              >
+                {entry.tag}
+                <span className="text-[10px] font-semibold text-white/40">{entry.count}</span>
+              </span>
+            ))}
+          </div>
+          {sortedTags.length > COLLAPSED_TAG_LIMIT && (
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              className="btn-ghost mt-4 border-white/10 px-4 py-2 text-xs"
+            >
+              {expanded ? 'Show fewer tags' : `Show all ${sortedTags.length} tags`}
+            </button>
+          )}
+        </>
+      ) : (
+        <p className="mt-5 text-sm text-white/50">No tags synced.</p>
+      )}
+    </motion.div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -147,9 +147,15 @@ export interface ProfileAnalysis {
   data_coverage?: DataCoverage;
   rating_distribution: Record<string, number>;
   monthly_stats: ActivityData[];
+  tag_counts?: TagCount[];
   recent_ratings: RecentRating[];
   recent_reviews: RecentReview[];
   recent_watching_trend: RecentWatchEvent[];
+}
+
+export interface TagCount {
+  tag: string;
+  count: number;
 }
 
 export interface RecentRating {
@@ -158,6 +164,7 @@ export interface RecentRating {
   rating: number | null;
   watched_date: string | null;
   is_rewatch: boolean;
+  tags?: string[];
 }
 
 export interface RecentReview {
@@ -168,6 +175,7 @@ export interface RecentReview {
   contains_spoilers: boolean;
   published_date: string | null;
   likes_count: number;
+  tags?: string[];
 }
 
 export interface RecentWatchEvent {
@@ -176,6 +184,7 @@ export interface RecentWatchEvent {
   watched_date: string | null;
   rating: number | null;
   is_rewatch: boolean;
+  tags?: string[];
 }
 
 export interface UploadFilesOptions {

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -13,6 +13,7 @@ import RatingDistributionChart from '../components/Charts/RatingDistributionChar
 import StatsCard from '../components/Charts/StatsCard';
 import SpoilerReviewText from '../components/SpoilerReviewText';
 import AdminScopeToggle from '../components/AdminScopeToggle';
+import TagsPanel, { TagChipList } from '../components/insights/TagsPanel';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 import { profileApi } from '../services/api';
 
@@ -181,6 +182,12 @@ const Analysis: React.FC = () => {
             />
           </div>
 
+          <TagsPanel
+            tagCounts={analysis.tag_counts}
+            username={analysis.username}
+            delay={0.15}
+          />
+
           <div className={`grid grid-cols-1 items-start gap-6 ${hasCoverageLimitations ? 'xl:grid-cols-3' : ''}`}>
             <motion.div
               className={`analysis-panel ${hasCoverageLimitations ? 'xl:col-span-2' : ''}`}
@@ -214,6 +221,7 @@ const Analysis: React.FC = () => {
                           {entry.rating !== null ? `${entry.rating.toFixed(1)} stars` : 'Unrated'}
                         </div>
                       </div>
+                      <TagChipList tags={entry.tags} className="mt-2" />
                     </div>
                   ))
                 ) : (
@@ -276,6 +284,7 @@ const Analysis: React.FC = () => {
                           {entry.rating !== null ? `${entry.rating.toFixed(1)} stars` : 'Unrated'}
                         </div>
                       </div>
+                      <TagChipList tags={entry.tags} className="mt-2" />
                     </div>
                   ))
                 ) : (
@@ -312,6 +321,7 @@ const Analysis: React.FC = () => {
                             {review.rating !== null ? `${review.rating.toFixed(1)} stars` : 'No rating'}
                           </div>
                         </div>
+                        <TagChipList tags={review.tags} className="mt-2" />
                         {reviewText ? (
                           <div className="mt-3">
                             <SpoilerReviewText

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -14,6 +14,7 @@ import {
 import TasteTimelinePanel from '../components/insights/TasteTimelinePanel';
 import { FeatureState, ProfileAvatar, WorkspaceTabs } from '../components/insights/InsightUI';
 import AdminScopeToggle from '../components/AdminScopeToggle';
+import FollowNetwork from '../components/FollowNetwork';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 import { useUrlProfileSelection } from '../hooks/useUrlProfileSelection';
 import {
@@ -325,6 +326,8 @@ export default function Compare() {
           <SignalCalendarPanel data={calendarQuery.data} coverage={fallbackCoverage} />
         )}
       </section>
+
+      <FollowNetwork profiles={completedProfiles} />
 
       <footer className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-white/10 py-3 text-[11px] text-white/35">
         <span className="flex items-center gap-1.5"><Scale className="h-3.5 w-3.5" /> Pair Dossier uses behavior and ratings.</span>


### PR DESCRIPTION
Closes out every deferred Letterboxd data point that doesn't require an official export file:

**Schema (alembic `20260731_0011`, all additive):** `profiles.letterboxd_person_id` (unique — the stable member id), `profiles.member_badge`, `profiles.reported_watchlist_count`, `watch_events.logged_date`, `movie_lists.updated_date`.

**Rename self-healing:** the scraper captures the person id (verified across profile shapes — it renders even without a bio, badge, or custom avatar); uploads under an unknown username with a known person id **auto-rename the existing profile in place**. Manual rename endpoint stays for edge cases.

**Data capture:** official-export diary log dates preserved next to watch dates; list updated timestamps stored; review comment counts as an opt-in scrape pass (`SPYBOXD_SCRAPE_REVIEW_COMMENTS=1`, one CSI request per review, heading count authoritative, blanks preserve prior values); review tags union into film-level tags (fixes the export-after-HTML narrowing found in review).

**UI:** tags get their first display (Analysis: profile tag cloud + per-entry chips) and the follow graph gets a real **network visualization** on Compare (circular layout, mutual = emerald, one-way = arrowed, hover/selection focus).

## Verification
- 291 backend tests pass; frontend `tsc` + `next build` green
- Live: fresh scrape captured person id `26275117` for a badge-less, bio-less profile and stored it through ingestion
- Migration applied + downgrade path complete

Still blocked on a real official export ZIP (waiting on one): `likes/reviews.csv`, `likes/lists.csv`, `comments.csv` tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)