### PR TITLE
Persist export-only member surfaces (liked reviews/lists, comments, pronoun) against the real export contract

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -140,6 +140,15 @@ sync sets `removed_at`; a re-follow resurrects the row. The first social sync
 for a profile is a baseline and emits no change events; later authoritative
 diffs emit `follow` entity-type rows in `profile_data_changes`.
 
+### `member_content_likes` and `member_comments`
+
+Export-only member activity. Official account exports enumerate likes the
+member placed on other members' reviews and lists (`likes/reviews.csv`,
+`likes/lists.csv`: like date + boxd.it URL) and the member's own comments
+(`comments.csv`: date, target URL, comment HTML). Rows are URL-keyed (comments
+by a URL/date/text digest) with the usual lineage and soft-removal semantics;
+scraper bundles never carry these files, so they always preserve prior state.
+
 ### `movie_enrichments` and `movie_watch_providers`
 
 Optional TMDB cache. `movie_enrichments` stores details such as overview, runtime, release date, language, genres, keywords, credits, countries, and expiry. `movie_watch_providers` stores region/provider/type rows separately so regional availability can expire independently.

--- a/alembic/versions/20260801_0012_add_export_surfaces.py
+++ b/alembic/versions/20260801_0012_add_export_surfaces.py
@@ -1,0 +1,108 @@
+"""Add the export-only member surfaces.
+
+Official account exports (the only source) carry three surfaces the runtime
+previously read and dropped: likes/reviews.csv and likes/lists.csv (like date
+plus the boxd.it URL of the liked content) and comments.csv (date, target URL,
+comment HTML). profiles.pronoun comes from the export's profile.csv.
+
+Revision ID: 20260801_0012
+Revises: 20260731_0011
+Create Date: 2026-08-01 00:30:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260801_0012"
+down_revision: Union[str, None] = "20260731_0011"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("profiles", sa.Column("pronoun", sa.String(length=50), nullable=True))
+    op.create_table(
+        "member_content_likes",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "profile_id",
+            sa.Integer(),
+            sa.ForeignKey("profiles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("content_type", sa.String(length=10), nullable=False),
+        sa.Column("target_url", sa.String(length=500), nullable=False),
+        sa.Column("liked_date", sa.Date(), nullable=True),
+        sa.Column(
+            "first_seen_profile_sync_id",
+            sa.BigInteger(),
+            sa.ForeignKey("profile_syncs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "last_seen_profile_sync_id",
+            sa.BigInteger(),
+            sa.ForeignKey("profile_syncs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint(
+            "profile_id", "content_type", "target_url", name="unique_member_content_like"
+        ),
+        sa.CheckConstraint(
+            "content_type IN ('review', 'list')", name="ck_member_content_likes_type"
+        ),
+    )
+    op.create_index(
+        "ix_member_content_likes_profile_removed",
+        "member_content_likes",
+        ["profile_id", "removed_at"],
+    )
+    op.create_table(
+        "member_comments",
+        sa.Column("id", sa.BigInteger(), sa.Identity(), primary_key=True),
+        sa.Column(
+            "profile_id",
+            sa.Integer(),
+            sa.ForeignKey("profiles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("comment_key", sa.String(length=600), nullable=False),
+        sa.Column("target_url", sa.String(length=500), nullable=False),
+        sa.Column("comment_html", sa.Text(), nullable=True),
+        sa.Column("commented_date", sa.Date(), nullable=True),
+        sa.Column(
+            "first_seen_profile_sync_id",
+            sa.BigInteger(),
+            sa.ForeignKey("profile_syncs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "last_seen_profile_sync_id",
+            sa.BigInteger(),
+            sa.ForeignKey("profile_syncs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("profile_id", "comment_key", name="unique_member_comment"),
+    )
+    op.create_index(
+        "ix_member_comments_profile_removed",
+        "member_comments",
+        ["profile_id", "removed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_member_comments_profile_removed", table_name="member_comments")
+    op.drop_table("member_comments")
+    op.drop_index("ix_member_content_likes_profile_removed", table_name="member_content_likes")
+    op.drop_table("member_content_likes")
+    op.drop_column("profiles", "pronoun")

--- a/backend/database/migrate.py
+++ b/backend/database/migrate.py
@@ -29,6 +29,8 @@ TABLE_COPY_ORDER = [
     "movie_list_items",
     "profile_favorite_movies",
     "profile_follow_edges",
+    "member_content_likes",
+    "member_comments",
     "profile_source_activities",
     "profile_data_changes",
     "movie_enrichments",

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -75,6 +75,7 @@ class Profile(Base):
     # profile and renamed in place instead of duplicated.
     letterboxd_person_id = Column(BigInteger, nullable=True)
     member_badge = Column(String(20), nullable=True)  # 'Patron' | 'Pro' | 'Crew'
+    pronoun = Column(String(50), nullable=True)  # official-export profile.csv only
     metadata_synced_at = Column(DateTime(timezone=True), nullable=True)
     last_profile_sync_id = Column(
         BigInteger,
@@ -140,6 +141,16 @@ class Profile(Base):
         back_populates="profile",
         cascade="all, delete-orphan",
         foreign_keys="ProfileFollowEdge.profile_id",
+    )
+    content_likes = relationship(
+        "MemberContentLike",
+        back_populates="profile",
+        cascade="all, delete-orphan",
+    )
+    member_comments = relationship(
+        "MemberComment",
+        back_populates="profile",
+        cascade="all, delete-orphan",
     )
 
     __table_args__ = (
@@ -1056,6 +1067,80 @@ class ProfileFollowEdge(Base):
             postgresql_where=sql_text("removed_at IS NULL"),
         ),
         Index("ix_profile_follow_edges_counterpart_profile", "counterpart_profile_id"),
+    )
+
+
+class MemberContentLike(Base):
+    """A like the profile's owner placed on another member's review or list.
+
+    Official account exports are the only source: likes/reviews.csv and
+    likes/lists.csv carry just the like date and the boxd.it short URL of the
+    liked content, so rows are URL-keyed with no film or author linkage.
+    """
+
+    __tablename__ = "member_content_likes"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    profile_id = Column(Integer, ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False)
+    content_type = Column(String(10), nullable=False)  # 'review' | 'list'
+    target_url = Column(String(500), nullable=False)
+    liked_date = Column(Date, nullable=True)
+    first_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    last_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    removed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    profile = relationship("Profile", back_populates="content_likes")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "profile_id", "content_type", "target_url",
+            name="unique_member_content_like",
+        ),
+        CheckConstraint(
+            "content_type IN ('review', 'list')",
+            name="ck_member_content_likes_type",
+        ),
+        Index("ix_member_content_likes_profile_removed", "profile_id", "removed_at"),
+    )
+
+
+class MemberComment(Base):
+    """A comment the profile's owner wrote on Letterboxd (export-only).
+
+    comments.csv carries the date, the boxd.it URL of the commented content,
+    and the comment HTML. The same member can comment repeatedly on one
+    thread, so identity is a digest over (url, date, text).
+    """
+
+    __tablename__ = "member_comments"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    profile_id = Column(Integer, ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False)
+    comment_key = Column(String(600), nullable=False)
+    target_url = Column(String(500), nullable=False)
+    comment_html = Column(Text, nullable=True)
+    commented_date = Column(Date, nullable=True)
+    first_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    last_seen_profile_sync_id = Column(
+        BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
+    )
+    removed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    profile = relationship("Profile", back_populates="member_comments")
+
+    __table_args__ = (
+        UniqueConstraint("profile_id", "comment_key", name="unique_member_comment"),
+        Index("ix_member_comments_profile_removed", "profile_id", "removed_at"),
     )
 
 

--- a/backend/services/ingestion.py
+++ b/backend/services/ingestion.py
@@ -11,6 +11,8 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from database.models import (
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -901,6 +903,129 @@ def _upsert_follow_edges(
     return len(seen)
 
 
+def _upsert_member_content_likes(
+    *,
+    analyzer_profile,
+    profile_id: int,
+    sync: ProfileSync,
+    content_type: str,
+    frame_name: str,
+    authoritative: bool,
+    db: Session,
+) -> int:
+    """Reconcile the export-only liked-reviews/liked-lists surfaces.
+
+    Rows are (Date, Content) where Content is the boxd.it URL of the liked
+    item. URL-keyed snapshot semantics mirror the watchlist: authoritative
+    files soft-remove unliked rows, absent files preserve prior state.
+    """
+    existing = {
+        like.target_url: like
+        for like in (
+            db.query(MemberContentLike)
+            .filter(
+                MemberContentLike.profile_id == profile_id,
+                MemberContentLike.content_type == content_type,
+            )
+            .all()
+        )
+    }
+    seen = set()
+    for row in frame_records(getattr(analyzer_profile, frame_name, pd.DataFrame())):
+        target_url = clean_text(first_value(row, ("Content", "URL", "Link")), max_length=500)
+        if not target_url or target_url in seen:
+            continue
+        seen.add(target_url)
+        like = existing.get(target_url)
+        if like is None:
+            like = MemberContentLike(
+                profile_id=profile_id,
+                content_type=content_type,
+                target_url=target_url,
+                first_seen_profile_sync_id=sync.id,
+            )
+            db.add(like)
+            existing[target_url] = like
+        liked_date = parse_date(first_value(row, ("Date",)))
+        if liked_date is not None:
+            like.liked_date = liked_date
+        like.last_seen_profile_sync_id = sync.id
+        like.removed_at = None
+
+    if authoritative:
+        now = _utcnow()
+        for target_url, like in existing.items():
+            if target_url not in seen and like.removed_at is None:
+                like.removed_at = now
+    db.flush()
+    return len(seen)
+
+
+def _upsert_member_comments(
+    *,
+    analyzer_profile,
+    profile_id: int,
+    sync: ProfileSync,
+    authoritative: bool,
+    db: Session,
+) -> int:
+    """Persist the member's own comments from the export's comments.csv.
+
+    A member can comment repeatedly on one thread, so identity is a digest
+    over (target URL, date, comment text).
+    """
+    existing = {
+        comment.comment_key: comment
+        for comment in (
+            db.query(MemberComment)
+            .filter(MemberComment.profile_id == profile_id)
+            .all()
+        )
+    }
+    seen = set()
+    for row in frame_records(getattr(analyzer_profile, "comments", pd.DataFrame())):
+        target_url = clean_text(first_value(row, ("Content", "URL", "Link")), max_length=500)
+        comment_html = clean_text(first_value(row, ("Comment", "Comment Text")))
+        commented_date = parse_date(first_value(row, ("Date",)))
+        if not target_url and not comment_html:
+            continue
+        digest = hashlib.sha256(
+            "|".join(
+                (
+                    target_url or "",
+                    commented_date.isoformat() if commented_date else "",
+                    comment_html or "",
+                )
+            ).encode("utf-8")
+        ).hexdigest()
+        comment_key = f"comment:{digest}"
+        if comment_key in seen:
+            continue
+        seen.add(comment_key)
+        comment = existing.get(comment_key)
+        if comment is None:
+            comment = MemberComment(
+                profile_id=profile_id,
+                comment_key=comment_key,
+                target_url=target_url or "",
+                first_seen_profile_sync_id=sync.id,
+            )
+            db.add(comment)
+            existing[comment_key] = comment
+        comment.comment_html = comment_html
+        comment.commented_date = commented_date
+        comment.last_seen_profile_sync_id = sync.id
+        comment.removed_at = None
+
+    if authoritative:
+        now = _utcnow()
+        for comment_key, comment in existing.items():
+            if comment_key not in seen and comment.removed_at is None:
+                comment.removed_at = now
+    db.flush()
+    return len(seen)
+
+
 def _upsert_source_activities(
     *,
     analyzer_profile,
@@ -1277,6 +1402,11 @@ def _update_profile_metadata(profile: Profile, analyzer_profile, sync: ProfileSy
     badge_value = clean_text(first_value(info, ("Badge",)), max_length=20)
     if badge_value is not None:
         profile.member_badge = badge_value
+
+    # Pronouns only exist in official-export profile.csv.
+    pronoun_value = clean_text(first_value(info, ("Pronoun", "Pronouns")), max_length=50)
+    if pronoun_value is not None:
+        profile.pronoun = pronoun_value
     profile.metadata_synced_at = now
 
 
@@ -1296,6 +1426,8 @@ def _dataset_file_names(analyzer_profile, dataset_name: str) -> List[str]:
         "favorites": ["favorites.csv"],
         "following": ["following.csv"],
         "followers": ["followers.csv"],
+        "liked_reviews": ["likes/reviews.csv"],
+        "liked_lists": ["likes/lists.csv"],
     }
     if dataset_name == "list_items":
         return sorted(
@@ -1340,6 +1472,8 @@ def _upsert_sync_datasets(
         "favorites",
         "following",
         "followers",
+        "liked_reviews",
+        "liked_lists",
     ):
         filenames = _dataset_file_names(analyzer_profile, dataset_name)
         infos = [source_files[name] for name in filenames]
@@ -1734,6 +1868,35 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
             db=db,
         )
 
+        liked_reviews_authoritative = _source_present(analyzer_profile, "likes/reviews.csv")
+        liked_lists_authoritative = _source_present(analyzer_profile, "likes/lists.csv")
+        comments_authoritative = _source_present(analyzer_profile, "comments.csv")
+        liked_reviews_count = _upsert_member_content_likes(
+            analyzer_profile=analyzer_profile,
+            profile_id=profile_id,
+            sync=sync,
+            content_type="review",
+            frame_name="liked_reviews",
+            authoritative=liked_reviews_authoritative,
+            db=db,
+        )
+        liked_lists_count = _upsert_member_content_likes(
+            analyzer_profile=analyzer_profile,
+            profile_id=profile_id,
+            sync=sync,
+            content_type="list",
+            frame_name="liked_lists",
+            authoritative=liked_lists_authoritative,
+            db=db,
+        )
+        comment_count = _upsert_member_comments(
+            analyzer_profile=analyzer_profile,
+            profile_id=profile_id,
+            sync=sync,
+            authoritative=comments_authoritative,
+            db=db,
+        )
+
         authoritative = {
             "profile": _source_present(analyzer_profile, "profile.csv"),
             "films": films_authoritative,
@@ -1743,7 +1906,9 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
             "reviews": _source_present(analyzer_profile, "reviews.csv"),
             "likes": _source_present(analyzer_profile, "likes.csv", "likes/films.csv"),
             "watchlist": watchlist_authoritative,
-            "comments": _source_present(analyzer_profile, "comments.csv"),
+            "comments": comments_authoritative,
+            "liked_reviews": liked_reviews_authoritative,
+            "liked_lists": liked_lists_authoritative,
             "lists": list_metadata_authoritative,
             "list_items": list_items_authoritative,
             "favorites": favorites_authoritative,
@@ -1759,7 +1924,9 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
             "reviews": review_count,
             "likes": len(getattr(analyzer_profile, "likes", pd.DataFrame())),
             "watchlist": watchlist_count,
-            "comments": 0,
+            "comments": comment_count,
+            "liked_reviews": liked_reviews_count,
+            "liked_lists": liked_lists_count,
             "lists": list_count,
             "list_items": list_item_count,
             "favorites": favorite_count,

--- a/backend/services/profile_loader.py
+++ b/backend/services/profile_loader.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import csv
+import io
 import math
 import json
 from pathlib import Path
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
@@ -54,6 +56,8 @@ class LoadedProfileData:
     all_films: pd.DataFrame
     following: pd.DataFrame
     followers: pd.DataFrame
+    liked_reviews: pd.DataFrame
+    liked_lists: pd.DataFrame
     avg_rating: float
     total_reviews: int
     join_date: Optional[date]
@@ -93,6 +97,51 @@ def _file_info(path: Path, row_count: int) -> Dict[str, Any]:
         "sha256": file_sha256(path),
         "row_count": max(int(row_count), 0),
     }
+
+
+def _read_official_list_export(path: Path) -> Optional[Tuple[Dict[str, Any], pd.DataFrame]]:
+    """Split an official "Letterboxd list export v7" file, or None if plain.
+
+    Official per-list files carry a preamble: a version line, a one-row
+    metadata block (Date,Name,Tags,URL,Description), a blank line, then the
+    item rows (Position,Name,Year,URL,Description — Description is the item
+    note). Plain CSV list files (the scraper's flat format) pass through.
+    """
+    try:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            first_line = handle.readline()
+            if not first_line.casefold().startswith("letterboxd list export"):
+                return None
+            reader = csv.reader(handle)
+            metadata_rows: List[List[str]] = []
+            for row in reader:
+                if not any(cell.strip() for cell in row):
+                    break
+                metadata_rows.append(row)
+            remainder = handle.read()
+    except OSError as exc:
+        raise ValueError(f"Failed to read official list file {path.name}: {exc}") from exc
+
+    metadata: Dict[str, Any] = {}
+    if len(metadata_rows) >= 2:
+        header, values = metadata_rows[0], metadata_rows[1]
+        raw = {
+            header[index].strip(): values[index] if index < len(values) else ""
+            for index in range(len(header))
+        }
+        metadata = {
+            "Title": raw.get("Name", ""),
+            "Description": raw.get("Description", ""),
+            "URL": raw.get("URL", ""),
+            "Published Date": raw.get("Date", ""),
+            "Tags": raw.get("Tags", ""),
+        }
+    items = (
+        pd.read_csv(io.StringIO(remainder))
+        if remainder.strip()
+        else pd.DataFrame(columns=["Position", "Name", "Year", "URL", "Description"])
+    )
+    return metadata, items
 
 
 def _detect_source_kind(source_files: Dict[str, Dict[str, Any]]) -> str:
@@ -173,6 +222,21 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
             source_name="likes/films.csv",
         )
 
+    # Official exports also enumerate likes the member placed on other
+    # members' reviews and lists (Date + boxd.it URL rows).
+    liked_reviews = pd.DataFrame()
+    liked_lists = pd.DataFrame()
+    liked_reviews_path = resolved_profile_path / "likes" / "reviews.csv"
+    if liked_reviews_path.exists():
+        liked_reviews = read_source(
+            liked_reviews_path, "likes/reviews.csv", source_name="likes/reviews.csv"
+        )
+    liked_lists_path = resolved_profile_path / "likes" / "lists.csv"
+    if liked_lists_path.exists():
+        liked_lists = read_source(
+            liked_lists_path, "likes/lists.csv", source_name="likes/lists.csv"
+        )
+
     all_films = pd.DataFrame()
     for candidate in ["films.csv", "all_films.csv", "films_comprehensive.csv"]:
         candidate_path = resolved_profile_path / candidate
@@ -196,10 +260,26 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
             if not entry_path.is_file() or entry_path.suffix.casefold() != ".csv":
                 continue
             relative_name = f"lists/{entry_path.name}"
-            list_df = read_source(entry_path, relative_name, source_name=relative_name)
-            list_df["list_name"] = entry_path.stem
+            official = _read_official_list_export(entry_path)
+            if official is not None:
+                metadata_row, list_df = official
+                info = _file_info(entry_path, len(list_df))
+                info["name"] = relative_name
+                info["relative_path"] = relative_name
+                source_files[relative_name] = info
+                list_name = metadata_row.get("Title") or entry_path.stem
+                metadata_frame = pd.DataFrame([metadata_row])
+                list_metadata = (
+                    pd.concat([list_metadata, metadata_frame], ignore_index=True)
+                    if not list_metadata.empty
+                    else metadata_frame
+                )
+            else:
+                list_df = read_source(entry_path, relative_name, source_name=relative_name)
+                list_name = entry_path.stem
+            list_df["list_name"] = list_name
             list_df["source_filename"] = relative_name
-            list_df.attrs["list_name"] = entry_path.stem
+            list_df.attrs["list_name"] = list_name
             list_df.attrs["source_filename"] = relative_name
             lists.append(list_df)
 
@@ -279,6 +359,8 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
         all_films=all_films,
         following=loaded.get("following", pd.DataFrame()),
         followers=loaded.get("followers", pd.DataFrame()),
+        liked_reviews=liked_reviews,
+        liked_lists=liked_lists,
         avg_rating=avg_rating,
         total_reviews=len(reviews),
         join_date=_parse_join_date(profile_info),

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260731_0011"
+HEAD_REVISION = "20260801_0012"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260731_0010"
+            script.get_revision(HEAD_REVISION).down_revision, "20260731_0011"
+        )
+        self.assertEqual(
+            script.get_revision("20260731_0011").down_revision, "20260731_0010"
         )
         self.assertEqual(
             script.get_revision("20260731_0010").down_revision, "20260730_0009"
@@ -148,6 +151,8 @@ class AdditiveMigrationContractTests(unittest.TestCase):
             "movie_list_items",
             "profile_favorite_movies",
             "profile_follow_edges",
+            "member_content_likes",
+            "member_comments",
             "profile_data_changes",
             "profile_source_activities",
             "movie_enrichments",
@@ -169,6 +174,21 @@ class AdditiveMigrationContractTests(unittest.TestCase):
                 "letterboxd_person_id",
                 "member_badge",
                 "reported_watchlist_count",
+            },
+            "member_content_likes": {
+                "profile_id",
+                "content_type",
+                "target_url",
+                "liked_date",
+                "removed_at",
+            },
+            "member_comments": {
+                "profile_id",
+                "comment_key",
+                "target_url",
+                "comment_html",
+                "commented_date",
+                "removed_at",
             },
             "profile_follow_edges": {
                 "profile_id",
@@ -278,6 +298,8 @@ class AdditiveMigrationContractTests(unittest.TestCase):
             "watchlist_items": {"unique_profile_watchlist_movie"},
             "movie_list_items": {"unique_movie_list_item"},
             "profile_follow_edges": {"unique_profile_follow_edge"},
+            "member_content_likes": {"unique_member_content_like"},
+            "member_comments": {"unique_member_comment"},
             "profile_data_changes": {"unique_profile_sync_change_key"},
             "profile_source_activities": {"unique_profile_source_activity"},
             "user_tracked_profiles": {"uq_user_tracked_profile"},

--- a/backend/tests/test_export_surfaces.py
+++ b/backend/tests/test_export_surfaces.py
@@ -1,0 +1,197 @@
+"""Export-only member surfaces: liked reviews/lists, comments, pronoun, preamble lists."""
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+
+from backend.database.models import (
+    MemberComment,
+    MemberContentLike,
+    Movie,
+    MovieList,
+    MovieListItem,
+    Profile,
+    ProfileDataChange,
+    ProfileFavoriteMovie,
+    ProfileFeedState,
+    ProfileFilm,
+    ProfileFollowEdge,
+    ProfileSourceActivity,
+    ProfileSync,
+    Rating,
+    Review,
+    SyncDataset,
+    WatchEvent,
+    WatchlistItem,
+)
+from backend.services.ingestion import unified_data_loader
+from backend.services.profile_loader import load_profile_data
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    ProfileSync.__table__,
+    ProfileFeedState.__table__,
+    SyncDataset.__table__,
+    Movie.__table__,
+    Rating.__table__,
+    ProfileFilm.__table__,
+    ProfileFollowEdge.__table__,
+    MemberComment.__table__,
+    MemberContentLike.__table__,
+    WatchEvent.__table__,
+    Review.__table__,
+    WatchlistItem.__table__,
+    MovieList.__table__,
+    MovieListItem.__table__,
+    ProfileFavoriteMovie.__table__,
+    ProfileDataChange.__table__,
+    ProfileSourceActivity.__table__,
+)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+OFFICIAL_LIST_FILE = """Letterboxd list export v7
+Date,Name,Tags,URL,Description
+2026-07-17,"2024, Ranked","yearly, ranked",https://boxd.it/VKn8e,Ranked releases.
+
+Position,Name,Year,URL,Description
+1,The Wild Robot,2024,https://boxd.it/IWFy,Loved it
+2,Dune: Part Two,2024,https://boxd.it/pUfA,
+"""
+
+
+def _write_export(root: Path, *, with_member_surfaces: bool = True) -> None:
+    """A minimal official export mirroring the real 2026 file shapes."""
+    root.mkdir()
+    pd.DataFrame([{
+        "Date Joined": "2023-08-21", "Username": "Viewer",
+        "Location": "", "Website": "", "Bio": "", "Pronoun": "He / his",
+    }]).to_csv(root / "profile.csv", index=False)
+    pd.DataFrame([{
+        "Date": "2023-10-15", "Name": "Lost in Translation", "Year": 2003,
+        "Letterboxd URI": "https://boxd.it/4ZVRqB", "Rating": 2.5,
+        "Rewatch": "", "Tags": "", "Watched Date": "2023-08-15",
+    }]).to_csv(root / "diary.csv", index=False)
+    pd.DataFrame([{
+        "Date": "2023-08-15", "Name": "Lost in Translation", "Year": 2003,
+        "Letterboxd URI": "https://boxd.it/4ZVRqB",
+    }]).to_csv(root / "watched.csv", index=False)
+    (root / "lists").mkdir()
+    (root / "lists" / "2024-ranked.csv").write_text(OFFICIAL_LIST_FILE, encoding="utf-8")
+    if with_member_surfaces:
+        likes = root / "likes"
+        likes.mkdir()
+        pd.DataFrame([
+            {"Date": "2023-10-30", "Content": "https://boxd.it/54qQSR"},
+        ]).to_csv(likes / "reviews.csv", index=False)
+        pd.DataFrame([
+            {"Date": "2023-12-15", "Content": "https://boxd.it/qo626"},
+            {"Date": "2024-01-02", "Content": "https://boxd.it/other1"},
+        ]).to_csv(likes / "lists.csv", index=False)
+        pd.DataFrame([
+            {"Date": "2024-02-25", "Content": "https://boxd.it/5UiziT",
+             "Comment": "One of the interpretations…"},
+        ]).to_csv(root / "comments.csv", index=False)
+
+
+def _import(tmp_path: Path, name: str, db: Session, **kwargs) -> Profile:
+    root = tmp_path / name
+    _write_export(root, **kwargs)
+    loaded = load_profile_data(str(root), "viewer")
+    profile = db.query(Profile).filter(Profile.username == "viewer").one_or_none()
+    if profile is None:
+        profile = Profile(username="viewer", scraping_status="pending")
+        db.add(profile)
+        db.commit()
+    unified_data_loader(loaded, profile.id, db)
+    db.commit()
+    db.expire_all()
+    return profile
+
+
+def test_export_member_surfaces_flow_into_models(tmp_path: Path, database: Session) -> None:
+    profile = _import(tmp_path, "export", database)
+
+    likes = database.query(MemberContentLike).filter(
+        MemberContentLike.removed_at.is_(None)
+    ).all()
+    assert {(like.content_type, like.target_url) for like in likes} == {
+        ("review", "https://boxd.it/54qQSR"),
+        ("list", "https://boxd.it/qo626"),
+        ("list", "https://boxd.it/other1"),
+    }
+    assert all(like.liked_date is not None for like in likes)
+
+    comment = database.query(MemberComment).one()
+    assert comment.target_url == "https://boxd.it/5UiziT"
+    assert comment.commented_date == date(2024, 2, 25)
+
+    database.refresh(profile)
+    assert profile.pronoun == "He / his"
+
+    # The official v7 preamble supplies list metadata; Description on item rows is the note.
+    movie_list = database.query(MovieList).one()
+    assert movie_list.name == "2024, Ranked"
+    assert movie_list.published_date == date(2026, 7, 17)
+    assert sorted(movie_list.tags) == ["ranked", "yearly"]
+    items = database.query(MovieListItem).order_by(MovieListItem.position).all()
+    assert [item.notes for item in items] == ["Loved it", None]
+
+    # Export diary rows carry both dates.
+    event = database.query(WatchEvent).filter(WatchEvent.superseded_at.is_(None)).one()
+    assert event.watched_date == date(2023, 8, 15)
+    assert event.logged_date == date(2023, 10, 15)
+
+
+def test_export_resync_removes_unliked_and_preserves_without_files(tmp_path: Path, database: Session) -> None:
+    _import(tmp_path, "first", database)
+
+    # Second export: one list-like gone -> soft removed.
+    root = tmp_path / "second"
+    _write_export(root, with_member_surfaces=True)
+    likes_frame = pd.DataFrame([{"Date": "2023-12-15", "Content": "https://boxd.it/qo626"}])
+    likes_frame.to_csv(root / "likes" / "lists.csv", index=False)
+    loaded = load_profile_data(str(root), "viewer")
+    profile = database.query(Profile).filter(Profile.username == "viewer").one()
+    unified_data_loader(loaded, profile.id, database)
+    database.commit()
+    database.expire_all()
+
+    removed = database.query(MemberContentLike).filter(
+        MemberContentLike.target_url == "https://boxd.it/other1"
+    ).one()
+    assert removed.removed_at is not None
+
+    # A scraper bundle (no member-surface files) preserves everything.
+    _import(tmp_path, "no_surfaces", database, with_member_surfaces=False)
+    active = database.query(MemberContentLike).filter(
+        MemberContentLike.removed_at.is_(None)
+    ).count()
+    assert active == 2
+    assert database.query(MemberComment).filter(
+        MemberComment.removed_at.is_(None)
+    ).count() == 1

--- a/backend/tests/test_follow_edges_ingestion.py
+++ b/backend/tests/test_follow_edges_ingestion.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from backend.database.models import (
     Movie,
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -49,6 +51,8 @@ TABLES = (
     WatchEvent.__table__,
     Review.__table__,
     WatchlistItem.__table__,
+    MemberComment.__table__,
+    MemberContentLike.__table__,
     MovieList.__table__,
     MovieListItem.__table__,
     ProfileFavoriteMovie.__table__,

--- a/backend/tests/test_full_sync_incremental.py
+++ b/backend/tests/test_full_sync_incremental.py
@@ -12,6 +12,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from backend.database.models import (
     Movie,
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -51,6 +53,8 @@ TABLES = (
     WatchEvent.__table__,
     Review.__table__,
     WatchlistItem.__table__,
+    MemberComment.__table__,
+    MemberContentLike.__table__,
     MovieList.__table__,
     MovieListItem.__table__,
     ProfileFavoriteMovie.__table__,

--- a/backend/tests/test_profile_data_clear.py
+++ b/backend/tests/test_profile_data_clear.py
@@ -10,6 +10,8 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.database.models import (
     Movie,
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -45,6 +47,8 @@ class ProfileDataClearTests(TestCase):
             ProfileFollowEdge.__table__,
             WatchEvent.__table__,
             WatchlistItem.__table__,
+            MemberComment.__table__,
+            MemberContentLike.__table__,
             MovieList.__table__,
             MovieListItem.__table__,
             ProfileFavoriteMovie.__table__,

--- a/backend/tests/test_rss_incremental.py
+++ b/backend/tests/test_rss_incremental.py
@@ -10,6 +10,8 @@ from sqlalchemy.orm import sessionmaker
 
 from backend.database.models import (
     Movie,
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -159,6 +161,8 @@ def database():
         WatchEvent.__table__,
         Review.__table__,
         WatchlistItem.__table__,
+        MemberComment.__table__,
+        MemberContentLike.__table__,
         MovieList.__table__,
         MovieListItem.__table__,
         ProfileFavoriteMovie.__table__,

--- a/backend/tests/test_scraped_tags_flow.py
+++ b/backend/tests/test_scraped_tags_flow.py
@@ -16,6 +16,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from backend.database.models import (
     Movie,
+    MemberComment,
+    MemberContentLike,
     MovieList,
     MovieListItem,
     Profile,
@@ -53,6 +55,8 @@ TABLES = (
     WatchEvent.__table__,
     Review.__table__,
     WatchlistItem.__table__,
+    MemberComment.__table__,
+    MemberContentLike.__table__,
     MovieList.__table__,
     MovieListItem.__table__,
     ProfileFavoriteMovie.__table__,

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -868,6 +868,18 @@ const ProfileManager: React.FC = () => {
             </div>
 
             <div className="rounded-xl border border-white/10 bg-black/15 p-3">
+              <p className="mb-3 text-xs leading-5 text-white/45">
+                Get the ZIP from{' '}
+                <a
+                  href="https://letterboxd.com/user/exportdata/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold text-cinema-300 underline-offset-2 hover:text-cinema-200 hover:underline"
+                >
+                  Letterboxd&nbsp;→&nbsp;Export your data
+                </a>
+                . Exports include surfaces public pages never show: liked reviews and lists, your comments, pronouns, and diary log dates.
+              </p>
               <label className="block">
                 <span className="mb-2 block text-xs font-semibold text-white/55">Official export ZIP</span>
                 <input


### PR DESCRIPTION
The last Letterboxd data points, built against a **real official export** (provided by the account owner) instead of guessed columns.

- **`member_content_likes`** — likes placed on other members' reviews/lists (`Date,Content` boxd.it rows); URL-keyed snapshot semantics with soft removal; scraper bundles (which never carry these files) preserve prior state
- **`member_comments`** — the member's own comments with date/target/HTML; digest identity for repeat comments on one thread; the `comments` dataset count is now real (was hardcoded 0)
- **`profiles.pronoun`** — export `profile.csv` carries it
- **Official list preamble parsing** — the `Letterboxd list export v7` metadata block now feeds list name/description/published date/tags, and item `Description` flows as the note (previously mangled by plain CSV reads)
- Upload UI links `letterboxd.com/user/exportdata/` so owners can grab their export in one click

Alembic `20260801_0012`, additive with full downgrade.

## Verification
- 293 backend tests pass (2 new fixture tests modeled byte-for-byte on the real export shapes); frontend build + typecheck green
- End-to-end against the real export: 41 review likes, 5 list likes, 7 comments, pronoun, 489/489 diary log dates, preamble list metadata — all verified in the DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)