### PR TITLE
Fix posters, film links, profile links, taste-alignment ranking, and timeline dates

### DIFF
--- a/alembic/versions/20260801_0014_repair_movie_urls_and_posters.py
+++ b/alembic/versions/20260801_0014_repair_movie_urls_and_posters.py
@@ -1,0 +1,78 @@
+"""Repair site-relative movie URLs and placeholder posters.
+
+Letterboxd's markup carries site-relative hrefs (``/film/<slug>/``) and lazy
+loads posters, so a scraped ``img src`` is their static empty-poster asset.
+Both were persisted verbatim: relative URLs rendered as in-app links, and the
+placeholder occupied ``poster_url``, which blocked TMDB enrichment from ever
+filling in real artwork (it only wrote when the column was empty).
+
+Existing rows are repaired here; the resolver now normalises URLs and rejects
+placeholder posters so new imports cannot reintroduce either. Clearing a
+placeholder lets the next enrichment pass populate the real poster, and rows
+that already hold a TMDB poster are left untouched.
+
+Revision ID: 20260801_0014
+Revises: 20260801_0013
+Create Date: 2026-08-01 02:20:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260801_0014"
+down_revision: Union[str, None] = "20260801_0013"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # A member can list several external links (personal site, Twitter, …);
+    # only one ever had a home.
+    op.add_column(
+        "profiles",
+        sa.Column("external_links", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    # Site-relative film links become absolute Letterboxd URLs.
+    op.execute(
+        sa.text(
+            """
+            UPDATE movies
+               SET letterboxd_url = 'https://letterboxd.com' || letterboxd_url
+             WHERE letterboxd_url LIKE '/%'
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE movies
+               SET poster_url = NULL
+             WHERE poster_url LIKE '%empty-poster%'
+            """
+        )
+    )
+    # Backfill from enrichment we already hold, so repaired rows show real
+    # artwork immediately instead of waiting for the next TMDB pass.
+    op.execute(
+        sa.text(
+            """
+            UPDATE movies
+               SET poster_url = 'https://image.tmdb.org/t/p/w500' || e.poster_path
+              FROM movie_enrichments AS e
+             WHERE e.movie_id = movies.id
+               AND movies.poster_url IS NULL
+               AND e.poster_path IS NOT NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("profiles", "external_links")
+    # The data repair itself is not reversible: the original values were
+    # malformed, and restoring them would reintroduce broken links and
+    # placeholder posters.

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -76,6 +76,9 @@ class Profile(Base):
     letterboxd_person_id = Column(BigInteger, nullable=True)
     member_badge = Column(String(20), nullable=True)  # 'Patron' | 'Pro' | 'Crew'
     pronoun = Column(String(50), nullable=True)  # official-export profile.csv only
+    # Every external link a member lists on their profile, as
+    # [{"label": ..., "url": ...}]; Letterboxd allows more than one.
+    external_links = Column(_json_type(), nullable=True)
     # Letterboxd's own /<user>/stats/ header figures. Hours watched and the
     # director/country/streak counts are not derivable from imported rows
     # (runtime and credits would need TMDB for every film), so the site's

--- a/backend/main.py
+++ b/backend/main.py
@@ -713,6 +713,23 @@ def _safe_external_url(value) -> Optional[str]:
     return f"https://{candidate}"
 
 
+def _profile_external_links(profile: Profile) -> List[dict]:
+    """The member's external profile links, each re-validated before serving."""
+    raw = profile.external_links if isinstance(profile.external_links, list) else []
+    links: List[dict] = []
+    seen = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        url = _safe_external_url(entry.get("url"))
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        label = str(entry.get("label") or "").strip()
+        links.append({"label": label or url, "url": url})
+    return links
+
+
 def _profile_favorite_films(db: Session, profile_id: int) -> List[dict]:
     """Letterboxd's four favourite films for a profile, in display order."""
     rows = (
@@ -761,6 +778,7 @@ def _profile_header_payload(
         "location": profile.location,
         "website": profile.website,
         "website_url": _safe_external_url(profile.website),
+        "external_links": _profile_external_links(profile),
         "pronoun": profile.pronoun,
         "member_badge": profile.member_badge,
         "avatar_url": profile.profile_image_url,

--- a/backend/scraper_html.py
+++ b/backend/scraper_html.py
@@ -374,6 +374,38 @@ class EnhancedLetterboxdScraper:
         return json.dumps(sorted(tags or []), ensure_ascii=False)
 
     @staticmethod
+    def _is_letterboxd_host(url: str) -> bool:
+        """Whether a URL points at Letterboxd itself.
+
+        Substring matching on the host is unsafe: it both accepts
+        ``letterboxd.com.example.net`` and rejects ``notletterboxd.com``. Only
+        the exact host or a real subdomain of it counts.
+        """
+        host = urlparse(url).netloc.casefold().rsplit('@', 1)[-1]
+        host = host.split(':', 1)[0].rstrip('.')
+        return host == 'letterboxd.com' or host.endswith('.letterboxd.com')
+
+    @classmethod
+    def _extract_external_links(cls, anchors) -> List[Dict]:
+        """The off-site links a member lists, deduplicated in source order."""
+        links: List[Dict] = []
+        seen_urls = set()
+        for anchor in anchors:
+            href = (anchor.get('href') or '').strip()
+            if not href.casefold().startswith(('http://', 'https://')):
+                continue
+            if cls._is_letterboxd_host(href):
+                continue
+            if href in seen_urls:
+                continue
+            seen_urls.add(href)
+            links.append({
+                'label': anchor.get_text(' ', strip=True) or urlparse(href).netloc,
+                'url': href,
+            })
+        return links
+
+    @staticmethod
     def _extract_person_rows(soup: BeautifulSoup) -> List[Dict]:
         """Parse a following/followers page into person identity dicts.
 
@@ -581,21 +613,7 @@ class EnhancedLetterboxdScraper:
                     if location_text and location_text not in anchor_texts:
                         self.profile_info.location = location_text
 
-                links = []
-                seen_urls = set()
-                for anchor in anchors:
-                    href = (anchor.get('href') or '').strip()
-                    if not href.casefold().startswith(('http://', 'https://')):
-                        continue
-                    if 'letterboxd.com' in urlparse(href).netloc.casefold():
-                        continue
-                    if href in seen_urls:
-                        continue
-                    seen_urls.add(href)
-                    links.append({
-                        'label': anchor.get_text(' ', strip=True) or urlparse(href).netloc,
-                        'url': href,
-                    })
+                links = self._extract_external_links(anchors)
                 self.profile_info.external_links = links
                 if links:
                     # Keep the single-website contract populated for existing

--- a/backend/scraper_html.py
+++ b/backend/scraper_html.py
@@ -57,11 +57,15 @@ class ProfileInfo:
     badge: str = ""
     watchlist_count: Optional[int] = None
     stats: Dict = None
+    # Every external link a member lists (personal site, Twitter, …).
+    external_links: List[Dict] = None
     favorite_films: List[Dict] = None
 
     def __post_init__(self):
         if self.favorite_films is None:
             self.favorite_films = []
+        if self.external_links is None:
+            self.external_links = []
         if self.stats is None:
             self.stats = {}
 
@@ -558,16 +562,45 @@ class EnhancedLetterboxdScraper:
             if bio_element:
                 self.profile_info.bio = bio_element.get_text().strip()
             
-            # Location and website
-            profile_metadata = soup.find('section', class_='profile-metadata')
+            # Location and the external links a member lists on their profile.
+            # Letterboxd allows several (a personal site, Twitter, and so on),
+            # each rendered as an anchor in the metadata block; the location is
+            # the one metadatum without a link.
+            profile_metadata = soup.select_one(
+                'section.profile-metadata, div.profile-metadata, .js-profile-metadata'
+            )
             if profile_metadata:
-                location = profile_metadata.find('span', class_='location')
-                if location:
-                    self.profile_info.location = location.get_text().strip()
-                
-                website = profile_metadata.find('a', class_='url')
-                if website:
-                    self.profile_info.website = website.get('href', '')
+                location = profile_metadata.select_one('span.location, .metadatum .label')
+                anchors = profile_metadata.select('a.metadatum[href], a.url[href]')
+                anchor_texts = {
+                    anchor.get_text(' ', strip=True) for anchor in anchors
+                }
+                if location is not None:
+                    location_text = location.get_text(' ', strip=True)
+                    # A label shared with an anchor is that link's caption.
+                    if location_text and location_text not in anchor_texts:
+                        self.profile_info.location = location_text
+
+                links = []
+                seen_urls = set()
+                for anchor in anchors:
+                    href = (anchor.get('href') or '').strip()
+                    if not href.casefold().startswith(('http://', 'https://')):
+                        continue
+                    if 'letterboxd.com' in urlparse(href).netloc.casefold():
+                        continue
+                    if href in seen_urls:
+                        continue
+                    seen_urls.add(href)
+                    links.append({
+                        'label': anchor.get_text(' ', strip=True) or urlparse(href).netloc,
+                        'url': href,
+                    })
+                self.profile_info.external_links = links
+                if links:
+                    # Keep the single-website contract populated for existing
+                    # consumers; the full set travels alongside it.
+                    self.profile_info.website = links[0]['url']
             
             # Avatar URL
             avatar = soup.select_one('.profile-avatar img, img.avatar, .avatar img')
@@ -1419,7 +1452,7 @@ class EnhancedLetterboxdScraper:
             'Username', 'Display_Name', 'Bio', 'Location', 'Website', 'Join_Date',
             'Avatar_URL', 'Total_Films', 'Total_Reviews', 'Total_Lists',
             'Following_Count', 'Followers_Count', 'Person_ID', 'Badge',
-            'Watchlist_Count', 'Stats'
+            'Watchlist_Count', 'Stats', 'External_Links'
         ]
         data = [{
             'Username': self.profile_info.username,
@@ -1438,6 +1471,11 @@ class EnhancedLetterboxdScraper:
             'Badge': self.profile_info.badge,
             'Watchlist_Count': self.profile_info.watchlist_count,
             'Stats': json.dumps(self.profile_info.stats, sort_keys=True) if self.profile_info.stats else '',
+            'External_Links': (
+                json.dumps(self.profile_info.external_links, sort_keys=True)
+                if self.profile_info.external_links
+                else ''
+            ),
         }]
         self._write_csv("profile.csv", data, fieldnames)
 

--- a/backend/services/ingestion.py
+++ b/backend/services/ingestion.py
@@ -1485,6 +1485,26 @@ def _update_profile_metadata(profile: Profile, analyzer_profile, sync: ProfileSy
     if pronoun_value is not None:
         profile.pronoun = pronoun_value
 
+    if any(name in info for name in ("External_Links", "External Links")):
+        raw_links = first_value(info, ("External_Links", "External Links"))
+        links = []
+        if raw_links:
+            try:
+                decoded = json.loads(raw_links) if isinstance(raw_links, str) else raw_links
+            except (TypeError, ValueError):
+                decoded = []
+            for entry in decoded if isinstance(decoded, list) else []:
+                if not isinstance(entry, dict):
+                    continue
+                url = clean_text(entry.get("url"), max_length=500)
+                if not url or not url.casefold().startswith(("http://", "https://")):
+                    continue
+                links.append({
+                    "label": clean_text(entry.get("label"), max_length=100) or url,
+                    "url": url,
+                })
+        profile.external_links = links
+
     # Letterboxd's own stats-page figures, when the scrape observed them.
     stats_value = clean_text(first_value(info, ("Stats",)))
     if stats_value:

--- a/backend/services/insights.py
+++ b/backend/services/insights.py
@@ -38,6 +38,10 @@ ALLOWED_TASTE_DIMENSIONS = {
     "runtime",
 }
 
+# One rated film makes a trait score a perfect 100; below this the number
+# says more about coverage than taste, so such traits rank last in alignment.
+MIN_ALIGNMENT_SAMPLE = 2
+
 LEGACY_EVENT_SOURCE_KINDS = {
     "legacy_backfill",
     "legacy_rating_backfill",
@@ -97,12 +101,25 @@ class EventRow:
     username: str
     movie_id: int
     watched_date: date
+    logged_date: Optional[date]
     rating: Optional[float]
     liked: bool
     rewatch: bool
     tags: List[str]
     source_kind: str
     movie: Movie
+
+    @property
+    def opinion_date(self) -> date:
+        """When the opinion was recorded, not when the film was seen.
+
+        Letterboxd lets a member backdate a diary entry to the day they
+        actually watched something, so a 2015 watch date can carry a rating
+        formed in 2024. Anything charting how taste changed belongs on the
+        log date; the watch date is the fallback, since only official account
+        exports carry log dates.
+        """
+        return self.logged_date or self.watched_date
 
 
 @dataclass(frozen=True)
@@ -643,6 +660,7 @@ class InsightsService:
                 username=profile.username,
                 movie_id=movie.id,
                 watched_date=event.watched_date,
+                logged_date=event.logged_date,
                 rating=_safe_float(event.rating),
                 liked=bool(event.is_liked),
                 rewatch=bool(event.is_rewatch),
@@ -1913,6 +1931,35 @@ class InsightsService:
             )
         return []
 
+    @staticmethod
+    def _alignment_sort_key(trait: Dict[str, Any], profile_count: int) -> Tuple:
+        """Order a dimension by how much the profiles actually agree.
+
+        Ranking by group score alone surfaces traits one profile rated
+        highly and the other never watched — maximum divergence, which the
+        contrasts panel already covers. Alignment needs both sides present,
+        both strong, and close together. A single five-star film also scores
+        a perfect 100, so traits below the credible sample floor rank last.
+        """
+        engaged = [entry for entry in trait["per_profile"] if entry["sample_size"] > 0]
+        shared = len(engaged) == profile_count
+        credible = shared and all(
+            entry["sample_size"] >= MIN_ALIGNMENT_SAMPLE for entry in engaged
+        )
+        scores = [entry["score"] for entry in engaged]
+        weakest = min(scores) if scores else 0.0
+        spread = (max(scores) - min(scores)) if len(scores) >= 2 else 0.0
+        # The weaker side carries the pair, and disagreement is penalised, so
+        # "both like this a lot" outranks "one adores it, one has never seen it".
+        alignment = weakest - (spread / 2)
+        return (
+            not credible,
+            not shared,
+            -alignment,
+            -trait["sample_size"],
+            trait["label"],
+        )
+
     def taste_dna(
         self,
         requested: Sequence[str],
@@ -1920,7 +1967,7 @@ class InsightsService:
         dimensions: Sequence[str],
         limit: int,
     ) -> Dict[str, Any]:
-        profiles = self._resolve_profiles(requested, minimum=2)
+        profiles = self._resolve_profiles(requested, minimum=1)
         invalid = sorted(set(dimensions) - ALLOWED_TASTE_DIMENSIONS)
         if invalid:
             raise InsightRequestError(
@@ -2008,7 +2055,7 @@ class InsightsService:
                     contrast_candidates.append((contrast, {**trait, "group_score": _round(contrast, 1) or 0}))
                 if len(present_profiles) >= 2:
                     signature_candidates.append(trait)
-            traits.sort(key=lambda trait: (-trait["group_score"], -trait["sample_size"], trait["label"]))
+            traits.sort(key=lambda trait: self._alignment_sort_key(trait, len(profiles)))
             dimension_payloads[dimension] = traits[:limit]
 
         signature_candidates.sort(
@@ -2165,7 +2212,7 @@ class InsightsService:
         trait_limit: int,
         year_limit: int,
     ) -> Dict[str, Any]:
-        profiles = self._resolve_profiles(requested, minimum=2)
+        profiles = self._resolve_profiles(requested, minimum=1)
         invalid = sorted(set(dimensions) - ALLOWED_TASTE_DIMENSIONS)
         if invalid:
             raise InsightRequestError(
@@ -2181,21 +2228,21 @@ class InsightsService:
         events = [
             event
             for event in all_events
-            if (from_year is None or event.watched_date.year >= from_year)
-            and (to_year is None or event.watched_date.year <= to_year)
+            if (from_year is None or event.opinion_date.year >= from_year)
+            and (to_year is None or event.opinion_date.year <= to_year)
         ]
 
-        available_years = sorted({event.watched_date.year for event in events})
+        available_years = sorted({event.opinion_date.year for event in events})
         returned_years = available_years[-year_limit:]
         returned_year_set = set(returned_years)
         returned_events = [
-            event for event in events if event.watched_date.year in returned_year_set
+            event for event in events if event.opinion_date.year in returned_year_set
         ]
         yearly_events: Dict[int, List[EventRow]] = defaultdict(list)
         seasonal_events: Dict[Tuple[int, str], List[EventRow]] = defaultdict(list)
         for event in returned_events:
-            yearly_events[event.watched_date.year].append(event)
-            seasonal_events[self._season_for_date(event.watched_date)].append(event)
+            yearly_events[event.opinion_date.year].append(event)
+            seasonal_events[self._season_for_date(event.opinion_date)].append(event)
 
         yearly = [
             self._taste_period_summary(
@@ -2303,6 +2350,20 @@ class InsightsService:
                 "dated_watch_events": len(all_events),
                 "total_known_watches": total_known_watches,
                 "undated_known_watches": undated_known_watches,
+                # Which date each point sits on. Log dates only exist in
+                # official account exports, so a timeline built on watch dates
+                # places backdated entries in the year of the viewing rather
+                # than the year the opinion was formed.
+                "date_basis": (
+                    "logged"
+                    if events and all(event.logged_date is not None for event in events)
+                    else "watched"
+                    if not any(event.logged_date is not None for event in events)
+                    else "mixed"
+                ),
+                "logged_date_events": sum(
+                    1 for event in events if event.logged_date is not None
+                ),
                 "date_coverage_ratio": _round(date_coverage_ratio, 3),
                 "rated_dated_events": rated_dated_events,
                 "rating_coverage_ratio": _round(rating_coverage_ratio, 3),

--- a/backend/services/movie_resolver.py
+++ b/backend/services/movie_resolver.py
@@ -5,7 +5,20 @@ from typing import Dict, Optional, Tuple
 from sqlalchemy.orm import Session
 
 from database.models import Movie
-from services.import_contracts import MovieIdentity
+from services.import_contracts import MovieIdentity, normalize_letterboxd_url
+
+
+def _usable_poster_url(value: Optional[str]) -> Optional[str]:
+    """Reject Letterboxd's lazy-load placeholder.
+
+    Poster images are resolved client-side, so a scraped ``img src`` is the
+    static empty-poster asset until their JS runs. Persisting it would mask
+    the real poster (TMDB enrichment supplies those).
+    """
+    absolute = normalize_letterboxd_url(value)
+    if not absolute or "empty-poster" in absolute:
+        return None
+    return absolute
 
 
 class MovieResolver:
@@ -34,8 +47,8 @@ class MovieResolver:
                 title=identity.title,
                 normalized_title=identity.normalized_title,
                 release_year=identity.release_year,
-                letterboxd_url=identity.letterboxd_url,
-                poster_url=identity.poster_url,
+                letterboxd_url=normalize_letterboxd_url(identity.letterboxd_url),
+                poster_url=_usable_poster_url(identity.poster_url),
                 first_seen_profile_sync_id=self.profile_sync_id,
                 last_seen_profile_sync_id=self.profile_sync_id,
             )
@@ -103,10 +116,19 @@ class MovieResolver:
             movie.letterboxd_id = identity.letterboxd_id
         if identity.letterboxd_slug and not movie.letterboxd_slug:
             movie.letterboxd_slug = identity.letterboxd_slug
-        if identity.letterboxd_url and not movie.letterboxd_url:
-            movie.letterboxd_url = identity.letterboxd_url
-        if identity.poster_url and (not movie.poster_url or movie.poster_url.startswith("/")):
-            movie.poster_url = identity.poster_url
+        # Every source funnels through the resolver, so normalising here keeps
+        # relative hrefs (data-item-link is site-relative) from reaching the
+        # database and rendering as in-app links.
+        identity_url = normalize_letterboxd_url(identity.letterboxd_url)
+        if identity_url and (not movie.letterboxd_url or movie.letterboxd_url.startswith("/")):
+            movie.letterboxd_url = identity_url
+        identity_poster = _usable_poster_url(identity.poster_url)
+        if identity_poster and (
+            not movie.poster_url
+            or movie.poster_url.startswith("/")
+            or "empty-poster" in movie.poster_url
+        ):
+            movie.poster_url = identity_poster
         if not movie.title and identity.title:
             movie.title = identity.title
             movie.normalized_title = identity.normalized_title

--- a/backend/services/tmdb_enrichment.py
+++ b/backend/services/tmdb_enrichment.py
@@ -417,7 +417,11 @@ def _persist_prepared(
         imdb_id = str(external_ids.get("imdb_id") or details.get("imdb_id") or "").strip()
         if imdb_id:
             movie.imdb_id = imdb_id
-        if not movie.poster_url and values.get("poster_path"):
+        # Letterboxd resolves posters client-side, so a scraped poster may be
+        # their static empty-poster placeholder. Treat that as absent, or the
+        # placeholder permanently blocks the real artwork.
+        poster_is_placeholder = bool(movie.poster_url) and "empty-poster" in movie.poster_url
+        if (not movie.poster_url or poster_is_placeholder) and values.get("poster_path"):
             image_base_url = os.getenv("TMDB_IMAGE_BASE_URL", DEFAULT_IMAGE_BASE_URL)
             movie.poster_url = f"{image_base_url.rstrip('/')}/{str(values['poster_path']).lstrip('/')}"
         raw_payload["details"] = details

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260801_0013"
+HEAD_REVISION = "20260801_0014"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260801_0012"
+            script.get_revision(HEAD_REVISION).down_revision, "20260801_0013"
+        )
+        self.assertEqual(
+            script.get_revision("20260801_0013").down_revision, "20260801_0012"
         )
         self.assertEqual(
             script.get_revision("20260801_0012").down_revision, "20260731_0011"

--- a/backend/tests/test_import_contracts.py
+++ b/backend/tests/test_import_contracts.py
@@ -972,7 +972,7 @@ class SocialSurfaceScrapingTests(unittest.TestCase):
             join_date=None, avatar_url="", total_films=1, total_reviews=0,
             total_lists=0, following_count=1, followers_count=None,
             person_id=26275117, badge="", watchlist_count=None, stats={},
-            favorite_films=[],
+            external_links=[], favorite_films=[],
         )
         scraper.films_data = [{
             "title": "Challengers", "year": 2024, "rating": 4.0, "film_id": "842301",

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -52,6 +52,7 @@ def event(
     rewatch: bool = False,
     rating: float | None = 4.0,
     liked: bool = False,
+    logged_date: date | None = None,
 ) -> EventRow:
     return EventRow(
         id=event_id,
@@ -59,6 +60,7 @@ def event(
         username=username,
         movie_id=movie.id,
         watched_date=watched_date,
+        logged_date=logged_date,
         rating=rating,
         liked=liked,
         rewatch=rewatch,

--- a/backend/tests/test_movie_url_and_poster_hygiene.py
+++ b/backend/tests/test_movie_url_and_poster_hygiene.py
@@ -1,0 +1,121 @@
+"""Movie links must be absolute and placeholder posters must never persist."""
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+
+from backend.database.models import Movie, Profile, ProfileSync
+from backend.services.import_contracts import MovieIdentity
+from backend.services.movie_resolver import MovieResolver
+from scraper_html import EnhancedLetterboxdScraper
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+EMPTY_POSTER = "https://s.ltrbxd.com/static/img/empty-poster-150-DtnLDE3k.png"
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    for table in (Profile.__table__, ProfileSync.__table__, Movie.__table__):
+        table.create(engine, checkfirst=True)
+    return sessionmaker(bind=engine, expire_on_commit=False)()
+
+
+def _identity(**overrides) -> MovieIdentity:
+    values = {
+        "title": "The Dark Knight",
+        "release_year": 2008,
+        "letterboxd_id": "51896",
+        "letterboxd_slug": "the-dark-knight",
+        "letterboxd_url": "/film/the-dark-knight/",
+        "poster_url": EMPTY_POSTER,
+    }
+    values.update(overrides)
+    return MovieIdentity(**values)
+
+
+def test_relative_film_link_is_stored_absolute():
+    # A site-relative href would render as an in-app link.
+    db = _session()
+    movie = MovieResolver(db, profile_sync_id=1).resolve(_identity())
+    assert movie.letterboxd_url == "https://letterboxd.com/film/the-dark-knight/"
+    db.close()
+
+
+def test_placeholder_poster_is_never_persisted():
+    # Letterboxd resolves posters client-side; the scraped src is a static
+    # placeholder that would otherwise block TMDB artwork forever.
+    db = _session()
+    movie = MovieResolver(db, profile_sync_id=1).resolve(_identity())
+    assert movie.poster_url is None
+    db.close()
+
+
+def test_existing_placeholder_and_relative_values_are_upgraded():
+    db = _session()
+    resolver = MovieResolver(db, profile_sync_id=1)
+    movie = resolver.resolve(_identity())
+    movie.poster_url = EMPTY_POSTER
+    movie.letterboxd_url = "/film/the-dark-knight/"
+    db.flush()
+
+    MovieResolver(db, profile_sync_id=2).resolve(
+        _identity(poster_url="https://a.ltrbxd.com/real-poster.jpg")
+    )
+    assert movie.poster_url == "https://a.ltrbxd.com/real-poster.jpg"
+    assert movie.letterboxd_url == "https://letterboxd.com/film/the-dark-knight/"
+    db.close()
+
+
+PROFILE_METADATA_MARKUP = """
+<section class="profile-metadata js-profile-metadata">
+  <div class="metadatum -has-label"><span class="label">🇩🇪</span></div>
+  <a class="metadatum -has-label" href="https://myanimelist.net/profile/whiteknight03X"
+     rel="me nofollow"><span class="label">myanimelist.net</span></a>
+  <a class="metadatum -has-label" href="https://twitter.com/InfiniteVibesss"
+     rel="me nofollow"><span class="label">InfiniteVibesss</span></a>
+  <a class="metadatum" href="/whiteknight03x/films/">Films</a>
+</section>
+"""
+
+
+def _scrape_metadata(markup: str):
+    """Run the profile-metadata branch of scrape_profile_info in isolation."""
+    scraper = EnhancedLetterboxdScraper.__new__(EnhancedLetterboxdScraper)
+    soup = BeautifulSoup(markup, "html.parser")
+    profile_metadata = soup.select_one(
+        "section.profile-metadata, div.profile-metadata, .js-profile-metadata"
+    )
+    from urllib.parse import urlparse
+
+    links = []
+    seen = set()
+    for anchor in profile_metadata.select("a.metadatum[href], a.url[href]"):
+        href = (anchor.get("href") or "").strip()
+        if not href.casefold().startswith(("http://", "https://")):
+            continue
+        if "letterboxd.com" in urlparse(href).netloc.casefold():
+            continue
+        if href in seen:
+            continue
+        seen.add(href)
+        links.append({"label": anchor.get_text(" ", strip=True) or urlparse(href).netloc, "url": href})
+    return links
+
+
+def test_all_external_profile_links_are_captured():
+    # Letterboxd allows several links; only one used to survive.
+    links = _scrape_metadata(PROFILE_METADATA_MARKUP)
+    assert [link["url"] for link in links] == [
+        "https://myanimelist.net/profile/whiteknight03X",
+        "https://twitter.com/InfiniteVibesss",
+    ]
+    assert links[1]["label"] == "InfiniteVibesss"
+    # Internal Letterboxd navigation is not an external link.
+    assert all("letterboxd.com" not in link["url"] for link in links)

--- a/backend/tests/test_movie_url_and_poster_hygiene.py
+++ b/backend/tests/test_movie_url_and_poster_hygiene.py
@@ -86,27 +86,13 @@ PROFILE_METADATA_MARKUP = """
 
 
 def _scrape_metadata(markup: str):
-    """Run the profile-metadata branch of scrape_profile_info in isolation."""
-    scraper = EnhancedLetterboxdScraper.__new__(EnhancedLetterboxdScraper)
+    """Exercise the scraper's own extraction, not a copy of it."""
     soup = BeautifulSoup(markup, "html.parser")
     profile_metadata = soup.select_one(
         "section.profile-metadata, div.profile-metadata, .js-profile-metadata"
     )
-    from urllib.parse import urlparse
-
-    links = []
-    seen = set()
-    for anchor in profile_metadata.select("a.metadatum[href], a.url[href]"):
-        href = (anchor.get("href") or "").strip()
-        if not href.casefold().startswith(("http://", "https://")):
-            continue
-        if "letterboxd.com" in urlparse(href).netloc.casefold():
-            continue
-        if href in seen:
-            continue
-        seen.add(href)
-        links.append({"label": anchor.get_text(" ", strip=True) or urlparse(href).netloc, "url": href})
-    return links
+    anchors = profile_metadata.select("a.metadatum[href], a.url[href]")
+    return EnhancedLetterboxdScraper._extract_external_links(anchors)
 
 
 def test_all_external_profile_links_are_captured():
@@ -119,3 +105,14 @@ def test_all_external_profile_links_are_captured():
     assert links[1]["label"] == "InfiniteVibesss"
     # Internal Letterboxd navigation is not an external link.
     assert all("letterboxd.com" not in link["url"] for link in links)
+
+
+def test_letterboxd_host_check_is_not_a_substring_match():
+    is_lbx = EnhancedLetterboxdScraper._is_letterboxd_host
+    assert is_lbx("https://letterboxd.com/user/") is True
+    assert is_lbx("https://www.letterboxd.com/user/") is True
+    # A lookalike domain that merely contains the string is not Letterboxd,
+    # and a host that ends with it must be a real subdomain.
+    assert is_lbx("https://letterboxd.com.attacker.example/") is False
+    assert is_lbx("https://notletterboxd.com/") is False
+    assert is_lbx("https://myanimelist.net/profile/x") is False

--- a/backend/tests/test_taste_alignment_order.py
+++ b/backend/tests/test_taste_alignment_order.py
@@ -1,0 +1,98 @@
+"""The taste-alignment panel must rank agreement, not one profile's ratings."""
+from __future__ import annotations
+
+from backend.services.insights import InsightsService
+
+
+def _trait(label: str, scores, samples, *, sample_size=None):
+    """A trait payload shaped like taste_dna builds it."""
+    per_profile = [
+        {"username": f"p{index}", "score": score, "sample_size": sample,
+         "average_rating": score / 20}
+        for index, (score, sample) in enumerate(zip(scores, samples))
+    ]
+    return {
+        "label": label,
+        "per_profile": per_profile,
+        "sample_size": sample_size if sample_size is not None else sum(samples),
+    }
+
+
+def _order(traits):
+    return [
+        trait["label"]
+        for trait in sorted(
+            traits, key=lambda t: InsightsService._alignment_sort_key(t, 2)
+        )
+    ]
+
+
+def test_one_sided_perfect_score_loses_to_genuine_agreement():
+    # The reported bug: a director one profile rated 5.0 and the other never
+    # watched was topping a panel titled "Where your tastes align".
+    traits = [
+        _trait("Only One Watched", [100.0, 0.0], [3, 0]),
+        _trait("Both Love It", [84.0, 80.0], [9, 7]),
+    ]
+    assert _order(traits) == ["Both Love It", "Only One Watched"]
+
+
+def test_closer_agreement_outranks_a_wider_split():
+    traits = [
+        _trait("Split", [96.0, 60.0], [5, 5]),
+        _trait("Aligned", [82.0, 80.0], [5, 5]),
+    ]
+    assert _order(traits) == ["Aligned", "Split"]
+
+
+def test_single_film_traits_rank_below_credible_ones():
+    # One five-star film scores a perfect 100 — coverage noise, not taste.
+    traits = [
+        _trait("One Film Each", [100.0, 100.0], [1, 1]),
+        _trait("Well Sampled", [76.0, 74.0], [12, 11]),
+    ]
+    assert _order(traits) == ["Well Sampled", "One Film Each"]
+
+
+def test_shared_traits_always_precede_unshared_ones():
+    traits = [
+        _trait("Unshared High", [100.0, 0.0], [8, 0]),
+        _trait("Shared Low", [52.0, 50.0], [4, 4]),
+    ]
+    assert _order(traits) == ["Shared Low", "Unshared High"]
+
+
+def test_stronger_mutual_affinity_wins_between_equally_aligned_traits():
+    traits = [
+        _trait("Warm", [62.0, 60.0], [6, 6]),
+        _trait("Hot", [92.0, 90.0], [6, 6]),
+    ]
+    assert _order(traits) == ["Hot", "Warm"]
+
+
+def test_opinion_date_prefers_the_log_date_over_a_backdated_watch():
+    """A 2015 watch logged in 2024 belongs to 2024 on a taste timeline.
+
+    Letterboxd lets members backdate diary entries to the day they actually
+    saw a film, so the rating on a backdated entry was formed years after the
+    watch date it carries.
+    """
+    from datetime import date as _date
+    from backend.services.insights import EventRow
+
+    backdated = EventRow(
+        id=1, profile_id=1, username="viewer", movie_id=1,
+        watched_date=_date(2015, 6, 1), logged_date=_date(2024, 3, 9),
+        rating=4.5, liked=False, rewatch=False, tags=[],
+        source_kind="diary_csv", movie=None,
+    )
+    assert backdated.opinion_date == _date(2024, 3, 9)
+
+    # Public HTML carries no log date, so the watch date is the only axis.
+    scraped_only = EventRow(
+        id=2, profile_id=1, username="viewer", movie_id=2,
+        watched_date=_date(2015, 6, 1), logged_date=None,
+        rating=4.5, liked=False, rewatch=False, tags=[],
+        source_kind="diary_csv", movie=None,
+    )
+    assert scraped_only.opinion_date == _date(2015, 6, 1)

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -581,6 +581,35 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   }
   if (path === '/api/watch-together') return json(route, watchTogether);
 
+  // Single-profile taste panel on Analysis; contract-shaped so the page
+  // renders without console noise.
+  if (path === '/api/taste-dna') {
+    return json(route, {
+      selected_profiles: [profiles[0].username],
+      dimensions: {
+        genre: [
+          {
+            id: 'genre:drama',
+            label: 'Drama',
+            dimension: 'genre',
+            group_score: 78,
+            sample_size: 42,
+            average_rating: 3.9,
+            like_rate: 0.3,
+            watch_share: 1,
+            per_profile: [
+              { username: profiles[0].username, score: 78, sample_size: 42, average_rating: 3.9 },
+            ],
+            top_movies: [],
+          },
+        ],
+      },
+      shared_signature: [],
+      contrasts: [],
+      coverage: { status: 'ready', score: 100, blockers: [], warnings: [] },
+    });
+  }
+
   // Social graph (contract-shaped empty states until fixtures grow edges).
   if (path === '/api/follow-graph/suggestions') return json(route, { suggestions: [] });
   if (path === '/api/follow-graph/mutuals') {

--- a/frontend/src/components/ProfileHeader.tsx
+++ b/frontend/src/components/ProfileHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { BadgeCheck, Globe, Heart, MapPin, RefreshCw, Users } from 'lucide-react';
 
@@ -117,6 +117,16 @@ export default function ProfileHeader({
   const badge = header.member_badge?.trim();
   const joinedLabel = formatMonthYear(header.join_date);
 
+  // A member can list several links (personal site, Twitter, …). Older
+  // payloads only carry the single website field, so fall back to it.
+  const externalLinks = useMemo(() => {
+    const links = header.external_links?.filter((link) => link.url) ?? [];
+    if (links.length > 0) return links;
+    return header.website_url
+      ? [{ label: header.website ?? header.website_url, url: header.website_url }]
+      : [];
+  }, [header.external_links, header.website, header.website_url]);
+
   // Letterboxd's own header stat row. Anything it never observed is dropped
   // rather than rendered as a blank or a misleading zero.
   const statCandidates: Array<StatItem | null> = [
@@ -221,17 +231,18 @@ export default function ProfileHeader({
                 {pronoun}
               </span>
             ) : null}
-            {header.website_url && header.website ? (
+            {externalLinks.map((link) => (
               <a
-                href={header.website_url}
+                key={link.url}
+                href={link.url}
                 target="_blank"
                 rel="noreferrer nofollow"
                 className="inline-flex max-w-full items-center gap-1.5 truncate text-white/70 transition-colors hover:text-cinema-300"
               >
                 <Globe className="h-3.5 w-3.5 text-cinema-400" aria-hidden="true" />
-                <span className="truncate">{header.website}</span>
+                <span className="truncate">{link.label}</span>
               </a>
-            ) : null}
+            ))}
             {joinedLabel ? <span>Joined {joinedLabel}</span> : null}
           </div>
         </div>

--- a/frontend/src/components/ProfileHeader.tsx
+++ b/frontend/src/components/ProfileHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { BadgeCheck, Globe, Heart, MapPin, RefreshCw, Users } from 'lucide-react';
 
@@ -118,14 +118,15 @@ export default function ProfileHeader({
   const joinedLabel = formatMonthYear(header.join_date);
 
   // A member can list several links (personal site, Twitter, …). Older
-  // payloads only carry the single website field, so fall back to it.
-  const externalLinks = useMemo(() => {
-    const links = header.external_links?.filter((link) => link.url) ?? [];
-    if (links.length > 0) return links;
-    return header.website_url
+  // payloads only carry the single website field, so fall back to it. Plain
+  // computation rather than useMemo: this component returns early when it has
+  // no header, so a hook here would not run in the same order every render.
+  const observedLinks = header.external_links?.filter((link) => link.url) ?? [];
+  const externalLinks = observedLinks.length > 0
+    ? observedLinks
+    : header.website_url
       ? [{ label: header.website ?? header.website_url, url: header.website_url }]
       : [];
-  }, [header.external_links, header.website, header.website_url]);
 
   // Letterboxd's own header stat row. Anything it never observed is dropped
   // rather than rendered as a blank or a misleading zero.

--- a/frontend/src/components/insights/ComparePanels.tsx
+++ b/frontend/src/components/insights/ComparePanels.tsx
@@ -275,19 +275,26 @@ function TraitMirror({ trait, profiles }: { trait: TasteTrait; profiles: string[
   const left = trait.per_profile.find((score) => score.username === profiles[0]);
   const right = trait.per_profile.find((score) => score.username === profiles[1]);
   return (
-    <div className="grid grid-cols-[minmax(0,1fr)_4rem_minmax(0,1fr)] items-center gap-2 text-xs">
+    // Names (directors, actors) need real room: a fixed narrow column
+    // truncated almost every one of them to "Paul Tho…".
+    <div className="grid grid-cols-[minmax(0,1fr)_minmax(8rem,14rem)_minmax(0,1fr)] items-center gap-2 text-xs">
       <div className="flex items-center justify-end gap-2">
-        <span className="truncate text-white/55">{left ? `${Math.round(left.score)}%` : '—'}</span>
-        <span className="h-1.5 w-full max-w-28 overflow-hidden rounded-full bg-white/10">
+        <span className="shrink-0 tabular-nums text-white/55">{left ? `${Math.round(left.score)}%` : '—'}</span>
+        <span className="h-1.5 w-full max-w-24 overflow-hidden rounded-full bg-white/10">
           <span className="ml-auto block h-full rounded-full bg-cinema-500" style={{ width: `${Math.max(2, left?.score ?? 0)}%` }} />
         </span>
       </div>
-      <span className="truncate text-center font-medium text-white/75" title={trait.label}>{trait.label}</span>
+      <span
+        className="truncate text-center text-sm font-medium text-white/85"
+        title={trait.label}
+      >
+        {trait.label}
+      </span>
       <div className="flex items-center gap-2">
-        <span className="h-1.5 w-full max-w-28 overflow-hidden rounded-full bg-white/10">
+        <span className="h-1.5 w-full max-w-24 overflow-hidden rounded-full bg-white/10">
           <span className="block h-full rounded-full bg-blue-500" style={{ width: `${Math.max(2, right?.score ?? 0)}%` }} />
         </span>
-        <span className="truncate text-white/55">{right ? `${Math.round(right.score)}%` : '—'}</span>
+        <span className="shrink-0 tabular-nums text-white/55">{right ? `${Math.round(right.score)}%` : '—'}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/insights/TasteProfilePanel.tsx
+++ b/frontend/src/components/insights/TasteProfilePanel.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { Dna } from 'lucide-react';
+
+import { insightsApi } from '../../services/api';
+import type { TasteTrait } from '../../services/api';
+
+const DIMENSION_LABELS: Record<string, string> = {
+  genre: 'Genres',
+  director: 'Directors',
+  actor: 'Actors',
+  language: 'Languages',
+  country: 'Countries',
+  decade: 'Decades',
+  keyword: 'Themes',
+  runtime: 'Runtime',
+};
+
+/**
+ * The taste breakdown for a single profile. The comparison view answers "where
+ * do two people agree"; this answers "what does this person actually gravitate
+ * toward", which only needs one profile's ratings.
+ */
+const TasteProfilePanel: React.FC<{ username: string; delay?: number }> = ({
+  username,
+  delay = 0,
+}) => {
+  const tasteQuery = useQuery({
+    queryKey: ['taste-dna', 'single', username],
+    queryFn: () => insightsApi.getTasteDna([username]),
+    enabled: Boolean(username),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const dimensions = useMemo(() => {
+    const payload = tasteQuery.data?.dimensions ?? {};
+    return Object.entries(payload)
+      .map(([dimension, traits]) => [dimension, (traits ?? []).slice(0, 6)] as const)
+      .filter(([, traits]) => traits.length > 0);
+  }, [tasteQuery.data]);
+
+  if (tasteQuery.isError) return null;
+
+  return (
+    <motion.section
+      className="analysis-panel"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <div className="flex items-center gap-2">
+        <Dna className="h-5 w-5 text-cinema-400" />
+        <h2 className="text-xl font-semibold text-white">Taste profile</h2>
+      </div>
+      <p className="mt-1 text-sm text-white/60">
+        What @{username} gravitates toward, from rated films with metadata.
+      </p>
+
+      {tasteQuery.isLoading && (
+        <p className="mt-6 text-sm text-white/40">Reading taste signals…</p>
+      )}
+
+      {!tasteQuery.isLoading && dimensions.length === 0 && (
+        <p className="mt-6 text-sm text-white/40">
+          No metadata dimensions are ready for this profile yet.
+        </p>
+      )}
+
+      <div className="mt-5 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+        {dimensions.map(([dimension, traits]) => (
+          <div key={dimension}>
+            <p className="text-xs font-semibold uppercase tracking-wide text-white/45">
+              {DIMENSION_LABELS[dimension] ?? dimension}
+            </p>
+            <ul className="mt-2 space-y-1.5">
+              {traits.map((trait: TasteTrait) => {
+                const score = Math.round(trait.group_score);
+                return (
+                  <li key={trait.id} className="flex items-center gap-2 text-sm">
+                    <span
+                      className="min-w-0 flex-1 truncate text-white/80"
+                      title={trait.label}
+                    >
+                      {trait.label}
+                    </span>
+                    <span className="h-1.5 w-16 shrink-0 overflow-hidden rounded-full bg-white/10">
+                      <span
+                        className="block h-full rounded-full bg-cinema-500"
+                        style={{ width: `${Math.max(2, score)}%` }}
+                      />
+                    </span>
+                    <span className="w-9 shrink-0 text-right text-xs tabular-nums text-white/45">
+                      {score}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {dimensions.length > 0 && (
+        <p className="mt-5 text-xs leading-5 text-white/35">
+          Scores blend average rating with how much of this profile&apos;s history the
+          trait covers. Traits backed by a single film rank last, since one rating
+          says more about coverage than taste.
+        </p>
+      )}
+    </motion.section>
+  );
+};
+
+export default TasteProfilePanel;

--- a/frontend/src/components/insights/TasteTimelinePanel.tsx
+++ b/frontend/src/components/insights/TasteTimelinePanel.tsx
@@ -145,7 +145,16 @@ export default function TasteTimelinePanel({ data, coverage }: {
       </section>
 
       <p className="flex items-start gap-2 px-1 text-xs leading-5 text-white/40">
-        <Info className="mt-0.5 h-4 w-4 shrink-0" /> Only observed, dated watch events are placed on the timeline. {data.summary.undated_known_watches.toLocaleString()} known watches without dates remain excluded.
+        <Info className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>
+          Only observed, dated events are placed on the timeline. {data.summary.undated_known_watches.toLocaleString()} known watches without dates remain excluded.
+          {' '}
+          {data.summary.date_basis === 'logged'
+            ? 'Points sit on the date each entry was logged, so a backdated watch counts toward the year the opinion was recorded.'
+            : data.summary.date_basis === 'mixed'
+              ? `Points sit on the log date where one is known (${data.summary.logged_date_events?.toLocaleString() ?? 0} events) and the watch date otherwise.`
+              : 'Points sit on the watch date: log dates only come from an official Letterboxd export, so entries backdated to an older viewing appear in that older year.'}
+        </span>
       </p>
 
       <section className="panel-insight p-4">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -768,6 +768,9 @@ export interface TasteTimelineResponse {
     dated_watch_events: number;
     total_known_watches: number;
     undated_known_watches: number;
+    /** Which date the points sit on; log dates only exist in account exports. */
+    date_basis?: 'logged' | 'watched' | 'mixed';
+    logged_date_events?: number;
     date_coverage_ratio: number | null;
     rated_dated_events: number;
     rating_coverage_ratio: number | null;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -133,6 +133,11 @@ export const authApi = {
   },
 };
 
+export interface ProfileExternalLink {
+  label: string;
+  url: string;
+}
+
 export interface ProfileFavoriteFilm {
   position: number;
   title: string;
@@ -154,6 +159,8 @@ export interface ProfileHeader {
   location: string | null;
   website: string | null;
   website_url: string | null;
+  /** Every external link the member lists; Letterboxd allows more than one. */
+  external_links?: ProfileExternalLink[];
   pronoun: string | null;
   member_badge: string | null;
   avatar_url: string | null;

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -16,6 +16,7 @@ import SpoilerReviewText from '../components/SpoilerReviewText';
 import AdminScopeToggle from '../components/AdminScopeToggle';
 import ProfileHeader from '../components/ProfileHeader';
 import ArchivePanel from '../components/insights/ArchivePanel';
+import TasteProfilePanel from '../components/insights/TasteProfilePanel';
 import TagsPanel, { TagChipList } from '../components/insights/TagsPanel';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 import { profileApi } from '../services/api';
@@ -220,6 +221,8 @@ const Analysis: React.FC = () => {
             username={analysis.username}
             delay={0.15}
           />
+
+          <TasteProfilePanel username={analysis.username} delay={0.18} />
 
           <ArchivePanel username={analysis.username} />
 


### PR DESCRIPTION
Everything spotted in the UI, fixed at the source.

### Posters and links
- **Posters were placeholders.** Letterboxd resolves poster images client-side, so a scraped `img src` is their static empty-poster asset. Worse: it occupied `poster_url`, and TMDB enrichment only wrote *when that column was empty* — so real artwork could never land. The resolver now rejects placeholders; enrichment treats one as absent.
- **Film links were site-relative** (`/film/<slug>/`) and so navigated inside Spyboxd. Normalised at the resolver — the single choke point every source funnels through.
- **Only one external profile link survived**, via an `a.url` selector that no longer matches Letterboxd's markup. Members can list several (this profile has MyAnimeList *and* Twitter); all are captured now.

Migration `20260801_0014` repairs stored data: 4,074 relative URLs made absolute, placeholders cleared, real artwork backfilled from enrichment already held — **4,788 of 4,950 movies now have a poster**.

### Taste panels
- **"Where your tastes align" was ranking divergence.** Group score is driven by average rating, so a director one profile rated 5.0 once and the other never watched scored 100 and topped the panel. Ranking now requires both profiles present, rewards the weaker side, and penalises the gap. Single-film traits rank last — one five-star rating scores a perfect 100 and reflects coverage, not taste.
- **The timeline plotted watch dates.** Letterboxd lets members backdate entries, so a 2015 watch date can carry a rating formed in 2024 — which is why years predating a profile's join date appeared. Points now sit on the **log date** where known, and the panel states which date it used.
- **Trait labels were capped at 4rem**, truncating nearly every name to "Paul Tho…". The column flexes and reads at a proper size.
- **Taste analysis now works for a single profile** — a new panel on the deep dive answers "what does this person gravitate toward".

## Verification
312 backend tests pass (15 new pinning each fix), `tsc` + `eslint` + `next build` green. The full migration chain was applied to a scratch database from empty to head to prove production will succeed. Live-verified: both external links captured, favourites show real TMDB posters and absolute Letterboxd URLs, single-profile taste returns sensible dimensions, and the timeline reports `date_basis: logged` for the export-backed profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)