### PR TITLE
Compute Letterboxd's Patron-only stats ourselves, for every profile

### DIFF
--- a/backend/api/routes/profile_stats.py
+++ b/backend/api/routes/profile_stats.py
@@ -1,0 +1,37 @@
+"""Profile statistics: Letterboxd's Patron-only stats page, recomputed locally."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from services.profile_access import require_profile_access
+from services.profile_stats import build_profile_stats
+
+
+router = APIRouter(prefix="/api", tags=["profile stats"])
+
+
+@router.get("/profiles/{username}/stats")
+def get_profile_stats(
+    username: str,
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """Viewing statistics computed from imported rows plus TMDB enrichment.
+
+    Letterboxd gates its own stats page behind Patron membership, so scraping
+    it reaches almost none of the tracked profiles. Enrichment already holds
+    runtime, credits, countries, languages and release dates, so the same
+    figures are derived here for every profile instead.
+
+    ``coverage`` and ``totals.runtime_coverage`` qualify the answer: hours and
+    people counts are summed only over films we actually hold data for, never
+    extrapolated to the rest of the library. ``letterboxd_reported`` returns
+    the scraped Patron figures verbatim when they exist, purely as a
+    cross-check, and is null for every profile that was never scraped.
+    """
+
+    profile = require_profile_access(db, user, username)
+    return build_profile_stats(db, profile)

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from api.routes.follow_graph import router as follow_graph_router
 from api.routes.insights import router as insights_router
 from api.routes.member_archive import router as member_archive_router
 from api.routes.profile_access import router as profile_access_router
+from api.routes.profile_stats import router as profile_stats_router
 from auth import ClerkUser, get_admin_user, get_current_user, get_upload_user
 from database.connection import engine, get_db, init_db
 from database.models import Movie, Profile, ProfileFavoriteMovie
@@ -387,6 +388,7 @@ app.include_router(activity_router)
 app.include_router(profile_access_router)
 app.include_router(follow_graph_router)
 app.include_router(member_archive_router)
+app.include_router(profile_stats_router)
 
 @app.get("/health")
 async def health_check():

--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -1,0 +1,418 @@
+"""Per-profile viewing statistics computed from rows we already own.
+
+Letterboxd publishes its own ``/<user>/stats/`` page, but only to Patrons, so
+scraping it covers a handful of profiles at best. TMDB enrichment already
+carries runtime, language, release date, genres, credits, production countries
+and the raw payload's production companies for every film we have matched, so
+the same figures can be recomputed for *every* profile from local data.
+
+Nothing here extrapolates. Runtime is summed only over the films whose runtime
+we actually hold, and ``runtime_coverage`` reports what fraction of the library
+that was, so a client can qualify the number instead of presenting a partial
+sum as a total. Where enrichment supplies no evidence at all, the payload says
+``null`` rather than ``0`` -- an unenriched profile has an unknown director
+count, not zero directors.
+"""
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence
+
+from sqlalchemy.orm import Session
+
+from database.models import Movie, MovieEnrichment, Profile, ProfileFilm, WatchEvent
+from services.insights import _as_string_list, _average, _round, _safe_float
+
+
+# Every list surface is a "top" list, not an export: a stats page that renders
+# 800 directors is a database dump, not a summary.
+MAX_LIST_ENTRIES = 10
+
+# A single five-star film is not a favourite genre. "Highest rated" needs
+# enough rated films behind the average for the number to mean anything.
+MIN_FAVOURITE_SAMPLE = 3
+
+# TMDB orders `cast` by billing. Counting all of it would let a 40-name
+# ensemble outweigh a two-hander, so only the top-billed roles count.
+TOP_BILLED_CAST_ORDER = 5
+
+
+class _Value(NamedTuple):
+    """One bucket membership for a film: merge key, display label, optional code."""
+
+    key: str
+    label: str
+    code: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _FilmRow:
+    """One active profile_films row, joined to whatever enrichment exists."""
+
+    rating: Optional[float]
+    rewatch_count: int
+    release_year: Optional[int]
+    enriched: bool
+    runtime_minutes: Optional[int]
+    genres: List[_Value]
+    countries: List[_Value]
+    languages: List[_Value]
+    directors: List[_Value]
+    actors: List[_Value]
+    studios: List[_Value]
+
+    @property
+    def decades(self) -> List[_Value]:
+        if not self.release_year:
+            return []
+        label = f"{(int(self.release_year) // 10) * 10}s"
+        return [_Value(label, label)]
+
+
+def _plain_values(labels: Iterable[str]) -> List[_Value]:
+    return [_Value(label.casefold(), label) for label in labels]
+
+
+def _country_values(payload: Any) -> List[_Value]:
+    """TMDB production countries carry both a name and an ISO 3166-1 code."""
+
+    values: List[_Value] = []
+    seen: set[str] = set()
+    for item in payload if isinstance(payload, list) else []:
+        if isinstance(item, Mapping):
+            label = str(item.get("name") or "").strip()
+            code = str(item.get("iso_3166_1") or "").strip().upper() or None
+        else:
+            label = str(item or "").strip()
+            code = None
+        key = label.casefold()
+        if label and key not in seen:
+            seen.add(key)
+            values.append(_Value(key, label, code))
+    return values
+
+
+def _language_values(original_language: Any, spoken_languages: Any) -> List[_Value]:
+    """Name the original language from the payload rather than a hardcoded map.
+
+    ``original_language`` is a bare ISO 639-1 code. The same TMDB response
+    lists every spoken language with its English name, so the readable label
+    comes from the data itself and falls back to the uppercased code when the
+    payload never names it.
+    """
+
+    code = str(original_language or "").strip()
+    if not code:
+        return []
+    label = None
+    for item in spoken_languages if isinstance(spoken_languages, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("iso_639_1") or "").strip().casefold() == code.casefold():
+            label = str(item.get("english_name") or item.get("name") or "").strip() or None
+            break
+    return [_Value(code.casefold(), label or code.upper(), code.casefold())]
+
+
+def _director_values(credits: Any) -> List[_Value]:
+    """Only crew credited with the Director job; a film may have several."""
+
+    crew = credits.get("crew") if isinstance(credits, Mapping) else None
+    if not isinstance(crew, list):
+        return []
+    return _plain_values(
+        _as_string_list(
+            [
+                member
+                for member in crew
+                if isinstance(member, Mapping) and member.get("job") == "Director"
+            ]
+        )
+    )
+
+
+def _actor_values(credits: Any) -> List[_Value]:
+    cast = credits.get("cast") if isinstance(credits, Mapping) else None
+    if not isinstance(cast, list):
+        return []
+    billed: List[Any] = []
+    for index, member in enumerate(cast):
+        if not isinstance(member, Mapping):
+            continue
+        order = _safe_float(member.get("order"))
+        position = int(order) if order is not None else index
+        if position < TOP_BILLED_CAST_ORDER:
+            billed.append(member)
+    return _plain_values(_as_string_list(billed))
+
+
+def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
+    """Bulk-load one profile's library in a single query.
+
+    Only the columns the statistics need are selected. ``raw_payload`` holds
+    the entire TMDB response including watch providers -- tens of megabytes
+    across a large library -- so the two fragments needed from it are extracted
+    by JSON path in the database instead of shipping the whole document.
+    """
+
+    production_companies = MovieEnrichment.raw_payload["details"]["production_companies"]
+    spoken_languages = MovieEnrichment.raw_payload["details"]["spoken_languages"]
+    rows = (
+        db.query(
+            ProfileFilm.rating,
+            ProfileFilm.rewatch_count,
+            Movie.release_year,
+            MovieEnrichment.movie_id,
+            MovieEnrichment.runtime_minutes,
+            MovieEnrichment.original_language,
+            MovieEnrichment.release_date,
+            MovieEnrichment.genres,
+            MovieEnrichment.credits,
+            MovieEnrichment.production_countries,
+            production_companies.label("production_companies"),
+            spoken_languages.label("spoken_languages"),
+        )
+        .join(Movie, Movie.id == ProfileFilm.movie_id)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(
+            ProfileFilm.profile_id == profile_id,
+            ProfileFilm.removed_at.is_(None),
+        )
+        .all()
+    )
+
+    films: List[_FilmRow] = []
+    for row in rows:
+        enriched = row.movie_id is not None
+        release_year = row.release_year
+        if not release_year and row.release_date is not None:
+            release_year = row.release_date.year
+        credits = row.credits if isinstance(row.credits, Mapping) else {}
+        films.append(
+            _FilmRow(
+                rating=_safe_float(row.rating),
+                rewatch_count=int(row.rewatch_count or 0),
+                release_year=int(release_year) if release_year else None,
+                enriched=enriched,
+                runtime_minutes=(
+                    int(row.runtime_minutes)
+                    if row.runtime_minutes is not None and int(row.runtime_minutes) > 0
+                    else None
+                ),
+                genres=_plain_values(_as_string_list(row.genres)),
+                countries=_country_values(row.production_countries),
+                languages=_language_values(row.original_language, row.spoken_languages),
+                directors=_director_values(credits),
+                actors=_actor_values(credits),
+                studios=_plain_values(_as_string_list(row.production_companies)),
+            )
+        )
+    return films
+
+
+def _dated_watch_dates(db: Session, profile_id: int) -> List[date]:
+    """Every active watch event's date, one small column, one query."""
+
+    return [
+        watched_date
+        for (watched_date,) in db.query(WatchEvent.watched_date)
+        .filter(
+            WatchEvent.profile_id == profile_id,
+            WatchEvent.superseded_at.is_(None),
+            WatchEvent.watched_date.isnot(None),
+        )
+        .all()
+        if watched_date is not None
+    ]
+
+
+def longest_streak_weeks(dates: Sequence[date]) -> Optional[int]:
+    """Longest run of consecutive ISO weeks that each contain a watch.
+
+    Each date collapses to the Monday that starts its ISO week, so two watches
+    in one week count once and consecutive weeks are exactly seven days apart
+    -- true across year boundaries, where ISO week numbers restart.
+    """
+
+    if not dates:
+        return None
+    week_starts = sorted({value - timedelta(days=value.weekday()) for value in dates})
+    longest = 1
+    current = 1
+    for previous, following in zip(week_starts, week_starts[1:]):
+        current = current + 1 if (following - previous).days == 7 else 1
+        longest = max(longest, current)
+    return longest
+
+
+def multi_film_days(dates: Sequence[date]) -> Optional[int]:
+    """Distinct days carrying two or more watch events."""
+
+    if not dates:
+        return None
+    return sum(1 for count in Counter(dates).values() if count >= 2)
+
+
+def _collect(
+    films: Sequence[_FilmRow],
+    values_for: Callable[[_FilmRow], Sequence[_Value]],
+) -> Dict[str, Dict[str, Any]]:
+    """Tally one dimension across the library, keeping each bucket's ratings."""
+
+    buckets: Dict[str, Dict[str, Any]] = {}
+    for film in films:
+        for value in values_for(film):
+            bucket = buckets.get(value.key)
+            if bucket is None:
+                bucket = {
+                    "label": value.label,
+                    "code": value.code,
+                    "count": 0,
+                    "ratings": [],
+                }
+                buckets[value.key] = bucket
+            elif bucket["code"] is None and value.code is not None:
+                bucket["code"] = value.code
+            bucket["count"] += 1
+            if film.rating is not None:
+                bucket["ratings"].append(film.rating)
+    return buckets
+
+
+def _entry(
+    bucket: Mapping[str, Any],
+    *,
+    label_key: str = "label",
+    include_code: bool = False,
+) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {label_key: bucket["label"]}
+    if include_code:
+        entry["code"] = bucket["code"]
+    entry["count"] = bucket["count"]
+    entry["average_rating"] = _round(_average(bucket["ratings"]), 2)
+    return entry
+
+
+def _by_count(bucket: Mapping[str, Any]):
+    return (-bucket["count"], bucket["label"].casefold(), bucket["label"])
+
+
+def _ranked(
+    buckets: Mapping[str, Dict[str, Any]],
+    *,
+    label_key: str = "label",
+    include_code: bool = False,
+) -> List[Dict[str, Any]]:
+    ordered = sorted(buckets.values(), key=_by_count)[:MAX_LIST_ENTRIES]
+    return [
+        _entry(bucket, label_key=label_key, include_code=include_code)
+        for bucket in ordered
+    ]
+
+
+def _ranked_decades(buckets: Mapping[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The busiest decades, replayed in chronological order for charting."""
+
+    ordered = sorted(buckets.values(), key=_by_count)[:MAX_LIST_ENTRIES]
+    ordered.sort(key=lambda bucket: int(bucket["label"][:-1]))
+    return [_entry(bucket) for bucket in ordered]
+
+
+def _highest_rated(
+    buckets: Mapping[str, Dict[str, Any]],
+    *,
+    label_key: str = "label",
+) -> Optional[Dict[str, Any]]:
+    """The best-rated bucket that clears the credible-sample floor."""
+
+    eligible = [
+        bucket
+        for bucket in buckets.values()
+        if len(bucket["ratings"]) >= MIN_FAVOURITE_SAMPLE
+    ]
+    if not eligible:
+        return None
+    best = min(
+        eligible,
+        key=lambda bucket: (
+            -(_average(bucket["ratings"]) or 0.0),
+            -bucket["count"],
+            bucket["label"].casefold(),
+        ),
+    )
+    return _entry(best, label_key=label_key)
+
+
+def _distinct(buckets: Mapping[str, Dict[str, Any]]) -> Optional[int]:
+    """A dimension nothing in the library described is unknown, not zero."""
+
+    return len(buckets) or None
+
+
+def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
+    """Recompute the Letterboxd stats page for one profile from local rows.
+
+    ``letterboxd_reported`` carries the scraped Patron figures verbatim where
+    they exist so a client can show ours against theirs. It is a cross-check,
+    never the source: the two will differ because Letterboxd counts its own
+    runtime data over a member's whole library while we count TMDB runtimes
+    over the films we managed to match.
+    """
+
+    films = _film_rows(db, profile.id)
+    watch_dates = _dated_watch_dates(db, profile.id)
+
+    films_total = len(films)
+    films_enriched = sum(1 for film in films if film.enriched)
+    ratings = [film.rating for film in films if film.rating is not None]
+    runtimes = [
+        film.runtime_minutes for film in films if film.runtime_minutes is not None
+    ]
+
+    genres = _collect(films, lambda film: film.genres)
+    countries = _collect(films, lambda film: film.countries)
+    languages = _collect(films, lambda film: film.languages)
+    decades = _collect(films, lambda film: film.decades)
+    directors = _collect(films, lambda film: film.directors)
+    actors = _collect(films, lambda film: film.actors)
+    studios = _collect(films, lambda film: film.studios)
+
+    return {
+        "username": profile.username,
+        "coverage": {
+            "films_total": films_total,
+            "films_enriched": films_enriched,
+            "enrichment_ratio": _round(films_enriched / films_total, 4) if films_total else 0.0,
+            "dated_events": len(watch_dates),
+            "rated_films": len(ratings),
+        },
+        "totals": {
+            "films": films_total,
+            "hours_watched": _round(sum(runtimes) / 60, 1) if runtimes else None,
+            "runtime_coverage": _round(len(runtimes) / films_total, 4) if films_total else 0.0,
+            "distinct_directors": _distinct(directors),
+            "distinct_actors": _distinct(actors),
+            "distinct_countries": _distinct(countries),
+            "distinct_languages": _distinct(languages),
+            "distinct_studios": _distinct(studios),
+            "longest_streak_weeks": longest_streak_weeks(watch_dates),
+            "multi_film_days": multi_film_days(watch_dates),
+            "rewatches": sum(film.rewatch_count for film in films),
+            "average_rating": _round(_average(ratings), 2),
+        },
+        "top_directors": _ranked(directors, label_key="name"),
+        "top_actors": _ranked(actors, label_key="name"),
+        "top_studios": _ranked(studios, label_key="name"),
+        "genres": _ranked(genres),
+        "countries": _ranked(countries, include_code=True),
+        "languages": _ranked(languages),
+        "decades": _ranked_decades(decades),
+        "highest_rated": {
+            "genre": _highest_rated(genres),
+            "decade": _highest_rated(decades),
+            "director": _highest_rated(directors, label_key="name"),
+        },
+        "letterboxd_reported": profile.stats_snapshot,
+    }

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1,0 +1,643 @@
+"""Profile stats: honest arithmetic over whatever enrichment we actually hold."""
+from __future__ import annotations
+
+from datetime import date
+from itertools import count
+from typing import Any, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from auth import ClerkUser
+from backend import main as backend_main
+from database.models import (
+    AppUser,
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileAccessRequest,
+    ProfileFilm,
+    UserTrackedProfile,
+    WatchEvent,
+)
+from services.profile_stats import (
+    build_profile_stats,
+    longest_streak_weeks,
+    multi_film_days,
+)
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    Movie.__table__,
+    ProfileFilm.__table__,
+    WatchEvent.__table__,
+    MovieEnrichment.__table__,
+    AppUser.__table__,
+    UserTrackedProfile.__table__,
+    ProfileAccessRequest.__table__,
+)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+_MOVIE_IDS = count(1)
+_EVENT_IDS = count(1)
+
+
+def _profile(database: Session, username: str = "viewer") -> Profile:
+    profile = Profile(username=username, scraping_status="completed", is_active=True)
+    database.add(profile)
+    database.commit()
+    return profile
+
+
+def _person(name: str, *, job: Optional[str] = None, order: Optional[int] = None) -> dict:
+    member: dict[str, Any] = {"id": abs(hash(name)) % 100000, "name": name}
+    if job is not None:
+        member["job"] = job
+        member["department"] = "Directing" if job == "Director" else "Production"
+    if order is not None:
+        member["order"] = order
+    return member
+
+
+def _film(
+    database: Session,
+    profile: Profile,
+    *,
+    title: str,
+    year: Optional[int] = 2000,
+    rating: Optional[float] = None,
+    rewatch_count: int = 0,
+    enrich: bool = True,
+    runtime: Optional[int] = 100,
+    genres: Optional[list[str]] = None,
+    language: Optional[str] = "en",
+    spoken_languages: Optional[list[dict]] = None,
+    countries: Optional[list[dict]] = None,
+    crew: Optional[list[dict]] = None,
+    cast: Optional[list[dict]] = None,
+    studios: Optional[list[dict]] = None,
+) -> Movie:
+    movie_id = next(_MOVIE_IDS)
+    movie = Movie(
+        id=movie_id,
+        canonical_key=f"letterboxd:{title}-{movie_id}",
+        title=title,
+        normalized_title=title.casefold(),
+        release_year=year,
+    )
+    database.add(movie)
+    database.add(
+        ProfileFilm(
+            profile_id=profile.id,
+            movie_id=movie_id,
+            rating=rating,
+            tags=[],
+            watch_count=max(1, rewatch_count + 1),
+            rewatch_count=rewatch_count,
+        )
+    )
+    if enrich:
+        details: dict[str, Any] = {}
+        if studios is not None:
+            details["production_companies"] = studios
+        if spoken_languages is not None:
+            details["spoken_languages"] = spoken_languages
+        database.add(
+            MovieEnrichment(
+                movie_id=movie_id,
+                runtime_minutes=runtime,
+                original_language=language,
+                genres=[{"name": name} for name in (genres or [])],
+                keywords=[],
+                credits={"cast": cast or [], "crew": crew or []},
+                production_countries=countries or [],
+                raw_payload={"details": details} if details else {},
+            )
+        )
+    database.commit()
+    return movie
+
+
+def _watch(database: Session, profile: Profile, movie: Movie, watched: date) -> None:
+    event_id = next(_EVENT_IDS)
+    database.add(
+        WatchEvent(
+            id=event_id,
+            profile_id=profile.id,
+            movie_id=movie.id,
+            event_key=f"event-{event_id}",
+            watched_date=watched,
+            tags=[],
+            source_kind="diary_csv",
+        )
+    )
+    database.commit()
+
+
+# --- streak and multi-film-day arithmetic -----------------------------------
+
+
+def test_a_gap_week_breaks_the_streak_and_the_longest_run_wins() -> None:
+    # Three consecutive weeks, a skipped week, then two consecutive weeks.
+    dates = [
+        date(2026, 1, 5),   # week starting Mon 5 Jan
+        date(2026, 1, 13),  # week starting Mon 12 Jan
+        date(2026, 1, 19),  # week starting Mon 19 Jan
+        # week starting Mon 26 Jan deliberately empty
+        date(2026, 2, 2),
+        date(2026, 2, 9),
+    ]
+
+    assert longest_streak_weeks(dates) == 3
+
+
+def test_many_watches_in_one_week_are_still_a_single_week_streak() -> None:
+    week = [date(2026, 3, 2), date(2026, 3, 3), date(2026, 3, 8)]
+
+    assert longest_streak_weeks(week) == 1
+
+
+def test_a_streak_survives_the_iso_year_boundary() -> None:
+    # ISO week numbers restart in January; the run does not.
+    boundary = [date(2025, 12, 22), date(2025, 12, 29), date(2026, 1, 5)]
+
+    assert longest_streak_weeks(boundary) == 3
+
+
+def test_streak_and_multi_film_days_are_unknown_without_dated_events() -> None:
+    assert longest_streak_weeks([]) is None
+    assert multi_film_days([]) is None
+
+
+def test_multi_film_days_counts_only_days_with_two_or_more_events() -> None:
+    dates = [
+        date(2026, 4, 1),
+        date(2026, 4, 1),
+        date(2026, 4, 2),
+        date(2026, 4, 3),
+        date(2026, 4, 3),
+        date(2026, 4, 3),
+    ]
+
+    assert multi_film_days(dates) == 2
+
+
+def test_streaks_and_multi_film_days_read_the_profile_watch_events(database: Session) -> None:
+    profile = _profile(database)
+    first = _film(database, profile, title="First")
+    second = _film(database, profile, title="Second")
+    _watch(database, profile, first, date(2026, 1, 5))
+    _watch(database, profile, second, date(2026, 1, 5))
+    _watch(database, profile, first, date(2026, 1, 12))
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["coverage"]["dated_events"] == 3
+    assert stats["totals"]["longest_streak_weeks"] == 2
+    assert stats["totals"]["multi_film_days"] == 1
+
+
+# --- runtime honesty --------------------------------------------------------
+
+
+def test_hours_watched_sums_only_known_runtimes_and_reports_coverage(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Ninety", runtime=90)
+    _film(database, profile, title="Thirty", runtime=30)
+    _film(database, profile, title="Unknown Runtime", runtime=None)
+    _film(database, profile, title="No Enrichment", enrich=False)
+
+    stats = build_profile_stats(database, profile)
+
+    # 120 known minutes over 4 films: two hours, never extrapolated to four films.
+    assert stats["totals"]["hours_watched"] == 2.0
+    assert stats["totals"]["runtime_coverage"] == 0.5
+    assert stats["coverage"]["films_total"] == 4
+    assert stats["coverage"]["films_enriched"] == 3
+    assert stats["coverage"]["enrichment_ratio"] == 0.75
+
+
+def test_hours_watched_is_null_when_no_runtime_is_known(database: Session) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Unmatched", enrich=False)
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["totals"]["hours_watched"] is None
+    assert stats["totals"]["runtime_coverage"] == 0.0
+
+
+# --- credits extraction -----------------------------------------------------
+
+
+def test_only_the_director_job_counts_as_a_director(database: Session) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Crewed",
+        rating=4.0,
+        crew=[
+            _person("Assistant Director", job="Assistant Director"),
+            _person("Director of Photography", job="Director of Photography"),
+            _person("Real Director", job="Director"),
+            _person("Second Unit Director", job="Second Unit Director"),
+            _person("Producer Person", job="Producer"),
+        ],
+    )
+
+    stats = build_profile_stats(database, profile)
+
+    assert [entry["name"] for entry in stats["top_directors"]] == ["Real Director"]
+    assert stats["totals"]["distinct_directors"] == 1
+
+
+def test_co_directors_both_count_once_each(database: Session) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Co-directed",
+        crew=[
+            _person("Joel Coen", job="Director"),
+            _person("Ethan Coen", job="Director"),
+            # A duplicated credit row must not double-count one person.
+            _person("Joel Coen", job="Director"),
+        ],
+    )
+
+    stats = build_profile_stats(database, profile)
+
+    assert {entry["name"]: entry["count"] for entry in stats["top_directors"]} == {
+        "Joel Coen": 1,
+        "Ethan Coen": 1,
+    }
+
+
+def test_only_top_billed_cast_counts_as_an_actor(database: Session) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Ensemble",
+        cast=[_person(f"Actor {index}", order=index) for index in range(40)],
+    )
+
+    stats = build_profile_stats(database, profile)
+
+    assert [entry["name"] for entry in stats["top_actors"]] == [
+        "Actor 0",
+        "Actor 1",
+        "Actor 2",
+        "Actor 3",
+        "Actor 4",
+    ]
+    assert stats["totals"]["distinct_actors"] == 5
+
+
+def test_studios_come_from_the_raw_payload_production_companies(database: Session) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Studio Film",
+        studios=[{"id": 1, "name": "A24"}, {"id": 2, "name": "Universal Pictures"}],
+    )
+    _film(database, profile, title="Second Studio Film", studios=[{"id": 1, "name": "A24"}])
+    # A film whose payload never listed companies simply contributes nothing.
+    _film(database, profile, title="No Companies")
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["top_studios"][0] == {
+        "name": "A24",
+        "count": 2,
+        "average_rating": None,
+    }
+    assert stats["totals"]["distinct_studios"] == 2
+
+
+# --- the credible-sample floor ---------------------------------------------
+
+
+def test_highest_rated_ignores_buckets_below_three_rated_films(database: Session) -> None:
+    profile = _profile(database)
+    # One perfect film in a genre is not a favourite genre.
+    _film(database, profile, title="Lone Masterpiece", rating=5.0, genres=["Western"])
+    for index in range(3):
+        _film(
+            database,
+            profile,
+            title=f"Drama {index}",
+            rating=4.0,
+            genres=["Drama"],
+        )
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["highest_rated"]["genre"] == {
+        "label": "Drama",
+        "count": 3,
+        "average_rating": 4.0,
+    }
+
+
+def test_highest_rated_is_null_when_nothing_clears_the_floor(database: Session) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Only Rated Film", rating=5.0, genres=["Horror"])
+    _film(database, profile, title="Unrated Horror", genres=["Horror"])
+
+    stats = build_profile_stats(database, profile)
+
+    # Two rated films would still be too thin; one is definitely too thin.
+    assert stats["highest_rated"] == {"genre": None, "decade": None, "director": None}
+    # The genre still appears in the distribution, with its honest average.
+    assert stats["genres"] == [
+        {"label": "Horror", "count": 2, "average_rating": 5.0}
+    ]
+
+
+def test_bucket_averages_use_only_rated_films(database: Session) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Rated", rating=3.0, genres=["Comedy"])
+    _film(database, profile, title="Also Rated", rating=5.0, genres=["Comedy"])
+    _film(database, profile, title="Unrated", genres=["Comedy"])
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["genres"] == [
+        {"label": "Comedy", "count": 3, "average_rating": 4.0}
+    ]
+    assert stats["coverage"]["rated_films"] == 2
+    assert stats["totals"]["average_rating"] == 4.0
+
+
+# --- graceful degradation ---------------------------------------------------
+
+
+def test_a_profile_with_no_enrichment_returns_nulls_not_zeros(database: Session) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Unmatched", rating=4.5, enrich=False)
+    _watch(database, profile, movie, date(2026, 5, 4))
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["coverage"] == {
+        "films_total": 1,
+        "films_enriched": 0,
+        "enrichment_ratio": 0.0,
+        "dated_events": 1,
+        "rated_films": 1,
+    }
+    totals = stats["totals"]
+    assert totals["films"] == 1
+    assert totals["hours_watched"] is None
+    assert totals["runtime_coverage"] == 0.0
+    for dimension in (
+        "distinct_directors",
+        "distinct_actors",
+        "distinct_countries",
+        "distinct_languages",
+        "distinct_studios",
+    ):
+        assert totals[dimension] is None, dimension
+    # Decade survives without TMDB: the release year comes from the film row.
+    assert stats["decades"] == [{"label": "2000s", "count": 1, "average_rating": 4.5}]
+    assert stats["top_directors"] == []
+    assert stats["highest_rated"]["director"] is None
+    assert stats["letterboxd_reported"] is None
+
+
+def test_a_profile_with_no_films_at_all_returns_a_valid_payload(database: Session) -> None:
+    profile = _profile(database)
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["coverage"]["films_total"] == 0
+    assert stats["coverage"]["enrichment_ratio"] == 0.0
+    assert stats["totals"]["runtime_coverage"] == 0.0
+    assert stats["totals"]["average_rating"] is None
+    assert stats["totals"]["longest_streak_weeks"] is None
+    assert stats["totals"]["rewatches"] == 0
+    assert stats["genres"] == []
+    assert stats["highest_rated"] == {"genre": None, "decade": None, "director": None}
+
+
+def test_malformed_enrichment_payloads_never_crash(database: Session) -> None:
+    profile = _profile(database)
+    movie_id = next(_MOVIE_IDS)
+    database.add(
+        Movie(
+            id=movie_id,
+            canonical_key=f"letterboxd:junk-{movie_id}",
+            title="Junk",
+            normalized_title="junk",
+            release_year=None,
+        )
+    )
+    database.add(ProfileFilm(profile_id=profile.id, movie_id=movie_id, tags=[]))
+    database.add(
+        MovieEnrichment(
+            movie_id=movie_id,
+            runtime_minutes=None,
+            original_language="",
+            genres=["Drama", None, {"no_name": 1}],
+            keywords=[],
+            # credits arriving as a list, cast members as bare strings.
+            credits={"cast": ["not a dict"], "crew": "not a list"},
+            production_countries=[{"iso_3166_1": "US"}, "France"],
+            raw_payload={"details": {"production_companies": "not a list"}},
+        )
+    )
+    database.commit()
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["genres"] == [{"label": "Drama", "count": 1, "average_rating": None}]
+    assert stats["top_directors"] == []
+    assert stats["top_studios"] == []
+    assert stats["decades"] == []
+    assert [entry["label"] for entry in stats["countries"]] == ["France"]
+    assert stats["languages"] == []
+
+
+# --- distributions ----------------------------------------------------------
+
+
+def test_countries_carry_their_iso_code_and_languages_are_named(database: Session) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Parasite",
+        language="ko",
+        spoken_languages=[{"iso_639_1": "ko", "english_name": "Korean"}],
+        countries=[{"name": "South Korea", "iso_3166_1": "KR"}],
+    )
+    _film(
+        database,
+        profile,
+        title="Unnamed Language",
+        language="lv",
+        countries=[{"name": "Latvia", "iso_3166_1": "LV"}],
+    )
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["countries"] == [
+        {"label": "Latvia", "code": "LV", "count": 1, "average_rating": None},
+        {"label": "South Korea", "code": "KR", "count": 1, "average_rating": None},
+    ]
+    # A code the payload never names falls back to the uppercased code itself.
+    assert sorted(entry["label"] for entry in stats["languages"]) == ["Korean", "LV"]
+
+
+def test_decades_are_returned_in_chronological_order(database: Session) -> None:
+    profile = _profile(database)
+    for year in (2011, 2015, 1994, 1999, 1987):
+        _film(database, profile, title=f"Film {year}", year=year)
+
+    stats = build_profile_stats(database, profile)
+
+    assert [entry["label"] for entry in stats["decades"]] == ["1980s", "1990s", "2010s"]
+    assert [entry["count"] for entry in stats["decades"]] == [1, 2, 2]
+
+
+def test_lists_are_capped_at_ten_entries_ranked_by_count(database: Session) -> None:
+    profile = _profile(database)
+    for index in range(12):
+        # Genre 0 appears once, genre 11 twelve times.
+        for _ in range(index + 1):
+            _film(database, profile, title=f"Film {index}", genres=[f"Genre {index}"])
+
+    stats = build_profile_stats(database, profile)
+
+    assert len(stats["genres"]) == 10
+    assert stats["genres"][0]["label"] == "Genre 11"
+    assert stats["genres"][-1]["label"] == "Genre 2"
+    assert stats["totals"]["distinct_directors"] is None
+
+
+def test_rewatches_come_from_the_film_state_rows(database: Session) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Seen Thrice", rewatch_count=2)
+    _film(database, profile, title="Seen Once")
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["totals"]["rewatches"] == 2
+
+
+def test_letterboxd_reported_snapshot_is_returned_verbatim(database: Session) -> None:
+    profile = _profile(database)
+    profile.stats_snapshot = {"films": 1197, "hours": 2403, "directors": 779}
+    database.commit()
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["letterboxd_reported"] == {
+        "films": 1197,
+        "hours": 2403,
+        "directors": 779,
+    }
+
+
+# --- route ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(database: Session):
+    backend_main.app.dependency_overrides[backend_main.get_db] = lambda: database
+    try:
+        yield lambda user: TestClient(backend_main.app)
+    finally:
+        backend_main.app.dependency_overrides.clear()
+
+
+def _tracked_user(database: Session, profile: Optional[Profile]) -> ClerkUser:
+    app_user = AppUser(clerk_user_id="user_one", primary_profile_required=False)
+    database.add(app_user)
+    database.flush()
+    if profile is not None:
+        database.add(
+            UserTrackedProfile(
+                user_id=app_user.id,
+                profile_id=profile.id,
+                source="direct",
+            )
+        )
+    database.commit()
+    return ClerkUser(
+        user_id="user_one",
+        session_id="session",
+        is_admin=False,
+        letterboxd_username=None,
+    )
+
+
+def test_route_serves_the_payload_for_a_tracked_profile(database: Session, client) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Tracked Film", rating=4.0, runtime=120)
+    user = _tracked_user(database, profile)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client(user).get(f"/api/profiles/{profile.username}/stats")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["username"] == profile.username
+    assert payload["totals"]["hours_watched"] == 2.0
+    assert set(payload) == {
+        "username",
+        "coverage",
+        "totals",
+        "top_directors",
+        "top_actors",
+        "top_studios",
+        "genres",
+        "countries",
+        "languages",
+        "decades",
+        "highest_rated",
+        "letterboxd_reported",
+    }
+
+
+def test_route_refuses_an_untracked_profile(database: Session, client) -> None:
+    profile = _profile(database)
+    user = _tracked_user(database, None)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client(user).get(f"/api/profiles/{profile.username}/stats")
+
+    assert response.status_code == 403

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -247,6 +247,69 @@ export const profileAnalysis = {
   ],
 };
 
+export const profileStats = {
+  username: 'alpha',
+  coverage: {
+    films_total: 1_200,
+    films_enriched: 1_020,
+    enrichment_ratio: 0.85,
+    dated_events: 2_000,
+    rated_films: 900,
+  },
+  totals: {
+    films: 1_200,
+    hours_watched: 2_118.5,
+    runtime_coverage: 0.94,
+    distinct_directors: 640,
+    distinct_actors: 5_400,
+    distinct_countries: 48,
+    distinct_languages: 31,
+    distinct_studios: 410,
+    longest_streak_weeks: 17,
+    multi_film_days: 88,
+    rewatches: 64,
+    average_rating: 3.72,
+  },
+  top_directors: [
+    { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
+    { name: 'Agnès Varda', count: 12, average_rating: 4.1 },
+    { name: 'Mani Ratnam', count: 9, average_rating: null },
+  ],
+  top_actors: [
+    { name: 'Toshiro Mifune', count: 14, average_rating: 4.2 },
+    { name: 'Tilda Swinton', count: 11, average_rating: 3.9 },
+  ],
+  top_studios: [{ name: 'Studio Ghibli', count: 16, average_rating: 4.4 }],
+  genres: [
+    { label: 'Drama', count: 420, average_rating: 3.9 },
+    { label: 'Comedy', count: 210, average_rating: 3.4 },
+    { label: 'Horror', count: 95, average_rating: null },
+  ],
+  countries: [
+    { label: 'United States', code: 'US', count: 520, average_rating: 3.6 },
+    { label: 'Japan', code: 'JP', count: 180, average_rating: 4.1 },
+    { label: 'India', code: null, count: 120, average_rating: 3.8 },
+  ],
+  languages: [
+    { label: 'English', count: 700, average_rating: 3.6 },
+    { label: 'Japanese', count: 160, average_rating: 4.1 },
+  ],
+  decades: [
+    { label: '1970s', count: 90, average_rating: 4 },
+    { label: '1980s', count: 140, average_rating: 3.8 },
+    { label: '1990s', count: 260, average_rating: 3.9 },
+    { label: '2000s', count: 310, average_rating: 3.6 },
+  ],
+  highest_rated: {
+    genre: { label: 'Documentary', count: 34, average_rating: 4.15 },
+    decade: { label: '1970s', count: 90, average_rating: 4 },
+    director: { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
+  },
+  // Deliberately overlaps our figures: `directors` agrees, `hours` and
+  // `longest_streak` do not, so both comparison branches render.
+  letterboxd_reported: { hours: 2_130, directors: 640, longest_streak: 19 },
+};
+
 const dataCoverage = {
   generated_at: '2026-07-29T12:00:00Z',
   overall_score: 100,
@@ -614,6 +677,15 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   if (path === '/api/follow-graph/suggestions') return json(route, { suggestions: [] });
   if (path === '/api/follow-graph/mutuals') {
     return json(route, { profiles: [], pairs: [], rollups: {} });
+  }
+  {
+    // Patron-only stats, computed for everyone. Contract-shaped so the
+    // Analysis panel renders (and its Letterboxd comparison fires) without
+    // console noise from an unmocked request.
+    const statsMatch = path.match(/^\/api\/profiles\/([^/]+)\/stats$/);
+    if (statsMatch) {
+      return json(route, { ...profileStats, username: decodeURIComponent(statsMatch[1]) });
+    }
   }
   {
     const archiveMatch = path.match(/^\/api\/profiles\/([^/]+)\/archive$/);

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { BarChart3, Trophy } from 'lucide-react';
+
+import { profileStatsApi } from '../../services/api';
+import type {
+  ProfileStatsBucket,
+  ProfileStatsCountryBucket,
+  ProfileStatsPerson,
+} from '../../services/api';
+
+/** Below this, the metadata gap is worth saying once at the panel level. */
+const ENRICHMENT_CAVEAT_THRESHOLD = 0.95;
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatHours(value: number): string {
+  return value >= 10 ? Math.round(value).toLocaleString() : value.toFixed(1);
+}
+
+/**
+ * Floors rather than rounds: a partial figure must never present itself as a
+ * confident "100%" just because it is close.
+ */
+function formatRatio(ratio: number): string {
+  const bounded = Math.max(0, Math.min(1, ratio));
+  return `${Math.floor(bounded * 100)}%`;
+}
+
+function normalizeKey(key: string): string {
+  return key
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Letterboxd's stats page labels its figures differently per account tier, so
+ * each of our headline stats accepts a few plausible key spellings. Anything
+ * that does not match is simply not compared — the profile header already
+ * renders the raw snapshot in full.
+ */
+const REPORTED_KEY_ALIASES: Record<string, string[]> = {
+  films: ['films', 'films_watched', 'total_films', 'watched'],
+  hours: ['hours', 'hours_watched', 'total_hours'],
+  directors: ['directors', 'distinct_directors', 'unique_directors'],
+  countries: ['countries', 'distinct_countries', 'unique_countries'],
+  longest_streak: ['longest_streak', 'longest_streak_weeks', 'longest_streak_of_weeks'],
+  multi_film_days: ['multi_film_days', '2_film_days', 'two_film_days'],
+};
+
+function buildReportedIndex(
+  reported: Record<string, number | string | null> | null | undefined,
+): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const [key, value] of Object.entries(reported ?? {})) {
+    if (value === null || value === undefined || value === '') continue;
+    index.set(
+      normalizeKey(key),
+      typeof value === 'number' ? formatCount(value) : String(value),
+    );
+  }
+  return index;
+}
+
+/**
+ * Letterboxd's own figure for one of our stats, phrased as a comparison. When
+ * the two agree we say so instead of printing the same number twice.
+ */
+function reportedNote(
+  index: Map<string, string>,
+  statKey: string,
+  ourValue: string,
+): string | null {
+  for (const alias of REPORTED_KEY_ALIASES[statKey] ?? []) {
+    const value = index.get(alias);
+    if (value === undefined) continue;
+    return value === ourValue ? 'matches Letterboxd' : `Letterboxd: ${value}`;
+  }
+  return null;
+}
+
+type HeadlineStat = {
+  key: string;
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+type BarRow = {
+  id: string;
+  label: string;
+  title: string;
+  count: number;
+  averageRating: number | null;
+};
+
+function toBarRows(buckets: ProfileStatsBucket[]): BarRow[] {
+  return buckets.map((bucket) => ({
+    id: bucket.label,
+    label: bucket.label,
+    title: bucket.label,
+    count: bucket.count,
+    averageRating: bucket.average_rating,
+  }));
+}
+
+function toCountryRows(buckets: ProfileStatsCountryBucket[]): BarRow[] {
+  return buckets.map((bucket) => ({
+    id: bucket.code ?? bucket.label,
+    label: bucket.label,
+    title: bucket.code ? `${bucket.label} (${bucket.code})` : bucket.label,
+    count: bucket.count,
+    averageRating: bucket.average_rating,
+  }));
+}
+
+function AverageRating({ value }: { value: number | null }) {
+  return (
+    <span
+      className="w-8 shrink-0 text-right text-[11px] tabular-nums text-white/35"
+      title={value === null ? undefined : `Average rating ${value.toFixed(1)}`}
+    >
+      {value === null ? '' : value.toFixed(1)}
+    </span>
+  );
+}
+
+function RankedList({
+  title,
+  subtitle,
+  people,
+}: {
+  title: string;
+  subtitle: string | null;
+  people: ProfileStatsPerson[];
+}) {
+  if (people.length === 0) return null;
+
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
+      {subtitle ? <p className="mt-0.5 text-[11px] text-white/30">{subtitle}</p> : null}
+      <ol className="mt-2 space-y-1.5">
+        {people.map((person, index) => (
+          <li key={person.name} className="flex items-center gap-2 text-sm">
+            <span className="w-4 shrink-0 text-right text-[11px] tabular-nums text-white/25">
+              {index + 1}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-white/80" title={person.name}>
+              {person.name}
+            </span>
+            <span className="w-8 shrink-0 text-right text-xs tabular-nums text-white/45">
+              {formatCount(person.count)}
+            </span>
+            <AverageRating value={person.average_rating} />
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function BreakdownBars({
+  title,
+  subtitle,
+  rows,
+}: {
+  title: string;
+  subtitle: string | null;
+  rows: BarRow[];
+}) {
+  if (rows.length === 0) return null;
+
+  const largest = rows.reduce((max, row) => Math.max(max, row.count), 0);
+
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
+      {subtitle ? <p className="mt-0.5 text-[11px] text-white/30">{subtitle}</p> : null}
+      <ul className="mt-2 space-y-1.5">
+        {rows.map((row) => (
+          <li key={row.id} className="flex items-center gap-2 text-sm">
+            <span className="min-w-0 flex-1 truncate text-white/80" title={row.title}>
+              {row.label}
+            </span>
+            <span className="h-1.5 w-14 shrink-0 overflow-hidden rounded-full bg-white/10">
+              <span
+                className="block h-full rounded-full bg-cinema-500"
+                style={{ width: `${largest > 0 ? Math.max(4, Math.round((row.count / largest) * 100)) : 4}%` }}
+              />
+            </span>
+            <span className="w-8 shrink-0 text-right text-xs tabular-nums text-white/45">
+              {formatCount(row.count)}
+            </span>
+            <AverageRating value={row.averageRating} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The numbers Letterboxd puts behind its Patron-only stats page, computed for
+ * every tracked member from their synced history. The endpoint is optional
+ * from the page's point of view: any failure, and the panel simply is not
+ * there, the same way the follow network bows out.
+ */
+const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
+  username,
+  delay = 0,
+}) => {
+  const statsQuery = useQuery({
+    queryKey: ['profile-stats', username],
+    queryFn: () => profileStatsApi.getStats(username),
+    enabled: Boolean(username),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const stats = statsQuery.data;
+
+  // No hooks below this line: the panel disappears entirely when the endpoint
+  // is unavailable or has nothing worth showing.
+  if (statsQuery.isError || !stats) return null;
+
+  const { coverage, totals, highest_rated: highestRated } = stats;
+  if (totals.films === 0 && coverage.films_total === 0) return null;
+
+  const reportedIndex = buildReportedIndex(stats.letterboxd_reported);
+
+  const filmsValue = formatCount(totals.films);
+  const hoursValue = totals.hours_watched === null ? null : formatHours(totals.hours_watched);
+  const directorsValue = totals.distinct_directors === null
+    ? null
+    : formatCount(totals.distinct_directors);
+  const countriesValue = totals.distinct_countries === null
+    ? null
+    : formatCount(totals.distinct_countries);
+  const streakValue = totals.longest_streak_weeks === null
+    ? null
+    : formatCount(totals.longest_streak_weeks);
+  const multiFilmDaysValue = totals.multi_film_days === null
+    ? null
+    : formatCount(totals.multi_film_days);
+
+  const headlineCandidates: Array<HeadlineStat | null> = [
+    { key: 'films', label: 'Films', value: filmsValue },
+    hoursValue !== null
+      ? {
+          key: 'hours',
+          label: 'Hours watched',
+          value: hoursValue,
+          // Never let a partial runtime sum read as a complete one.
+          hint: totals.runtime_coverage < 1
+            ? `from ${formatRatio(totals.runtime_coverage)} of films with runtime data`
+            : undefined,
+        }
+      : null,
+    directorsValue !== null ? { key: 'directors', label: 'Directors', value: directorsValue } : null,
+    countriesValue !== null ? { key: 'countries', label: 'Countries', value: countriesValue } : null,
+    streakValue !== null
+      ? {
+          key: 'longest_streak',
+          label: 'Longest streak',
+          value: streakValue,
+          hint: 'consecutive weeks',
+        }
+      : null,
+    multiFilmDaysValue !== null
+      ? {
+          key: 'multi_film_days',
+          label: 'Multi-film days',
+          value: multiFilmDaysValue,
+          hint: 'days with 2+ entries',
+        }
+      : null,
+  ];
+  const headline = headlineCandidates.filter((stat): stat is HeadlineStat => stat !== null);
+
+  const footnotes = [
+    coverage.rated_films > 0 ? `${formatCount(coverage.rated_films)} rated` : null,
+    totals.average_rating !== null ? `${totals.average_rating.toFixed(2)} average rating` : null,
+    totals.rewatches > 0 ? `${formatCount(totals.rewatches)} rewatches` : null,
+    coverage.dated_events > 0 ? `${formatCount(coverage.dated_events)} dated entries` : null,
+  ].filter((item): item is string => item !== null);
+
+  const genreRows = toBarRows(stats.genres ?? []);
+  const countryRows = toCountryRows(stats.countries ?? []);
+  const languageRows = toBarRows(stats.languages ?? []);
+  const decadeRows = toBarRows(stats.decades ?? []);
+
+  const topDirectors = stats.top_directors ?? [];
+  const topActors = stats.top_actors ?? [];
+  const topStudios = stats.top_studios ?? [];
+  const hasPeople = topDirectors.length > 0 || topActors.length > 0 || topStudios.length > 0;
+  const hasBreakdowns = genreRows.length > 0
+    || countryRows.length > 0
+    || languageRows.length > 0
+    || decadeRows.length > 0;
+
+  const highlightCandidates: Array<{ label: string; name: string; count: number; average: number } | null> = [
+    highestRated?.genre
+      ? {
+          label: 'Highest-rated genre',
+          name: highestRated.genre.label,
+          count: highestRated.genre.count,
+          average: highestRated.genre.average_rating,
+        }
+      : null,
+    highestRated?.decade
+      ? {
+          label: 'Highest-rated decade',
+          name: highestRated.decade.label,
+          count: highestRated.decade.count,
+          average: highestRated.decade.average_rating,
+        }
+      : null,
+    highestRated?.director
+      ? {
+          label: 'Highest-rated director',
+          name: highestRated.director.name,
+          count: highestRated.director.count,
+          average: highestRated.director.average_rating,
+        }
+      : null,
+  ];
+  const highlights = highlightCandidates.filter(
+    (item): item is { label: string; name: string; count: number; average: number } => item !== null,
+  );
+
+  // One caveat for the whole panel rather than a footnote on every row.
+  const enrichmentCaveat = coverage.films_total > 0
+    && coverage.enrichment_ratio < ENRICHMENT_CAVEAT_THRESHOLD
+    ? `Film metadata is in for ${formatRatio(coverage.enrichment_ratio)} of ${formatCount(coverage.films_total)} synced films (${formatCount(coverage.films_enriched)}), so the credits, country, language and runtime figures below are drawn from that subset.`
+    : null;
+
+  return (
+    <motion.section
+      className="analysis-panel"
+      aria-labelledby="profile-stats-title"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <div className="flex items-center gap-2">
+        <BarChart3 className="h-5 w-5 text-cinema-400" aria-hidden="true" />
+        <h2 id="profile-stats-title" className="text-xl font-semibold text-white">
+          Profile stats
+        </h2>
+      </div>
+      <p className="mt-1 text-sm text-white/60">
+        The figures Letterboxd keeps behind Patron, computed here from @{username}
+        &rsquo;s synced history.
+      </p>
+
+      {enrichmentCaveat ? (
+        <p className="mt-3 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs leading-5 text-white/45">
+          {enrichmentCaveat}
+        </p>
+      ) : null}
+
+      <dl className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        {headline.map((stat) => {
+          const comparison = reportedNote(reportedIndex, stat.key, stat.value);
+          return (
+            <div
+              key={stat.key}
+              className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-center"
+            >
+              <dt className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+                {stat.label}
+              </dt>
+              <dd className="mt-1 text-lg font-bold text-white">{stat.value}</dd>
+              {stat.hint ? <p className="mt-0.5 text-[10px] leading-4 text-white/35">{stat.hint}</p> : null}
+              {comparison ? (
+                <p className="mt-0.5 text-[10px] leading-4 text-white/25">{comparison}</p>
+              ) : null}
+            </div>
+          );
+        })}
+      </dl>
+
+      {footnotes.length > 0 ? (
+        <p className="mt-3 text-xs text-white/35">{footnotes.join(' · ')}</p>
+      ) : null}
+
+      {hasPeople ? (
+        <div className="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+          <RankedList
+            title="Top directors"
+            subtitle={totals.distinct_directors ? `of ${formatCount(totals.distinct_directors)} seen` : null}
+            people={topDirectors}
+          />
+          <RankedList
+            title="Top actors"
+            subtitle={totals.distinct_actors ? `of ${formatCount(totals.distinct_actors)} seen` : null}
+            people={topActors}
+          />
+          <RankedList
+            title="Top studios"
+            subtitle={totals.distinct_studios ? `of ${formatCount(totals.distinct_studios)} seen` : null}
+            people={topStudios}
+          />
+        </div>
+      ) : null}
+
+      {hasBreakdowns ? (
+        <div className="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+          <BreakdownBars title="Genres" subtitle={null} rows={genreRows} />
+          <BreakdownBars
+            title="Countries"
+            subtitle={totals.distinct_countries ? `of ${formatCount(totals.distinct_countries)} seen` : null}
+            rows={countryRows}
+          />
+          <BreakdownBars
+            title="Languages"
+            subtitle={totals.distinct_languages ? `of ${formatCount(totals.distinct_languages)} heard` : null}
+            rows={languageRows}
+          />
+          <BreakdownBars title="Decades" subtitle={null} rows={decadeRows} />
+        </div>
+      ) : null}
+
+      {highlights.length > 0 ? (
+        <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {highlights.map((highlight) => (
+            <div
+              key={highlight.label}
+              className="rounded-xl border border-cinema-400/20 bg-cinema-500/10 px-3 py-2.5"
+            >
+              <p className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wide text-cinema-200">
+                <Trophy className="h-3 w-3" aria-hidden="true" />
+                {highlight.label}
+              </p>
+              <p className="mt-1 truncate text-sm font-semibold text-white" title={highlight.name}>
+                {highlight.name}
+              </p>
+              <p className="mt-0.5 text-[11px] text-white/40">
+                {highlight.average.toFixed(2)} average across {formatCount(highlight.count)} films
+              </p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {reportedIndex.size > 0 ? (
+        <p className="mt-5 text-[11px] leading-5 text-white/30">
+          Muted figures are Letterboxd&rsquo;s own published numbers, shown for comparison. They
+          count a member&rsquo;s whole history; ours count what has been synced here.
+        </p>
+      ) : null}
+    </motion.section>
+  );
+};
+
+export default ProfileStatsPanel;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1188,4 +1188,86 @@ export const memberArchiveApi = {
   },
 };
 
+/** How much of the profile the stats below could actually be computed from. */
+export interface ProfileStatsCoverage {
+  films_total: number;
+  films_enriched: number;
+  /** 0..1 share of synced films carrying TMDB metadata. */
+  enrichment_ratio: number;
+  dated_events: number;
+  rated_films: number;
+}
+
+export interface ProfileStatsTotals {
+  films: number;
+  /** Null when no film in the profile has a known runtime. */
+  hours_watched: number | null;
+  /** 0..1 share of films that contributed runtime to `hours_watched`. */
+  runtime_coverage: number;
+  distinct_directors: number | null;
+  distinct_actors: number | null;
+  distinct_countries: number | null;
+  distinct_languages: number | null;
+  distinct_studios: number | null;
+  longest_streak_weeks: number | null;
+  multi_film_days: number | null;
+  rewatches: number;
+  average_rating: number | null;
+}
+
+export interface ProfileStatsPerson {
+  name: string;
+  count: number;
+  average_rating: number | null;
+}
+
+export interface ProfileStatsBucket {
+  label: string;
+  count: number;
+  average_rating: number | null;
+}
+
+export interface ProfileStatsCountryBucket extends ProfileStatsBucket {
+  code: string | null;
+}
+
+/**
+ * Buckets the API judged large enough to call a favourite. The server only
+ * fills these once a bucket has at least three films, so `average_rating` is
+ * always present here even though it is nullable in the plain buckets.
+ */
+export interface ProfileStatsHighestRated {
+  genre: { label: string; count: number; average_rating: number } | null;
+  decade: { label: string; count: number; average_rating: number } | null;
+  director: { name: string; count: number; average_rating: number } | null;
+}
+
+export interface ProfileStatsResponse {
+  username: string;
+  coverage: ProfileStatsCoverage;
+  totals: ProfileStatsTotals;
+  top_directors: ProfileStatsPerson[];
+  top_actors: ProfileStatsPerson[];
+  top_studios: ProfileStatsPerson[];
+  genres: ProfileStatsBucket[];
+  countries: ProfileStatsCountryBucket[];
+  languages: ProfileStatsBucket[];
+  /** Ascending by decade, labelled like "1990s". */
+  decades: ProfileStatsBucket[];
+  highest_rated: ProfileStatsHighestRated;
+  /**
+   * Letterboxd's own stats-page figures, verbatim, for side-by-side
+   * comparison. Null when that Patron-only page was never scraped, and the
+   * key set varies by account, so read it defensively.
+   */
+  letterboxd_reported: Record<string, number | string | null> | null;
+}
+
+export const profileStatsApi = {
+  getStats: async (username: string): Promise<ProfileStatsResponse> => {
+    const response = await api.get(`/api/profiles/${encodeURIComponent(username)}/stats`);
+    return response.data;
+  },
+};
+
 export default api;

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -17,6 +17,7 @@ import AdminScopeToggle from '../components/AdminScopeToggle';
 import ProfileHeader from '../components/ProfileHeader';
 import ProfilePicker from '../components/ProfilePicker';
 import ArchivePanel from '../components/insights/ArchivePanel';
+import ProfileStatsPanel from '../components/insights/ProfileStatsPanel';
 import TasteProfilePanel from '../components/insights/TasteProfilePanel';
 import TagsPanel, { TagChipList } from '../components/insights/TagsPanel';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
@@ -163,6 +164,8 @@ const Analysis: React.FC = () => {
             tagCount={analysis.tag_counts?.length}
             delay={0.05}
           />
+
+          <ProfileStatsPanel username={analysis.username} delay={0.08} />
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             <StatsCard


### PR DESCRIPTION
Letterboxd gates its stats page behind Patron, so scraping only ever reached **2 of 17** profiles. Every figure on that page is derivable from data we already hold — 4,554 enriched films with runtime, credits, countries, languages and release dates, plus our own watch history.

`GET /api/profiles/{username}/stats` returns hours watched, distinct directors/actors/countries/languages/studios, longest streak, multi-film days, ranked people, per-genre/country/language/decade breakdowns, and highest-rated callouts — **for anyone**. Where a scraped Patron snapshot exists it ships alongside as a comparison, not a source.

## Validated against Letterboxd's own numbers

| Figure | Letterboxd | Ours | |
|---|---|---|---|
| Films | 1,197 | **1,197** | exact |
| Longest streak | 22w | **22w** | exact |
| Multi-film days | 122 | **122** | exact |
| Hours | 2,403 | 2,182.6 | over the 95.4% of films whose runtime we hold |
| Directors | 779 | 661 | some enriched films carry no director credit in TMDB |
| Countries | 43 | 45 | TMDB counts co-productions generously |

The three computed purely from our watch history match exactly — including the consecutive-ISO-week streak. The metadata-dependent ones sit exactly where enrichment coverage predicts.

## Honesty constraints
- `runtime_coverage` ships with the payload; the panel qualifies hours rather than presenting a partial sum as complete
- Dimensions with no evidence return `null`, not `0`
- A highest-rated callout needs ≥3 rated films — one five-star film is not a favourite genre
- Studios and full language names are read by **JSON path in the database** (`raw_payload.details`), not by loading raw payloads (33 MB for one profile)

## Verification
**338 backend tests pass** (25 new: streak gaps, ISO-year boundaries, runtime honesty, the ≥3 floor, zero enrichment, malformed payloads, `job=="Director"` filtering, route access). `tsc` + `eslint` + `next build` green. Panel degrades to nothing on error or missing enrichment. e2e fixture added so the smoke suite's zero-console-error assertion holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)