### PR TITLE
Give the follow network its own Network page

### DIFF
--- a/frontend/src/app/(app)/network/page.tsx
+++ b/frontend/src/app/(app)/network/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from 'react';
+
+import Network from '../../../views/Network';
+
+export default function NetworkPage() {
+  return (
+    <Suspense>
+      <Network />
+    </Suspense>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -19,7 +19,7 @@ import {
   SignalIcon as SignalIconSolid,
   ScaleIcon as ScaleIconSolid,
 } from '@heroicons/react/24/solid';
-import { LogOut, Menu, UsersRound, X } from 'lucide-react';
+import { LogOut, Menu, UsersRound, Waypoints, X } from 'lucide-react';
 import { useCurrentUser } from '../hooks/useCurrentUser';
 import AdminScopeToggle from './AdminScopeToggle';
 
@@ -55,6 +55,13 @@ const NAVIGATION_ITEMS = [
     icon: UsersRound,
     activeIcon: UsersRound,
     description: 'Find a Group Pick',
+  },
+  {
+    path: '/network',
+    label: 'Network',
+    icon: Waypoints,
+    activeIcon: Waypoints,
+    description: 'The Follow Graph',
   },
   {
     path: '/profiles',

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -14,7 +14,6 @@ import {
 import TasteTimelinePanel from '../components/insights/TasteTimelinePanel';
 import { FeatureState, ProfileAvatar, WorkspaceTabs } from '../components/insights/InsightUI';
 import AdminScopeToggle from '../components/AdminScopeToggle';
-import FollowNetwork from '../components/FollowNetwork';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 import { useUrlProfileSelection } from '../hooks/useUrlProfileSelection';
 import {
@@ -326,8 +325,6 @@ export default function Compare() {
           <SignalCalendarPanel data={calendarQuery.data} coverage={fallbackCoverage} />
         )}
       </section>
-
-      <FollowNetwork profiles={completedProfiles} />
 
       <footer className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-white/10 py-3 text-[11px] text-white/35">
         <span className="flex items-center gap-1.5"><Scale className="h-3.5 w-3.5" /> Pair Dossier uses behavior and ratings.</span>

--- a/frontend/src/views/Network.tsx
+++ b/frontend/src/views/Network.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { Trophy, Waypoints } from 'lucide-react';
+
+import FollowNetwork from '../components/FollowNetwork';
+import { followGraphApi } from '../services/api';
+import { useScopedProfiles } from '../hooks/useScopedProfiles';
+
+export default function Network() {
+  const profilesQuery = useScopedProfiles();
+  const completedProfiles = useMemo(
+    () => (profilesQuery.data ?? []).filter((profile) => profile.scraping_status === 'completed'),
+    [profilesQuery.data],
+  );
+
+  // Shares the FollowNetwork component's query key, so the graph and the
+  // ranking render from one request.
+  const mutualsQuery = useQuery({
+    queryKey: ['follow-mutuals', 'network'],
+    queryFn: () => followGraphApi.getMutuals([]),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const ranking = useMemo(() => {
+    const rollups = mutualsQuery.data?.rollups ?? {};
+    return Object.entries(rollups)
+      .map(([username, rollup]) => ({
+        username,
+        follows: rollup.follows_in_group,
+        followedBy: rollup.followed_by_in_group,
+        total: rollup.follows_in_group + rollup.followed_by_in_group,
+      }))
+      .filter((entry) => entry.total > 0)
+      .sort((a, b) => b.total - a.total || a.username.localeCompare(b.username))
+      .slice(0, 8);
+  }, [mutualsQuery.data]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="space-y-6"
+    >
+      <header>
+        <h1 className="flex items-center gap-3 text-3xl font-bold text-white text-glow">
+          <Waypoints className="h-8 w-8 text-cinema-400" />
+          Network
+        </h1>
+        <p className="mt-1 text-sm text-white/55">
+          Who follows whom across the profiles you monitor
+        </p>
+      </header>
+
+      <FollowNetwork profiles={completedProfiles} />
+
+      {ranking.length > 0 && (
+        <section className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-white/75">
+            <Trophy className="h-4 w-4 text-cinema-400" />
+            Most connected
+          </h2>
+          <ol className="grid gap-2 sm:grid-cols-2">
+            {ranking.map((entry, index) => (
+              <li
+                key={entry.username}
+                className="flex items-center justify-between rounded-lg border border-white/5 bg-black/20 px-3 py-2 text-sm"
+              >
+                <span className="flex items-center gap-2 text-white/80">
+                  <span className="w-5 text-right text-xs text-white/35">{index + 1}.</span>
+                  @{entry.username}
+                </span>
+                <span className="text-xs text-white/45">
+                  follows {entry.follows} · followed by {entry.followedBy}
+                </span>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
Moves the follow-network graph off the bottom of Compare into a dedicated **/network** page (sidebar entry with the Waypoints icon), making room for the graph to grow features. Seeds the page with a "Most connected" ranking computed from the mutuals rollups — same query key as the graph, so both render from one request.

- New: `views/Network.tsx`, `app/(app)/network/page.tsx`, nav entry in `Layout.tsx`
- Compare drops the network section (its mutual-badge row for the selected pair stays)
- `tsc` + `next build` green, `/network` route generated; e2e nav interactions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)