### PR TITLE
Rating comparison against your circle and Letterboxd, plus network graph fixes

### DIFF
--- a/alembic/versions/20260801_0015_add_letterboxd_film_ratings.py
+++ b/alembic/versions/20260801_0015_add_letterboxd_film_ratings.py
@@ -1,0 +1,50 @@
+"""Add Letterboxd's own crowd rating per film.
+
+Letterboxd publishes a weighted average and rating count for every film on
+its rating-histogram include. The figure is film-level and shared by every
+profile, so one fetch serves the whole library and belongs on ``movies``
+rather than on any per-profile row.
+
+Revision ID: 20260801_0015
+Revises: 20260801_0014
+Create Date: 2026-08-01 12:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260801_0015"
+down_revision: Union[str, None] = "20260801_0014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("movies", sa.Column("letterboxd_average_rating", sa.Float(), nullable=True))
+    op.add_column("movies", sa.Column("letterboxd_rating_count", sa.BigInteger(), nullable=True))
+    op.add_column(
+        "movies",
+        sa.Column("letterboxd_rating_synced_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_check_constraint(
+        "ck_movies_letterboxd_average_range",
+        "movies",
+        "letterboxd_average_rating IS NULL "
+        "OR (letterboxd_average_rating >= 0 AND letterboxd_average_rating <= 5)",
+    )
+    op.create_check_constraint(
+        "ck_movies_letterboxd_rating_count_nonnegative",
+        "movies",
+        "letterboxd_rating_count IS NULL OR letterboxd_rating_count >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_movies_letterboxd_rating_count_nonnegative", "movies", type_="check")
+    op.drop_constraint("ck_movies_letterboxd_average_range", "movies", type_="check")
+    op.drop_column("movies", "letterboxd_rating_synced_at")
+    op.drop_column("movies", "letterboxd_rating_count")
+    op.drop_column("movies", "letterboxd_average_rating")

--- a/backend/api/dependencies.py
+++ b/backend/api/dependencies.py
@@ -1,0 +1,28 @@
+"""Shared FastAPI dependencies for route modules.
+
+``get_active_upload_user`` lived in ``main`` while only ``main`` used it, but a
+route module cannot import from ``main`` — ``main`` imports the routers first,
+so the reference does not exist yet. Applying the dependency at the
+``include_router`` call worked around that and made the route's auth invisible
+to anything inspecting the route itself. Keeping it here lets every route
+declare its own trust boundary directly.
+"""
+from __future__ import annotations
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_upload_user
+from database.connection import get_db
+from services.profile_access import ensure_app_user
+
+
+def get_active_upload_user(
+    user: ClerkUser = Depends(get_upload_user),
+    db: Session = Depends(get_db),
+) -> ClerkUser:
+    """Reject disabled Clerk admins while preserving ingestion-token uploads."""
+
+    if user.user_id != "ingestion-token":
+        ensure_app_user(db, user)
+    return user

--- a/backend/api/routes/film_ratings.py
+++ b/backend/api/routes/film_ratings.py
@@ -1,0 +1,175 @@
+"""Delivery path for Letterboxd's own crowd rating per film.
+
+Letterboxd challenges datacenter IPs, which is why every Letterboxd read in this
+repo happens on a residential machine and is then uploaded (``/upload/``). TMDB
+enrichment can run on the production server because TMDB has no such
+restriction; the Letterboxd rating backfill in ``services.letterboxd_ratings``
+cannot, so it writes ``movies.letterboxd_average_rating`` into the *local*
+database. This endpoint is how those values reach production.
+
+A film's crowd rating is film-level and shared by every profile, so this carries
+no per-profile data at all: one modest batch of ``(slug, average, count)`` rows
+that any profile's comparison can then read.
+
+Auth is deliberately the same trust boundary as ``/upload/``: ``main`` mounts
+this router behind ``get_active_upload_user`` (ingestion token, or an enabled
+Clerk admin), and the route additionally declares ``get_upload_user`` itself so
+the token gate travels with the router even if the mount is ever rewritten.
+``backend/tests/test_route_access_matrix.py`` pins the mounted dependency.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+import logging
+from typing import Dict, List, Optional, Tuple
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_upload_user
+from database.connection import get_db
+from database.models import Movie
+from services.letterboxd_ratings import resolve_slug
+
+
+LOGGER = logging.getLogger("spyboxd.film_ratings")
+
+router = APIRouter(prefix="/api/films", tags=["film ratings"])
+
+# One request must never be unbounded: the pusher chunks the library, and the
+# whole catalogue is only a few thousand films.
+MAX_BATCH_SIZE = 1000
+# Letterboxd's scale. The column carries a matching CHECK constraint
+# (``ck_movies_letterboxd_average_range``), so a value outside this range has to
+# be rejected here rather than handed to the database as a 500.
+MIN_AVERAGE_RATING = 0.0
+MAX_AVERAGE_RATING = 5.0
+# ``letterboxd_rating_count`` is a BIGINT with a non-negative CHECK. The most
+# rated film on the site sits in the low millions, so anything past a trillion
+# is a corrupt payload rather than a real count.
+MAX_RATING_COUNT = 10**12
+
+
+class FilmRatingEntry(BaseModel):
+    """One film's crowd rating as scraped on the residential machine."""
+
+    slug: str = Field(..., max_length=250)
+    average_rating: Optional[float] = None
+    rating_count: Optional[int] = None
+    synced_at: Optional[datetime] = None
+
+
+class FilmRatingBatch(BaseModel):
+    ratings: List[FilmRatingEntry] = Field(..., min_length=1, max_length=MAX_BATCH_SIZE)
+
+
+def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _movies_by_slug(db: Session, slugs: set[str]) -> Dict[str, List[Movie]]:
+    """Load every film whose slug matches, case-insensitively, in one query."""
+
+    if not slugs:
+        return {}
+    movies = (
+        db.query(Movie)
+        .filter(func.lower(Movie.letterboxd_slug).in_(sorted(slugs)))
+        .all()
+    )
+    mapping: Dict[str, List[Movie]] = defaultdict(list)
+    for movie in movies:
+        mapping[(movie.letterboxd_slug or "").lower()].append(movie)
+    return mapping
+
+
+@router.post("/letterboxd-ratings")
+def ingest_letterboxd_ratings(
+    payload: FilmRatingBatch,
+    db: Session = Depends(get_db),
+    _user: ClerkUser = Depends(get_upload_user),
+):
+    """Apply a batch of locally scraped Letterboxd film ratings.
+
+    Every count is per submitted entry, and ``updated + unmatched + skipped``
+    always equals ``received``:
+
+    * ``updated`` — matched a film by ``movies.letterboxd_slug`` (case
+      insensitively) and wrote the average.
+    * ``unmatched`` — production has never seen that film. Expected drift
+      between the two databases, so it is reported, never fatal.
+    * ``skipped`` — the entry carried nothing safely writable: no usable slug,
+      an average outside Letterboxd's 0-5 scale, an impossible rating count, or
+      a null average.
+
+    A null average is "Letterboxd did not publish one", not zero, so it never
+    overwrites a value production already holds — the same rule the local
+    backfill applies in ``services.letterboxd_ratings``. A null ``rating_count``
+    likewise leaves the stored count alone. ``synced_at`` records when the
+    residential machine read the figure, falling back to the request time.
+    """
+
+    received = len(payload.ratings)
+    request_time = datetime.now(timezone.utc)
+
+    # (slug, average, count, synced_at) for entries worth writing.
+    prepared: List[Tuple[str, float, Optional[int], datetime]] = []
+    skipped = 0
+    for entry in payload.ratings:
+        slug = resolve_slug(entry.slug, None)
+        average = entry.average_rating
+        count = entry.rating_count
+        usable = (
+            slug is not None
+            and average is not None
+            # Written as a range test so NaN — which compares false against
+            # everything — is skipped rather than stored.
+            and MIN_AVERAGE_RATING <= average <= MAX_AVERAGE_RATING
+            and (count is None or 0 <= count <= MAX_RATING_COUNT)
+        )
+        if not usable:
+            skipped += 1
+            continue
+        prepared.append(
+            (slug.lower(), float(average), count, _as_utc(entry.synced_at) or request_time)
+        )
+
+    matches = _movies_by_slug(db, {slug for slug, _, _, _ in prepared})
+
+    updated = 0
+    unmatched = 0
+    for slug, average, count, synced_at in prepared:
+        movies = matches.get(slug)
+        if not movies:
+            unmatched += 1
+            continue
+        for movie in movies:
+            movie.letterboxd_average_rating = average
+            if count is not None:
+                movie.letterboxd_rating_count = count
+            movie.letterboxd_rating_synced_at = synced_at
+        updated += 1
+
+    try:
+        db.commit()
+    except SQLAlchemyError:
+        db.rollback()
+        # The payload is trusted-but-remote; its details never reach the client.
+        LOGGER.exception("Letterboxd film rating batch failed to persist")
+        raise HTTPException(status_code=500, detail="Failed to store Letterboxd film ratings")
+
+    return {
+        "received": received,
+        "updated": updated,
+        "unmatched": unmatched,
+        "skipped": skipped,
+    }

--- a/backend/api/routes/film_ratings.py
+++ b/backend/api/routes/film_ratings.py
@@ -11,11 +11,11 @@ A film's crowd rating is film-level and shared by every profile, so this carries
 no per-profile data at all: one modest batch of ``(slug, average, count)`` rows
 that any profile's comparison can then read.
 
-Auth is deliberately the same trust boundary as ``/upload/``: ``main`` mounts
-this router behind ``get_active_upload_user`` (ingestion token, or an enabled
-Clerk admin), and the route additionally declares ``get_upload_user`` itself so
-the token gate travels with the router even if the mount is ever rewritten.
-``backend/tests/test_route_access_matrix.py`` pins the mounted dependency.
+Auth is deliberately the same trust boundary as ``/upload/``: the route
+declares ``get_active_upload_user`` (ingestion token, or an enabled Clerk
+admin) directly, so the gate is visible on the route itself rather than
+depending on how it happens to be mounted.
+``backend/tests/test_route_access_matrix.py`` pins it.
 """
 
 from __future__ import annotations
@@ -31,7 +31,8 @@ from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from auth import ClerkUser, get_upload_user
+from api.dependencies import get_active_upload_user
+from auth import ClerkUser
 from database.connection import get_db
 from database.models import Movie
 from services.letterboxd_ratings import resolve_slug
@@ -96,7 +97,7 @@ def _movies_by_slug(db: Session, slugs: set[str]) -> Dict[str, List[Movie]]:
 def ingest_letterboxd_ratings(
     payload: FilmRatingBatch,
     db: Session = Depends(get_db),
-    _user: ClerkUser = Depends(get_upload_user),
+    _user: ClerkUser = Depends(get_active_upload_user),
 ):
     """Apply a batch of locally scraped Letterboxd film ratings.
 

--- a/backend/api/routes/rating_comparison.py
+++ b/backend/api/routes/rating_comparison.py
@@ -1,0 +1,37 @@
+"""Rating comparison: one profile's ratings against its circle, Letterboxd and TMDB."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from services.profile_access import require_profile_access
+from services.rating_comparison import DEFAULT_LIMIT, MAX_LIMIT, build_rating_comparison
+
+
+router = APIRouter(prefix="/api", tags=["rating comparison"])
+
+
+@router.get("/profiles/{username}/rating-comparison")
+def get_rating_comparison(
+    username: str,
+    limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """Whether this profile runs generous or harsh relative to its own circle.
+
+    Every tracked profile's rating for the same film is already held locally, so
+    each film carries a group average taken over the *other* profiles who rated
+    it -- never over this one, which would correlate a member with themselves.
+    Letterboxd can only ever show its own site-wide average, which is why this
+    comparison does not exist there.
+
+    ``summary`` also reports the same profile against Letterboxd's crowd average
+    and TMDB's (halved from /10 onto the 5-point scale). The Letterboxd figures
+    stay null until that backfill lands; everything else is unaffected.
+    """
+
+    profile = require_profile_access(db, user, username)
+    return build_rating_comparison(db, profile, limit=limit)

--- a/backend/api/routes/rating_comparison.py
+++ b/backend/api/routes/rating_comparison.py
@@ -1,4 +1,4 @@
-"""Rating comparison: one profile's ratings against its circle, Letterboxd and TMDB."""
+"""Rating comparison: one profile's ratings against its circle and Letterboxd."""
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Query
@@ -28,9 +28,10 @@ def get_rating_comparison(
     Letterboxd can only ever show its own site-wide average, which is why this
     comparison does not exist there.
 
-    ``summary`` also reports the same profile against Letterboxd's crowd average
-    and TMDB's (halved from /10 onto the 5-point scale). The Letterboxd figures
-    stay null until that backfill lands; everything else is unaffected.
+    ``summary`` also reports the same profile against Letterboxd's own crowd
+    average, the single external reference point here. Those figures stay null
+    for any film the crowd-average backfill has not reached; everything else is
+    unaffected.
     """
 
     profile = require_profile_access(db, user, username)

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -570,6 +570,12 @@ class Movie(Base):
     poster_url = Column(String(500), nullable=True)
     tmdb_id = Column(BigInteger, nullable=True)
     imdb_id = Column(String(32), nullable=True)
+    # Letterboxd's own crowd rating for the film, from its rating-histogram
+    # include. Film-level and shared by every profile, so one fetch serves the
+    # whole library.
+    letterboxd_average_rating = Column(Float, nullable=True)
+    letterboxd_rating_count = Column(BigInteger, nullable=True)
+    letterboxd_rating_synced_at = Column(DateTime(timezone=True), nullable=True)
     tmdb_lookup_attempted_at = Column(DateTime(timezone=True), nullable=True)
     tmdb_lookup_expires_at = Column(DateTime(timezone=True), nullable=True)
     tmdb_lookup_key = Column(String(64), nullable=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Depends, Query, Response
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
+from api.dependencies import get_active_upload_user
 from api.routes.activity import router as activity_router
 from api.routes.film_ratings import router as film_ratings_router
 from api.routes.follow_graph import router as follow_graph_router
@@ -70,17 +71,6 @@ _PROFILE_DIRECTORY_COMPONENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}")
 
 class _OwnerExportPublicationConsentRequired(PermissionError):
     """Expected upload validation failure with a fixed, public-safe message."""
-
-
-def get_active_upload_user(
-    user: ClerkUser = Depends(get_upload_user),
-    db: Session = Depends(get_db),
-) -> ClerkUser:
-    """Reject disabled Clerk admins while preserving ingestion-token uploads."""
-
-    if user.user_id != "ingestion-token":
-        ensure_app_user(db, user)
-    return user
 
 
 def _remove_scraped_profile_directory(username: str) -> None:
@@ -395,7 +385,7 @@ app.include_router(rating_comparison_router)
 # Letterboxd film ratings can only be scraped from a residential IP, so they
 # arrive over the same ingestion-token boundary as /upload/ rather than being
 # enriched on this server the way TMDB data is.
-app.include_router(film_ratings_router, dependencies=[Depends(get_active_upload_user)])
+app.include_router(film_ratings_router)
 
 @app.get("/health")
 async def health_check():

--- a/backend/main.py
+++ b/backend/main.py
@@ -15,6 +15,7 @@ from fastapi import FastAPI, UploadFile, File, Form, HTTPException, Depends, Que
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from api.routes.activity import router as activity_router
+from api.routes.film_ratings import router as film_ratings_router
 from api.routes.follow_graph import router as follow_graph_router
 from api.routes.insights import router as insights_router
 from api.routes.member_archive import router as member_archive_router
@@ -391,6 +392,10 @@ app.include_router(follow_graph_router)
 app.include_router(member_archive_router)
 app.include_router(profile_stats_router)
 app.include_router(rating_comparison_router)
+# Letterboxd film ratings can only be scraped from a residential IP, so they
+# arrive over the same ingestion-token boundary as /upload/ rather than being
+# enriched on this server the way TMDB data is.
+app.include_router(film_ratings_router, dependencies=[Depends(get_active_upload_user)])
 
 @app.get("/health")
 async def health_check():

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from api.routes.insights import router as insights_router
 from api.routes.member_archive import router as member_archive_router
 from api.routes.profile_access import router as profile_access_router
 from api.routes.profile_stats import router as profile_stats_router
+from api.routes.rating_comparison import router as rating_comparison_router
 from auth import ClerkUser, get_admin_user, get_current_user, get_upload_user
 from database.connection import engine, get_db, init_db
 from database.models import Movie, Profile, ProfileFavoriteMovie
@@ -389,6 +390,7 @@ app.include_router(profile_access_router)
 app.include_router(follow_graph_router)
 app.include_router(member_archive_router)
 app.include_router(profile_stats_router)
+app.include_router(rating_comparison_router)
 
 @app.get("/health")
 async def health_check():

--- a/backend/services/letterboxd_ratings.py
+++ b/backend/services/letterboxd_ratings.py
@@ -1,0 +1,482 @@
+"""Opt-in backfill of Letterboxd's own crowd rating for each canonical film.
+
+Never imported by the profile ingestion path. This mirrors the shape of
+``services.tmdb_enrichment``: bounded candidate selection with an expiry window,
+network work performed outside the read transaction, per-movie savepoints and
+batched commits, so a two-hour run can be interrupted and resumed.
+
+The source is Letterboxd's rating-histogram CSI include
+(``/csi/film/<slug>/rating-histogram/``), roughly 6KB against the ~300KB film
+page. Its ``averagerating`` anchor carries the authoritative phrase::
+
+    Weighted average of 4.50 based on 4,609,944 ratings
+
+Both numbers are read from that phrase alone. The per-bucket bar labels in the
+same document use abbreviated forms ("27.6K", "2.2M") and are never used as a
+rating count.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+import html as html_module
+import logging
+import re
+import time
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+from sqlalchemy.orm import Session
+
+from database.models import Movie
+
+try:
+    from curl_cffi import requests as curl_requests
+except ImportError:  # Kept for a clear local error before dependencies are installed.
+    curl_requests = None
+
+try:
+    import cloudscraper
+except ImportError:  # pragma: no cover - optional fallback only
+    cloudscraper = None
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_MAX_AGE_DAYS = 30
+DEFAULT_DELAY_SECONDS = 1.5
+DEFAULT_MAX_RETRIES = 4
+DEFAULT_BACKOFF_SECONDS = 2.0
+DEFAULT_BATCH_SIZE = 10
+DEFAULT_TIMEOUT_SECONDS = 30
+RATING_HISTOGRAM_URL_TEMPLATE = "https://letterboxd.com/csi/film/{slug}/rating-histogram/"
+
+# Letterboxd renders the weighted average only once a film has enough ratings.
+# Everything else in the include (the ten half-star buckets) is deliberately
+# ignored: its visible labels are abbreviated and lossy.
+_WEIGHTED_AVERAGE_RE = re.compile(
+    r"Weighted\s+average\s+of\s+(\d+(?:\.\d+)?)\s+based\s+on\s+([\d,]+)\s+ratings?",
+    re.IGNORECASE,
+)
+_FILM_SLUG_RE = re.compile(r"/film/([^/?#]+)")
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+class LetterboxdRatingError(RuntimeError):
+    """A film's rating histogram could not be retrieved."""
+
+
+class LetterboxdRatingParseError(RuntimeError):
+    """The histogram was retrieved but its weighted average was not usable."""
+
+
+@dataclass(frozen=True)
+class RatingCandidate:
+    movie_id: int
+    title: str
+    slug: str
+
+
+@dataclass(frozen=True)
+class ParsedRating:
+    """A film's crowd rating, where ``None`` means "Letterboxd did not say"."""
+
+    average: Optional[float]
+    count: Optional[int]
+
+    @property
+    def is_known(self) -> bool:
+        return self.average is not None
+
+
+@dataclass
+class RatingSyncStats:
+    selected: int = 0
+    skipped_no_slug: int = 0
+    fetched: int = 0
+    updated: int = 0
+    unavailable: int = 0
+    failed: int = 0
+    dry_run: bool = False
+    errors: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _aware_utc(value: Optional[datetime]) -> Optional[datetime]:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def resolve_slug(letterboxd_slug: Optional[str], letterboxd_url: Optional[str]) -> Optional[str]:
+    """Resolve a film's Letterboxd slug, falling back to its stored URL."""
+    candidate = (letterboxd_slug or "").strip().strip("/")
+    if candidate and "/" not in candidate and "?" not in candidate:
+        return candidate
+    for source in (candidate, (letterboxd_url or "").strip()):
+        if not source:
+            continue
+        match = _FILM_SLUG_RE.search(source)
+        if match:
+            resolved = match.group(1).strip("/")
+            if resolved:
+                return resolved
+    return None
+
+
+def parse_rating_histogram(document: Optional[str]) -> ParsedRating:
+    """Parse Letterboxd's weighted-average phrase out of the CSI include.
+
+    Returns an all-``None`` result when the film has too few ratings for
+    Letterboxd to publish an average (the include is then empty, or renders the
+    histogram without an ``averagerating`` anchor). That is "unknown", not zero.
+
+    Raises ``LetterboxdRatingParseError`` when the phrase is present but carries
+    a value outside Letterboxd's 0-5 scale, which would mean the markup drifted.
+    """
+    if not document:
+        return ParsedRating(average=None, count=None)
+
+    match = _WEIGHTED_AVERAGE_RE.search(html_module.unescape(document))
+    if match is None:
+        return ParsedRating(average=None, count=None)
+
+    raw_average, raw_count = match.group(1), match.group(2)
+    try:
+        average = float(raw_average)
+        count = int(raw_count.replace(",", ""))
+    except ValueError as exc:  # pragma: no cover - regex already constrains this
+        raise LetterboxdRatingParseError(f"Unreadable weighted average {raw_average!r}") from exc
+
+    if not 0.0 <= average <= 5.0:
+        raise LetterboxdRatingParseError(
+            f"Weighted average {average} is outside Letterboxd's 0-5 scale"
+        )
+    if count < 0:  # pragma: no cover - regex already constrains this
+        raise LetterboxdRatingParseError(f"Negative rating count {count}")
+    return ParsedRating(average=average, count=count)
+
+
+def _build_session():
+    """Mirror the scraper's browser impersonation; Letterboxd challenges plain requests."""
+    if curl_requests is not None:
+        session = curl_requests.Session(impersonate="chrome")
+        impersonates = True
+    elif cloudscraper is not None:
+        session = cloudscraper.create_scraper(
+            browser={"browser": "chrome", "platform": "darwin", "mobile": False}
+        )
+        impersonates = False
+    else:  # pragma: no cover - dependency error surfaced at call time
+        raise LetterboxdRatingError(
+            "curl_cffi (or cloudscraper) is required to fetch Letterboxd rating histograms"
+        )
+    session.headers.update(
+        {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Connection": "keep-alive",
+            "X-Requested-With": "XMLHttpRequest",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Ch-Ua": '"Chromium";v="124", "Google Chrome";v="124", "Not-A.Brand";v="99"',
+            "Sec-Ch-Ua-Mobile": "?0",
+            "Sec-Ch-Ua-Platform": '"macOS"',
+            "Referer": "https://letterboxd.com/",
+        }
+    )
+    return session, impersonates
+
+
+class LetterboxdRatingFetcher:
+    """Fetches one film's rating-histogram include, with retry and backoff."""
+
+    def __init__(
+        self,
+        *,
+        session: Any = None,
+        impersonates: Optional[bool] = None,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        backoff_seconds: float = DEFAULT_BACKOFF_SECONDS,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if max_retries <= 0:
+            raise ValueError("max_retries must be positive")
+        if session is None:
+            session, built_impersonates = _build_session()
+            impersonates = built_impersonates if impersonates is None else impersonates
+        self._session = session
+        self._impersonates = bool(impersonates)
+        self._max_retries = max_retries
+        self._backoff_seconds = backoff_seconds
+        self._timeout_seconds = timeout_seconds
+        self._sleep = sleeper
+
+    def fetch(self, slug: str) -> Optional[str]:
+        """Return the include's HTML, or ``None`` when Letterboxd has no such film.
+
+        Raises ``LetterboxdRatingError`` once retries are exhausted; the caller
+        treats that as a failure and leaves the stored values untouched.
+        """
+        url = RATING_HISTOGRAM_URL_TEMPLATE.format(slug=slug)
+        last_error = "unknown error"
+        for attempt in range(self._max_retries):
+            try:
+                request_kwargs: Dict[str, Any] = {"timeout": self._timeout_seconds}
+                if self._impersonates:
+                    request_kwargs["impersonate"] = "chrome"
+                response = self._session.get(url, **request_kwargs)
+                status = int(getattr(response, "status_code", 0))
+                if status in (404, 410):
+                    # A retired or renamed film page: terminal, never retried.
+                    return None
+                if status == 429 or status >= 500:
+                    last_error = f"HTTP {status}"
+                elif status >= 400:
+                    raise LetterboxdRatingError(f"HTTP {status} for {url}")
+                else:
+                    return response.text
+            except LetterboxdRatingError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - any transport error is retryable
+                last_error = f"{type(exc).__name__}: {exc}"
+
+            if attempt < self._max_retries - 1:
+                wait_seconds = self._backoff_seconds * (2**attempt)
+                logger.warning(
+                    "Letterboxd rating histogram attempt %s/%s failed for %s (%s); retrying in %ss",
+                    attempt + 1,
+                    self._max_retries,
+                    slug,
+                    last_error,
+                    wait_seconds,
+                )
+                self._sleep(wait_seconds)
+        raise LetterboxdRatingError(
+            f"Failed to fetch {url} after {self._max_retries} attempts ({last_error})"
+        )
+
+
+def _select_candidates(
+    db: Session,
+    *,
+    now: datetime,
+    max_age_days: int,
+    refresh: bool,
+    limit: Optional[int],
+    movie_ids: Optional[Sequence[int]],
+) -> tuple[List[RatingCandidate], int]:
+    cutoff = now - timedelta(days=max_age_days)
+    query = db.query(
+        Movie.id,
+        Movie.title,
+        Movie.letterboxd_slug,
+        Movie.letterboxd_url,
+        Movie.letterboxd_rating_synced_at,
+    ).order_by(Movie.id)
+    if movie_ids:
+        query = query.filter(
+            Movie.id.in_(list(dict.fromkeys(int(value) for value in movie_ids)))
+        )
+
+    skipped_no_slug = 0
+    ranked: List[tuple[tuple[int, datetime, int], RatingCandidate]] = []
+    for movie_id, title, slug, url, synced_at in query.all():
+        synced = _aware_utc(synced_at)
+        if not refresh and synced is not None and synced > cutoff:
+            continue
+        resolved = resolve_slug(slug, url)
+        if not resolved:
+            skipped_no_slug += 1
+            continue
+        # A bounded run should spend its budget on films that were never synced
+        # before it revisits the oldest expired ones.
+        ranked.append(
+            (
+                (0 if synced is None else 1, synced or _EPOCH, int(movie_id)),
+                RatingCandidate(movie_id=int(movie_id), title=str(title), slug=resolved),
+            )
+        )
+    ranked.sort(key=lambda item: item[0])
+    candidates = [candidate for _, candidate in ranked]
+    if limit is not None:
+        candidates = candidates[:limit]
+    return candidates, skipped_no_slug
+
+
+def _chunks(values: Sequence[Any], size: int) -> Iterable[Sequence[Any]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _persist_rating(
+    db: Session,
+    candidate: RatingCandidate,
+    parsed: ParsedRating,
+    *,
+    synced_at: datetime,
+) -> None:
+    """Stamp the attempt, and write values only when Letterboxd published them.
+
+    An "unknown" result never overwrites a previously fetched average: the
+    absent phrase means Letterboxd declined to publish one, not that the film's
+    rating became zero.
+    """
+    movie = db.get(Movie, candidate.movie_id)
+    if movie is None:
+        raise ValueError(f"Movie {candidate.movie_id} disappeared during rating sync")
+    if parsed.is_known:
+        movie.letterboxd_average_rating = parsed.average
+        movie.letterboxd_rating_count = parsed.count
+    movie.letterboxd_rating_synced_at = synced_at
+    db.flush()
+
+
+def sync_letterboxd_ratings(
+    db: Session,
+    fetcher: Optional[LetterboxdRatingFetcher] = None,
+    *,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    delay_seconds: float = DEFAULT_DELAY_SECONDS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    limit: Optional[int] = None,
+    movie_ids: Optional[Sequence[int]] = None,
+    refresh: bool = False,
+    dry_run: bool = False,
+    progress: Optional[Callable[[int, int, RatingCandidate], None]] = None,
+    sleeper: Callable[[float], None] = time.sleep,
+    now: Optional[datetime] = None,
+) -> RatingSyncStats:
+    """Backfill ``movies.letterboxd_*`` from Letterboxd's rating histograms.
+
+    Resuming is driven entirely by ``movies.letterboxd_rating_synced_at``: a
+    film whose stamp is newer than ``max_age_days`` is skipped, and every
+    attempt that reached a definite answer (an average, or a confirmed absence)
+    is stamped, so an interrupted run picks up where it left off and dead films
+    are not retried on every pass. One film never fails the run.
+    """
+    if max_age_days <= 0:
+        raise ValueError("max_age_days must be positive")
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+    if delay_seconds < 0:
+        raise ValueError("delay_seconds must not be negative")
+    if limit is not None and limit <= 0:
+        raise ValueError("limit must be positive when provided")
+
+    current_time = _aware_utc(now) or datetime.now(timezone.utc)
+    candidates, skipped_no_slug = _select_candidates(
+        db,
+        now=current_time,
+        max_age_days=max_age_days,
+        refresh=refresh,
+        limit=limit,
+        movie_ids=movie_ids,
+    )
+    # End the read transaction before the (slow, deliberately paced) fetches.
+    db.rollback()
+
+    stats = RatingSyncStats(
+        selected=len(candidates),
+        skipped_no_slug=skipped_no_slug,
+        dry_run=dry_run,
+    )
+    if dry_run or not candidates:
+        return stats
+    if fetcher is None:
+        raise ValueError("fetcher is required unless dry_run is enabled")
+
+    completed = 0
+    requests_made = 0
+    for candidate_batch in _chunks(candidates, batch_size):
+        resolved_batch: List[tuple[RatingCandidate, ParsedRating]] = []
+        for candidate in candidate_batch:
+            if progress:
+                progress(completed + 1, len(candidates), candidate)
+            completed += 1
+            if requests_made and delay_seconds:
+                sleeper(delay_seconds)
+            try:
+                document = fetcher.fetch(candidate.slug)
+                requests_made += 1
+                stats.fetched += 1
+                parsed = parse_rating_histogram(document)
+            except Exception as exc:  # noqa: BLE001 - one film never fails the run
+                requests_made += 1
+                stats.failed += 1
+                message = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "Letterboxd rating sync failed for %s (%s): %s",
+                    candidate.slug,
+                    candidate.movie_id,
+                    message,
+                )
+                stats.errors.append(
+                    {
+                        "movie_id": candidate.movie_id,
+                        "title": candidate.title,
+                        "slug": candidate.slug,
+                        "error": message,
+                    }
+                )
+                continue
+            resolved_batch.append((candidate, parsed))
+
+        written_updates = 0
+        written_unavailable = 0
+        for candidate, parsed in resolved_batch:
+            try:
+                with db.begin_nested():
+                    _persist_rating(
+                        db,
+                        candidate,
+                        parsed,
+                        synced_at=datetime.now(timezone.utc),
+                    )
+                if parsed.is_known:
+                    written_updates += 1
+                else:
+                    written_unavailable += 1
+            except Exception as exc:  # noqa: BLE001 - one film never fails the run
+                stats.failed += 1
+                message = f"Database write failed: {exc}"
+                logger.warning(
+                    "Letterboxd rating write failed for %s (%s): %s",
+                    candidate.slug,
+                    candidate.movie_id,
+                    exc,
+                )
+                stats.errors.append(
+                    {
+                        "movie_id": candidate.movie_id,
+                        "title": candidate.title,
+                        "slug": candidate.slug,
+                        "error": message,
+                    }
+                )
+
+        try:
+            db.commit()
+            stats.updated += written_updates
+            stats.unavailable += written_unavailable
+        except Exception as exc:  # noqa: BLE001 - a lost batch must not stop the run
+            db.rollback()
+            stats.failed += written_updates + written_unavailable
+            stats.errors.append(
+                {
+                    "movie_id": None,
+                    "title": None,
+                    "slug": None,
+                    "error": f"Batch commit failed: {exc}",
+                }
+            )
+
+    return stats

--- a/backend/services/rating_comparison.py
+++ b/backend/services/rating_comparison.py
@@ -4,8 +4,8 @@ Letterboxd shows a member their own rating beside its site-wide average and
 nothing else. We hold every tracked profile's rating for the same films, so a
 film can also carry a *local* average -- what this member's own circle thought
 of it -- and that is the comparison Letterboxd structurally cannot make. The
-same film therefore gets up to three reference points: the group, Letterboxd's
-crowd, and TMDB's crowd.
+same film therefore gets two reference points: the group, and Letterboxd's own
+crowd.
 
 Two rules keep the local comparison honest.
 
@@ -26,13 +26,13 @@ included, because a film everyone scores 4.5 except one holdout is not the same
 object as a film split down the middle. That needs three raters to mean
 anything, so the floor there is three in total rather than two others.
 
-The two external averages degrade independently and neither is required.
-``movies.letterboxd_average_rating`` is backfilled separately and is null until
-that lands, so every ``letterboxd_*`` field simply reports null and the rest of
-the payload is unaffected. TMDB scores out of ten and is halved onto
-Letterboxd's five-point scale before any subtraction -- comparing the two
-scales directly would silently double every TMDB delta. A TMDB average of 0.0
-with no votes is an absent opinion, not a terrible one, and is discarded.
+The Letterboxd average is the only external reference here, and it is never
+required. ``movies.letterboxd_average_rating`` is backfilled separately and is
+null for any film that backfill has not reached, so the ``letterboxd_*`` fields
+simply report null for it and the rest of the payload is unaffected. It is
+already on Letterboxd's own five-point scale -- the same scale as every rating
+in this module -- so nothing is converted between the two numbers being
+subtracted.
 
 Nothing here extrapolates: a profile that shares no film with anybody returns a
 complete payload of nulls and empty lists rather than zeros.
@@ -65,9 +65,6 @@ LEAN_THRESHOLD = 0.15
 DEFAULT_LIMIT = 10
 MAX_LIMIT = 50
 
-# TMDB scores out of 10, Letterboxd out of 5.
-TMDB_SCALE_DIVISOR = 2.0
-
 
 @dataclass(frozen=True)
 class _FilmRow:
@@ -77,7 +74,6 @@ class _FilmRow:
     title: str
     profile_rating: Optional[float]
     letterboxd_average: Optional[float]
-    tmdb_average: Optional[float]  # already converted onto the 5-point scale
     other_ratings: Tuple[float, ...]
 
     @property
@@ -115,21 +111,6 @@ def _clamp_limit(limit: Optional[int]) -> int:
     except (TypeError, ValueError):
         return DEFAULT_LIMIT
     return max(1, min(value, MAX_LIMIT))
-
-
-def _tmdb_average_on_five(vote_average: Any, vote_count: Any) -> Optional[float]:
-    """Halve TMDB's /10 score, and treat an unvoted film as having no average.
-
-    TMDB reports ``vote_average`` 0.0 for films nobody has voted on. Taking that
-    at face value would invent a zero-star crowd opinion and hand the profile a
-    fake five-star delta, so it is discarded rather than compared.
-    """
-
-    average = _safe_float(vote_average)
-    votes = _safe_float(vote_count)
-    if average is None or average <= 0 or votes is None or votes < 1:
-        return None
-    return average / TMDB_SCALE_DIVISOR
 
 
 def _letterboxd_average(value: Any) -> Optional[float]:
@@ -175,26 +156,20 @@ def _other_ratings_by_movie(db: Session, profile_id: int) -> Dict[int, List[floa
 
 
 def _library_rows(db: Session, profile_id: int) -> List[_FilmRow]:
-    """Bulk-load the profile's library, its own ratings, and both site averages.
+    """Bulk-load the profile's library, its own ratings, and the site average.
 
-    ``raw_payload`` holds TMDB's entire response -- tens of megabytes across a
-    library -- so the two numbers needed from it are extracted by JSON path in
-    the database instead of shipping the document to Python.
+    Only the columns this comparison reads are selected, so a large library
+    never drags whole ``Movie`` rows into memory to reach four numbers.
     """
 
-    tmdb_vote_average = MovieEnrichment.raw_payload["details"]["vote_average"].as_float()
-    tmdb_vote_count = MovieEnrichment.raw_payload["details"]["vote_count"].as_float()
     rows = (
         db.query(
             ProfileFilm.movie_id,
             ProfileFilm.rating,
             Movie.title,
             Movie.letterboxd_average_rating,
-            tmdb_vote_average.label("tmdb_vote_average"),
-            tmdb_vote_count.label("tmdb_vote_count"),
         )
         .join(Movie, Movie.id == ProfileFilm.movie_id)
-        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
         .filter(
             ProfileFilm.profile_id == profile_id,
             ProfileFilm.removed_at.is_(None),
@@ -208,10 +183,6 @@ def _library_rows(db: Session, profile_id: int) -> List[_FilmRow]:
             title=row.title or "",
             profile_rating=_safe_float(row.rating),
             letterboxd_average=_letterboxd_average(row.letterboxd_average_rating),
-            tmdb_average=_tmdb_average_on_five(
-                row.tmdb_vote_average,
-                row.tmdb_vote_count,
-            ),
             other_ratings=tuple(others.get(int(row.movie_id), ())),
         )
         for row in rows
@@ -286,7 +257,6 @@ def _film_delta(row: _FilmRow, identity: Dict[str, Any]) -> Dict[str, Any]:
         # which is the number ``coverage.min_raters`` is a floor on.
         "rater_count": len(row.other_ratings),
         "letterboxd_average": _round(row.letterboxd_average, 2),
-        "tmdb_average": _round(row.tmdb_average, 2),
     }
 
 
@@ -311,7 +281,7 @@ def build_rating_comparison(
     *,
     limit: int = DEFAULT_LIMIT,
 ) -> Dict[str, Any]:
-    """Compare one profile's ratings with its circle, Letterboxd and TMDB.
+    """Compare one profile's ratings with its circle and with Letterboxd.
 
     ``summary.group_delta`` is the mean of ``profile rating - group average``
     over every compared film, where each group average is taken over the other
@@ -335,11 +305,6 @@ def build_rating_comparison(
         row.profile_rating - row.letterboxd_average
         for row in rated
         if row.letterboxd_average is not None
-    ]
-    tmdb_pairs = [
-        row.profile_rating - row.tmdb_average
-        for row in rated
-        if row.tmdb_average is not None
     ]
 
     generous = _ordered(
@@ -384,12 +349,10 @@ def build_rating_comparison(
             "compared_films": len(compared),
             "min_raters": MIN_OTHER_RATERS,
             "letterboxd_average_films": len(letterboxd_pairs),
-            "tmdb_average_films": len(tmdb_pairs),
         },
         "summary": {
             "group_delta": rounded_group_delta,
             "letterboxd_delta": _round(_average(letterboxd_pairs), 2),
-            "tmdb_delta": _round(_average(tmdb_pairs), 2),
             "lean": _lean(rounded_group_delta),
             "agreement": _round(_agreement(compared), 2),
         },

--- a/backend/services/rating_comparison.py
+++ b/backend/services/rating_comparison.py
@@ -1,0 +1,399 @@
+"""How one profile rates against the circle it actually shares films with.
+
+Letterboxd shows a member their own rating beside its site-wide average and
+nothing else. We hold every tracked profile's rating for the same films, so a
+film can also carry a *local* average -- what this member's own circle thought
+of it -- and that is the comparison Letterboxd structurally cannot make. The
+same film therefore gets up to three reference points: the group, Letterboxd's
+crowd, and TMDB's crowd.
+
+Two rules keep the local comparison honest.
+
+* **The group average for a film always excludes the profile being measured.**
+  Leaving a member inside the crowd they are measured against drags that crowd
+  toward them, shrinks every delta, and correlates a profile with itself: a
+  member who rated everything five stars while everyone else rated three would
+  still look partly agreeable purely because their own fives sit in the
+  average. Every ``group_average`` in this payload is the mean over *other*
+  profiles only.
+* **A film needs at least two other raters before it is compared at all.** One
+  other person is an opinion, not a group, and half the difference between two
+  people is not a lean.
+
+``most_divisive`` answers a different question and so uses a different rule:
+its spread is measured across *every* profile who rated the film, this one
+included, because a film everyone scores 4.5 except one holdout is not the same
+object as a film split down the middle. That needs three raters to mean
+anything, so the floor there is three in total rather than two others.
+
+The two external averages degrade independently and neither is required.
+``movies.letterboxd_average_rating`` is backfilled separately and is null until
+that lands, so every ``letterboxd_*`` field simply reports null and the rest of
+the payload is unaffected. TMDB scores out of ten and is halved onto
+Letterboxd's five-point scale before any subtraction -- comparing the two
+scales directly would silently double every TMDB delta. A TMDB average of 0.0
+with no votes is an absent opinion, not a terrible one, and is discarded.
+
+Nothing here extrapolates: a profile that shares no film with anybody returns a
+complete payload of nulls and empty lists rather than zeros.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, aliased, load_only
+
+from database.models import Movie, MovieEnrichment, Profile, ProfileFilm
+from services.insights import InsightsService, _average, _pearson, _round, _safe_float
+
+
+# One other person is an opinion, not a group.
+MIN_OTHER_RATERS = 2
+
+# A spread needs a crowd: two raters describe a gap, three describe a split.
+MIN_SPREAD_RATERS = 3
+
+# Two paired points always correlate perfectly; a correlation needs three.
+MIN_CORRELATION_FILMS = 3
+
+# Below this the mean delta is rating noise (a single half-star on a handful of
+# films), not a temperament.
+LEAN_THRESHOLD = 0.15
+
+DEFAULT_LIMIT = 10
+MAX_LIMIT = 50
+
+# TMDB scores out of 10, Letterboxd out of 5.
+TMDB_SCALE_DIVISOR = 2.0
+
+
+@dataclass(frozen=True)
+class _FilmRow:
+    """One film in the profile's library with every rating we can compare it to."""
+
+    movie_id: int
+    title: str
+    profile_rating: Optional[float]
+    letterboxd_average: Optional[float]
+    tmdb_average: Optional[float]  # already converted onto the 5-point scale
+    other_ratings: Tuple[float, ...]
+
+    @property
+    def group_average(self) -> Optional[float]:
+        """The mean over other profiles only -- never including this one."""
+
+        return _average(self.other_ratings)
+
+    @property
+    def is_compared(self) -> bool:
+        return (
+            self.profile_rating is not None
+            and len(self.other_ratings) >= MIN_OTHER_RATERS
+        )
+
+    @property
+    def delta(self) -> Optional[float]:
+        group_average = self.group_average
+        if not self.is_compared or group_average is None:
+            return None
+        return self.profile_rating - group_average
+
+    @property
+    def all_ratings(self) -> Tuple[float, ...]:
+        """Every rating on the film, this profile's included."""
+
+        if self.profile_rating is None:
+            return self.other_ratings
+        return (*self.other_ratings, self.profile_rating)
+
+
+def _clamp_limit(limit: Optional[int]) -> int:
+    try:
+        value = int(limit) if limit is not None else DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+    return max(1, min(value, MAX_LIMIT))
+
+
+def _tmdb_average_on_five(vote_average: Any, vote_count: Any) -> Optional[float]:
+    """Halve TMDB's /10 score, and treat an unvoted film as having no average.
+
+    TMDB reports ``vote_average`` 0.0 for films nobody has voted on. Taking that
+    at face value would invent a zero-star crowd opinion and hand the profile a
+    fake five-star delta, so it is discarded rather than compared.
+    """
+
+    average = _safe_float(vote_average)
+    votes = _safe_float(vote_count)
+    if average is None or average <= 0 or votes is None or votes < 1:
+        return None
+    return average / TMDB_SCALE_DIVISOR
+
+
+def _letterboxd_average(value: Any) -> Optional[float]:
+    """The Letterboxd crowd average, or null while the backfill is pending."""
+
+    average = _safe_float(value)
+    return average if average is not None and average > 0 else None
+
+
+def _other_ratings_by_movie(db: Session, profile_id: int) -> Dict[int, List[float]]:
+    """Every *other* tracked profile's rating for the films in this library.
+
+    Restricted to the films this profile actually holds by subquery, so a large
+    shared movie table never leaves the database. Only active, completed
+    profiles count towards the group, matching the rule the rest of the app
+    uses for a usable imported profile.
+    """
+
+    library = aliased(ProfileFilm)
+    library_movie_ids = select(library.movie_id).where(
+        library.profile_id == profile_id,
+        library.removed_at.is_(None),
+    )
+    rows = (
+        db.query(ProfileFilm.movie_id, ProfileFilm.rating)
+        .join(Profile, Profile.id == ProfileFilm.profile_id)
+        .filter(
+            ProfileFilm.profile_id != profile_id,
+            ProfileFilm.removed_at.is_(None),
+            ProfileFilm.rating.isnot(None),
+            Profile.is_active.is_(True),
+            Profile.scraping_status == "completed",
+            ProfileFilm.movie_id.in_(library_movie_ids),
+        )
+        .all()
+    )
+    grouped: Dict[int, List[float]] = {}
+    for movie_id, rating in rows:
+        value = _safe_float(rating)
+        if value is not None:
+            grouped.setdefault(int(movie_id), []).append(value)
+    return grouped
+
+
+def _library_rows(db: Session, profile_id: int) -> List[_FilmRow]:
+    """Bulk-load the profile's library, its own ratings, and both site averages.
+
+    ``raw_payload`` holds TMDB's entire response -- tens of megabytes across a
+    library -- so the two numbers needed from it are extracted by JSON path in
+    the database instead of shipping the document to Python.
+    """
+
+    tmdb_vote_average = MovieEnrichment.raw_payload["details"]["vote_average"].as_float()
+    tmdb_vote_count = MovieEnrichment.raw_payload["details"]["vote_count"].as_float()
+    rows = (
+        db.query(
+            ProfileFilm.movie_id,
+            ProfileFilm.rating,
+            Movie.title,
+            Movie.letterboxd_average_rating,
+            tmdb_vote_average.label("tmdb_vote_average"),
+            tmdb_vote_count.label("tmdb_vote_count"),
+        )
+        .join(Movie, Movie.id == ProfileFilm.movie_id)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(
+            ProfileFilm.profile_id == profile_id,
+            ProfileFilm.removed_at.is_(None),
+        )
+        .all()
+    )
+    others = _other_ratings_by_movie(db, profile_id)
+    return [
+        _FilmRow(
+            movie_id=int(row.movie_id),
+            title=row.title or "",
+            profile_rating=_safe_float(row.rating),
+            letterboxd_average=_letterboxd_average(row.letterboxd_average_rating),
+            tmdb_average=_tmdb_average_on_five(
+                row.tmdb_vote_average,
+                row.tmdb_vote_count,
+            ),
+            other_ratings=tuple(others.get(int(row.movie_id), ())),
+        )
+        for row in rows
+    ]
+
+
+def _film_identities(db: Session, movie_ids: Sequence[int]) -> Dict[int, Dict[str, Any]]:
+    """Display fields for the handful of films that reached an output list.
+
+    Poster hygiene (TMDB path, placeholder rejection, Letterboxd image
+    endpoints) already lives in ``InsightsService._movie_summary``; this reuses
+    it rather than growing a second copy of those rules.
+    """
+
+    if not movie_ids:
+        return {}
+    rows = (
+        db.query(Movie, MovieEnrichment)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .options(load_only(MovieEnrichment.movie_id, MovieEnrichment.poster_path))
+        .filter(Movie.id.in_(set(movie_ids)))
+        .all()
+    )
+    identities: Dict[int, Dict[str, Any]] = {}
+    for movie, enrichment in rows:
+        summary = InsightsService._movie_summary(movie, enrichment)
+        identities[movie.id] = {
+            "title": summary["title"],
+            "year": summary["year"],
+            "poster_url": summary["poster_url"],
+            "letterboxd_url": summary["letterboxd_url"],
+        }
+    return identities
+
+
+def _lean(group_delta: Optional[float]) -> Optional[str]:
+    """Name the temperament from the reported delta, so the two always agree."""
+
+    if group_delta is None:
+        return None
+    if group_delta > LEAN_THRESHOLD:
+        return "generous"
+    if group_delta < -LEAN_THRESHOLD:
+        return "harsh"
+    return "aligned"
+
+
+def _agreement(compared: Sequence[_FilmRow]) -> Optional[float]:
+    """Pearson correlation of this profile's ratings against the group's.
+
+    Both sequences are paired per film, and the group side excludes this
+    profile, so a member cannot correlate with themselves. Two points always
+    correlate perfectly, so three paired films is the floor; a group that rated
+    every shared film identically has no variance to correlate against and
+    returns null rather than a fabricated 1.0.
+    """
+
+    if len(compared) < MIN_CORRELATION_FILMS:
+        return None
+    profile_ratings = [row.profile_rating for row in compared]
+    group_averages = [row.group_average for row in compared]
+    return _pearson(profile_ratings, group_averages)
+
+
+def _film_delta(row: _FilmRow, identity: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        **identity,
+        "profile_rating": _round(row.profile_rating, 2),
+        "group_average": _round(row.group_average, 2),
+        "delta": _round(row.delta, 2),
+        # The size of the group behind ``group_average``: other raters only,
+        # which is the number ``coverage.min_raters`` is a floor on.
+        "rater_count": len(row.other_ratings),
+        "letterboxd_average": _round(row.letterboxd_average, 2),
+        "tmdb_average": _round(row.tmdb_average, 2),
+    }
+
+
+def _divisive_entry(row: _FilmRow, identity: Dict[str, Any]) -> Dict[str, Any]:
+    ratings = row.all_ratings
+    return {
+        **identity,
+        "rating_spread": _round(max(ratings) - min(ratings), 2),
+        "rater_count": len(ratings),
+        "group_average": _round(row.group_average, 2),
+        "profile_rating": _round(row.profile_rating, 2),
+    }
+
+
+def _ordered(rows: Iterable[_FilmRow], *, key) -> List[_FilmRow]:
+    return sorted(rows, key=key)
+
+
+def build_rating_comparison(
+    db: Session,
+    profile: Profile,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> Dict[str, Any]:
+    """Compare one profile's ratings with its circle, Letterboxd and TMDB.
+
+    ``summary.group_delta`` is the mean of ``profile rating - group average``
+    over every compared film, where each group average is taken over the other
+    profiles who rated that film and never over this one. ``lean`` reads that
+    delta against a half-star-noise threshold, and ``agreement`` correlates the
+    two rating sequences over the same films.
+
+    ``most_generous`` and ``most_harsh`` only ever contain films whose delta
+    actually points that way: a uniformly harsh profile has no generous films,
+    and returning its least-harsh ones under that heading would be a lie.
+    """
+
+    limit = _clamp_limit(limit)
+    rows = _library_rows(db, profile.id)
+
+    rated = [row for row in rows if row.profile_rating is not None]
+    compared = [row for row in rows if row.is_compared]
+
+    group_delta = _average([row.delta for row in compared])
+    letterboxd_pairs = [
+        row.profile_rating - row.letterboxd_average
+        for row in rated
+        if row.letterboxd_average is not None
+    ]
+    tmdb_pairs = [
+        row.profile_rating - row.tmdb_average
+        for row in rated
+        if row.tmdb_average is not None
+    ]
+
+    generous = _ordered(
+        (row for row in compared if row.delta > 0),
+        key=lambda row: (-row.delta, -len(row.other_ratings), row.title.casefold(), row.movie_id),
+    )[:limit]
+    harsh = _ordered(
+        (row for row in compared if row.delta < 0),
+        key=lambda row: (row.delta, -len(row.other_ratings), row.title.casefold(), row.movie_id),
+    )[:limit]
+    divisive = _ordered(
+        (row for row in rows if len(row.all_ratings) >= MIN_SPREAD_RATERS),
+        key=lambda row: (
+            -(max(row.all_ratings) - min(row.all_ratings)),
+            -len(row.all_ratings),
+            row.title.casefold(),
+            row.movie_id,
+        ),
+    )[:limit]
+
+    identities = _film_identities(
+        db,
+        [row.movie_id for row in (*generous, *harsh, *divisive)],
+    )
+
+    def identity(row: _FilmRow) -> Dict[str, Any]:
+        return identities.get(
+            row.movie_id,
+            {
+                "title": row.title,
+                "year": None,
+                "poster_url": None,
+                "letterboxd_url": None,
+            },
+        )
+
+    rounded_group_delta = _round(group_delta, 2)
+    return {
+        "username": profile.username,
+        "coverage": {
+            "rated_films": len(rated),
+            "compared_films": len(compared),
+            "min_raters": MIN_OTHER_RATERS,
+            "letterboxd_average_films": len(letterboxd_pairs),
+            "tmdb_average_films": len(tmdb_pairs),
+        },
+        "summary": {
+            "group_delta": rounded_group_delta,
+            "letterboxd_delta": _round(_average(letterboxd_pairs), 2),
+            "tmdb_delta": _round(_average(tmdb_pairs), 2),
+            "lean": _lean(rounded_group_delta),
+            "agreement": _round(_agreement(compared), 2),
+        },
+        "most_generous": [_film_delta(row, identity(row)) for row in generous],
+        "most_harsh": [_film_delta(row, identity(row)) for row in harsh],
+        "most_divisive": [_divisive_entry(row, identity(row)) for row in divisive],
+    }

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260801_0014"
+HEAD_REVISION = "20260801_0015"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260801_0013"
+            script.get_revision(HEAD_REVISION).down_revision, "20260801_0014"
+        )
+        self.assertEqual(
+            script.get_revision("20260801_0014").down_revision, "20260801_0013"
         )
         self.assertEqual(
             script.get_revision("20260801_0013").down_revision, "20260801_0012"

--- a/backend/tests/test_film_ratings_push.py
+++ b/backend/tests/test_film_ratings_push.py
@@ -32,6 +32,26 @@ def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
 
 
 RATINGS_URL = "/api/films/letterboxd-ratings"
+
+
+def _api_routes(routes):
+    """Flatten routers the way test_route_access_matrix does.
+
+    Newer FastAPI defers ``include_router`` behind a wrapper, so scanning
+    ``app.routes`` for APIRoute instances finds nothing for an included
+    router. The repo already hit this; mirror its traversal rather than
+    depending on which version happens to be installed.
+    """
+    for route in routes:
+        if isinstance(route, APIRoute):
+            yield route
+            continue
+        included_router = getattr(route, "original_router", None)
+        nested = getattr(included_router, "routes", None)
+        if nested is not None:
+            yield from _api_routes(nested)
+
+
 INGESTION_TOKEN = "test-ingestion-token"
 _MOVIE_IDS = count(1)
 
@@ -328,8 +348,8 @@ def test_ingestion_token_is_required(client, database):
 def test_route_carries_the_upload_trust_boundary():
     route = next(
         candidate
-        for candidate in backend_main.app.routes
-        if isinstance(candidate, APIRoute) and candidate.path == RATINGS_URL
+        for candidate in _api_routes(backend_main.app.routes)
+        if candidate.path == RATINGS_URL
     )
     names = {dependency.call.__name__ for dependency in route.dependant.dependencies}
 

--- a/backend/tests/test_film_ratings_push.py
+++ b/backend/tests/test_film_ratings_push.py
@@ -1,0 +1,365 @@
+"""Residential-machine delivery of Letterboxd's own crowd rating per film.
+
+The values can only be scraped where the scraper runs, so they arrive as a batch
+over the same ingestion-token boundary as ``/upload/``. These tests pin the
+contract that makes that batch safe to trust: match by slug, tolerate films
+production has never seen, and never let a bad or absent value overwrite a good
+one — the database's own CHECK constraint must never be the thing that catches a
+malformed payload.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from itertools import count
+from typing import Optional
+
+import pytest
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend import main as backend_main
+from database.models import Movie
+from scripts.push_letterboxd_ratings import collect_ratings, iter_batches
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+RATINGS_URL = "/api/films/letterboxd-ratings"
+INGESTION_TOKEN = "test-ingestion-token"
+_MOVIE_IDS = count(1)
+
+
+@pytest.fixture(autouse=True)
+def ingestion_token(monkeypatch):
+    """The API only honours X-Upload-Token when one is configured."""
+    monkeypatch.setenv("INGESTION_API_TOKEN", INGESTION_TOKEN)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Movie.__table__.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+@pytest.fixture()
+def client(database) -> TestClient:
+    backend_main.app.dependency_overrides[backend_main.get_db] = lambda: database
+    try:
+        yield TestClient(backend_main.app)
+    finally:
+        backend_main.app.dependency_overrides.clear()
+
+
+def _film(
+    database: Session,
+    slug: Optional[str],
+    *,
+    url: Optional[str] = None,
+    average: Optional[float] = None,
+    rating_count: Optional[int] = None,
+    synced_at: Optional[datetime] = None,
+) -> Movie:
+    movie_id = next(_MOVIE_IDS)
+    movie = Movie(
+        id=movie_id,
+        canonical_key=f"letterboxd:{slug or movie_id}",
+        title=f"Film {movie_id}",
+        normalized_title=f"film {movie_id}",
+        release_year=2024,
+        letterboxd_slug=slug,
+        letterboxd_url=url,
+        letterboxd_average_rating=average,
+        letterboxd_rating_count=rating_count,
+        letterboxd_rating_synced_at=synced_at,
+    )
+    database.add(movie)
+    database.commit()
+    return movie
+
+
+def _post(client: TestClient, ratings: list[dict], *, token: Optional[str] = INGESTION_TOKEN):
+    headers = {"X-Upload-Token": token} if token is not None else {}
+    return client.post(RATINGS_URL, json={"ratings": ratings}, headers=headers)
+
+
+def _entry(slug: str, **overrides) -> dict:
+    entry = {"slug": slug, "average_rating": 4.0, "rating_count": 1000, "synced_at": None}
+    entry.update(overrides)
+    return entry
+
+
+def _reload(database: Session, movie: Movie) -> Movie:
+    database.expire_all()
+    return database.get(Movie, movie.id)
+
+
+def test_matching_slug_writes_the_letterboxd_average(client, database):
+    movie = _film(database, "the-brutalist")
+
+    response = _post(
+        client,
+        [
+            _entry(
+                "the-brutalist",
+                average_rating=4.12,
+                rating_count=250_000,
+                synced_at="2026-08-01T10:30:00+00:00",
+            )
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0}
+
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == pytest.approx(4.12)
+    assert stored.letterboxd_rating_count == 250_000
+    assert stored.letterboxd_rating_synced_at.replace(tzinfo=timezone.utc) == datetime(
+        2026, 8, 1, 10, 30, tzinfo=timezone.utc
+    )
+
+
+def test_slug_matching_is_case_insensitive_in_both_directions(client, database):
+    stored_lower = _film(database, "the-brutalist")
+    stored_mixed = _film(database, "Nickel-Boys")
+
+    response = _post(
+        client,
+        [
+            _entry("THE-Brutalist", average_rating=4.12),
+            _entry("nickel-boys", average_rating=3.87),
+        ],
+    )
+
+    assert response.json() == {"received": 2, "updated": 2, "unmatched": 0, "skipped": 0}
+    assert _reload(database, stored_lower).letterboxd_average_rating == pytest.approx(4.12)
+    assert _reload(database, stored_mixed).letterboxd_average_rating == pytest.approx(3.87)
+
+
+def test_unknown_slugs_are_reported_not_fatal(client, database):
+    known = _film(database, "the-brutalist")
+
+    response = _post(
+        client,
+        [
+            _entry("the-brutalist", average_rating=4.12),
+            _entry("a-film-production-has-never-seen", average_rating=3.5),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"received": 2, "updated": 1, "unmatched": 1, "skipped": 0}
+    # The rest of the batch still landed.
+    assert _reload(database, known).letterboxd_average_rating == pytest.approx(4.12)
+
+
+def test_out_of_range_averages_are_skipped_before_the_check_constraint(client, database):
+    high = _film(database, "too-high", average=3.0, rating_count=10)
+    low = _film(database, "too-low", average=3.0, rating_count=10)
+
+    response = _post(
+        client,
+        [
+            _entry("too-high", average_rating=5.5),
+            _entry("too-low", average_rating=-0.1),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"received": 2, "updated": 0, "unmatched": 0, "skipped": 2}
+    assert _reload(database, high).letterboxd_average_rating == pytest.approx(3.0)
+    assert _reload(database, low).letterboxd_average_rating == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("literal", ["NaN", "Infinity"])
+def test_non_finite_averages_are_skipped(client, database, literal):
+    """JSON's NaN/Infinity literals parse into floats; a range test rejects both."""
+    movie = _film(database, "the-brutalist", average=3.0)
+
+    response = client.post(
+        RATINGS_URL,
+        content=(
+            '{"ratings": [{"slug": "the-brutalist", "average_rating": ' + literal + "}]}"
+        ),
+        headers={"X-Upload-Token": INGESTION_TOKEN, "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    assert _reload(database, movie).letterboxd_average_rating == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("rating_count", [-1, 10**19])
+def test_impossible_rating_counts_are_skipped(client, database, rating_count):
+    """A negative count breaks the CHECK; an astronomical one overflows BIGINT."""
+    movie = _film(database, "the-brutalist", average=3.0, rating_count=10)
+
+    response = _post(
+        client,
+        [
+            _entry("the-brutalist", average_rating=4.0, rating_count=rating_count),
+        ],
+    )
+
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == pytest.approx(3.0)
+    assert stored.letterboxd_rating_count == 10
+
+
+def test_null_average_never_clobbers_a_known_value(client, database):
+    movie = _film(
+        database,
+        "the-brutalist",
+        average=4.12,
+        rating_count=250_000,
+        synced_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+    response = _post(client, [_entry("the-brutalist", average_rating=None, rating_count=999)])
+
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == pytest.approx(4.12)
+    assert stored.letterboxd_rating_count == 250_000
+    assert stored.letterboxd_rating_synced_at.replace(tzinfo=timezone.utc) == datetime(
+        2026, 7, 1, tzinfo=timezone.utc
+    )
+
+
+def test_null_rating_count_keeps_the_stored_count(client, database):
+    movie = _film(database, "the-brutalist", average=4.0, rating_count=250_000)
+
+    response = _post(client, [_entry("the-brutalist", average_rating=4.2, rating_count=None)])
+
+    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0}
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == pytest.approx(4.2)
+    assert stored.letterboxd_rating_count == 250_000
+
+
+def test_missing_synced_at_falls_back_to_the_request_time(client, database):
+    movie = _film(database, "the-brutalist")
+    before = datetime.now(timezone.utc)
+
+    assert _post(client, [_entry("the-brutalist", synced_at=None)]).status_code == 200
+
+    stamped = _reload(database, movie).letterboxd_rating_synced_at.replace(tzinfo=timezone.utc)
+    assert stamped >= before.replace(microsecond=0)
+
+
+def test_counts_always_account_for_every_submitted_entry(client, database):
+    _film(database, "the-brutalist")
+
+    response = _post(
+        client,
+        [
+            _entry("the-brutalist", average_rating=4.12),
+            _entry("never-seen-here", average_rating=3.0),
+            _entry("the-brutalist", average_rating=99.0),
+            _entry("   ", average_rating=3.0),
+        ],
+    )
+
+    body = response.json()
+    assert body["received"] == 4
+    assert body["updated"] + body["unmatched"] + body["skipped"] == body["received"]
+    assert body == {"received": 4, "updated": 1, "unmatched": 1, "skipped": 2}
+
+
+def test_oversized_batch_is_rejected_outright(client, database):
+    movie = _film(database, "the-brutalist", average=3.0)
+
+    response = _post(
+        client,
+        [_entry("the-brutalist", average_rating=4.12) for _ in range(1001)],
+    )
+
+    assert response.status_code == 422
+    assert _reload(database, movie).letterboxd_average_rating == pytest.approx(3.0)
+
+
+def test_maximum_batch_size_is_accepted(client, database):
+    _film(database, "the-brutalist")
+
+    response = _post(
+        client,
+        [_entry(f"film-{index}", average_rating=3.0) for index in range(999)]
+        + [_entry("the-brutalist", average_rating=4.12)],
+    )
+
+    assert response.status_code == 200
+    assert response.json()["received"] == 1000
+
+
+def test_empty_batch_is_rejected(client):
+    assert _post(client, []).status_code == 422
+
+
+def test_ingestion_token_is_required(client, database):
+    movie = _film(database, "the-brutalist", average=3.0)
+    entries = [_entry("the-brutalist", average_rating=4.12)]
+
+    assert _post(client, entries, token=None).status_code == 401
+    assert _post(client, entries, token="not-the-token").status_code == 401
+    assert _reload(database, movie).letterboxd_average_rating == pytest.approx(3.0)
+
+    assert _post(client, entries).status_code == 200
+
+
+def test_route_carries_the_upload_trust_boundary():
+    route = next(
+        candidate
+        for candidate in backend_main.app.routes
+        if isinstance(candidate, APIRoute) and candidate.path == RATINGS_URL
+    )
+    names = {dependency.call.__name__ for dependency in route.dependant.dependencies}
+
+    # The mounted gate rejects disabled Clerk admins; the route's own dependency
+    # keeps the ingestion-token check attached to the router itself.
+    assert "get_active_upload_user" in names
+    assert "get_upload_user" in names
+
+
+def test_pusher_collects_only_films_with_a_known_average(database):
+    _film(database, "the-brutalist", average=4.12, rating_count=250_000)
+    _film(database, None, url="https://letterboxd.com/film/nickel-boys/", average=3.87)
+    _film(database, "no-average-yet")
+    _film(database, None, url=None, average=2.5)
+
+    entries, skipped_no_slug = collect_ratings(database)
+
+    assert skipped_no_slug == 1
+    assert [entry["slug"] for entry in entries] == ["the-brutalist", "nickel-boys"]
+    assert entries[0]["average_rating"] == pytest.approx(4.12)
+    assert entries[0]["rating_count"] == 250_000
+    assert entries[1]["rating_count"] is None
+
+
+def test_pusher_respects_the_limit_and_chunks_into_batches(database):
+    for index in range(5):
+        _film(database, f"film-{index}", average=3.0)
+
+    entries, _ = collect_ratings(database, limit=3)
+    batches = list(iter_batches(entries, 2))
+
+    assert len(entries) == 3
+    assert [len(batch) for batch in batches] == [2, 1]

--- a/backend/tests/test_film_ratings_push.py
+++ b/backend/tests/test_film_ratings_push.py
@@ -333,10 +333,9 @@ def test_route_carries_the_upload_trust_boundary():
     )
     names = {dependency.call.__name__ for dependency in route.dependant.dependencies}
 
-    # The mounted gate rejects disabled Clerk admins; the route's own dependency
-    # keeps the ingestion-token check attached to the router itself.
+    # The route declares its own gate rather than inheriting one from how it is
+    # mounted, so the trust boundary is visible on the route itself.
     assert "get_active_upload_user" in names
-    assert "get_upload_user" in names
 
 
 def test_pusher_collects_only_films_with_a_known_average(database):

--- a/backend/tests/test_letterboxd_ratings.py
+++ b/backend/tests/test_letterboxd_ratings.py
@@ -1,0 +1,523 @@
+"""Letterboxd crowd-rating backfill: parsing, slug resolution, resume, isolation."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+
+from backend.database.models import Movie, Profile, ProfileSync
+from backend.services.letterboxd_ratings import (
+    LetterboxdRatingError,
+    LetterboxdRatingFetcher,
+    LetterboxdRatingParseError,
+    parse_rating_histogram,
+    resolve_slug,
+    sync_letterboxd_ratings,
+)
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures of the real CSI include shape (letterboxd.com/csi/film/<slug>/rating-histogram/).
+# Trimmed to three of the ten half-star buckets; every attribute form is verbatim.
+# ---------------------------------------------------------------------------
+
+_BUCKETS = """
+<tr class="column" style="--value: 0.012379758286082376;">
+  <th scope="row" class="_sr-only">★★</th>
+  <td class="cell">
+    <a href="/film/the-dark-knight/ratings/rated/2/by/rating/" class="barcolumn tooltip" title="27,617 ★★ ratings (1%)">
+      <span class="_sr-only">27.6K (1%)</span>
+      <span class="bar"><span class="fill"></span></span>
+    </a>
+  </td>
+</tr>
+<tr class="column" style="--value: 0.4703254723937711;">
+  <th scope="row" class="_sr-only">★★★★</th>
+  <td class="cell">
+    <a href="/film/the-dark-knight/ratings/rated/4/by/rating/" class="barcolumn tooltip" title="1,049,211 ★★★★ ratings (23%)">
+      <span class="_sr-only">1M (23%)</span>
+      <span class="bar"><span class="fill"></span></span>
+    </a>
+  </td>
+</tr>
+<tr class="column" style="--value: 1.0;">
+  <th scope="row" class="_sr-only">★★★★★</th>
+  <td class="cell">
+    <a href="/film/the-dark-knight/ratings/rated/5/by/rating/" class="barcolumn tooltip" title="2,230,819 ★★★★★ ratings (48%)">
+      <span class="_sr-only">2.2M (48%)</span>
+      <span class="bar"><span class="fill"></span></span>
+    </a>
+  </td>
+</tr>
+"""
+
+
+def _histogram(average_anchor: str = "") -> str:
+    return f"""
+<div class="rating-histogram"> <div class="layout">
+<table class="chart">
+  <caption class="_sr-only">Rating Distribution</caption>
+  <tbody class="plot">{_BUCKETS}</tbody>
+</table>
+{average_anchor}
+</div> </div>
+"""
+
+
+HISTOGRAM_WITH_AVERAGE = _histogram(
+    '<a href="/film/the-dark-knight/ratings/" class="averagerating tooltip"'
+    ' title="Weighted average of 4.50 based on 4,609,944 ratings"> 4.5 </a>'
+)
+# Letterboxd withholds the weighted average until a film has enough ratings.
+HISTOGRAM_WITHOUT_AVERAGE = _histogram()
+# A film with no ratings at all: the include is served 200 but is blank.
+EMPTY_INCLUDE = "\n\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_weighted_average_line_is_the_source_of_truth():
+    parsed = parse_rating_histogram(HISTOGRAM_WITH_AVERAGE)
+    assert parsed.average == 4.5
+    assert parsed.count == 4_609_944
+    assert parsed.is_known is True
+
+
+def test_abbreviated_bucket_labels_are_never_used_as_the_count():
+    # "2.2M" and "27.6K" appear in the same document; the count must come from
+    # the weighted-average phrase, which is exact.
+    assert "2.2M" in HISTOGRAM_WITH_AVERAGE and "27.6K" in HISTOGRAM_WITH_AVERAGE
+    parsed = parse_rating_histogram(HISTOGRAM_WITH_AVERAGE)
+    assert parsed.count == 4_609_944
+    assert parsed.count not in (22, 2_200_000, 27_600, 2_230_819, 1_049_211)
+
+
+def test_thousands_separators_and_singular_rating_are_parsed():
+    document = _histogram(
+        '<a class="averagerating tooltip"'
+        ' title="Weighted average of 2.75 based on 1,234,567 ratings"> 2.8 </a>'
+    )
+    assert parse_rating_histogram(document).count == 1_234_567
+
+    singular = _histogram(
+        '<a class="averagerating tooltip"'
+        ' title="Weighted average of 3.00 based on 1 rating"> 3.0 </a>'
+    )
+    parsed = parse_rating_histogram(singular)
+    assert (parsed.average, parsed.count) == (3.0, 1)
+
+
+def test_histogram_without_an_average_is_unknown_not_zero():
+    parsed = parse_rating_histogram(HISTOGRAM_WITHOUT_AVERAGE)
+    assert parsed.average is None
+    assert parsed.count is None
+    assert parsed.is_known is False
+
+
+def test_blank_and_missing_includes_are_unknown():
+    for document in (EMPTY_INCLUDE, "", None):
+        parsed = parse_rating_histogram(document)
+        assert (parsed.average, parsed.count) == (None, None)
+
+
+def test_html_entities_in_the_phrase_are_tolerated():
+    document = _histogram(
+        '<a class="averagerating tooltip"'
+        ' title="Weighted&nbsp;average of 4.05 based on 12,000 ratings"> 4.1 </a>'
+    )
+    parsed = parse_rating_histogram(document)
+    assert (parsed.average, parsed.count) == (4.05, 12_000)
+
+
+def test_out_of_scale_average_is_loud_markup_drift():
+    document = _histogram(
+        '<a class="averagerating tooltip"'
+        ' title="Weighted average of 45.0 based on 10 ratings"> 45 </a>'
+    )
+    with pytest.raises(LetterboxdRatingParseError):
+        parse_rating_histogram(document)
+
+
+# ---------------------------------------------------------------------------
+# Slug resolution
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("slug", "url", "expected"),
+    [
+        ("the-dark-knight", None, "the-dark-knight"),
+        (None, "https://letterboxd.com/film/parasite-2019/", "parasite-2019"),
+        (None, "/film/interstellar/", "interstellar"),
+        ("", "https://letterboxd.com/film/abigail-2024/", "abigail-2024"),
+        ("  the-dark-knight  ", None, "the-dark-knight"),
+        (None, "https://letterboxd.com/whiteknight03x/", None),
+        (None, None, None),
+        ("", "", None),
+    ],
+)
+def test_slug_resolution_falls_back_to_the_film_url(slug, url, expected):
+    assert resolve_slug(slug, url) == expected
+
+
+# ---------------------------------------------------------------------------
+# Fetching (no network: a fake session stands in for curl_cffi)
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class FakeHTTPSession:
+    def __init__(self, responses):
+        self.headers = {}
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(url)
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+def _fetcher(responses, **overrides):
+    sleeps = []
+    kwargs = {
+        "session": FakeHTTPSession(responses),
+        "impersonates": False,
+        "backoff_seconds": 2.0,
+        "sleeper": sleeps.append,
+    }
+    kwargs.update(overrides)
+    return LetterboxdRatingFetcher(**kwargs), sleeps
+
+
+def test_transient_failure_is_retried_with_exponential_backoff():
+    fetcher, sleeps = _fetcher(
+        [FakeResponse(503), ConnectionError("reset"), FakeResponse(200, HISTOGRAM_WITH_AVERAGE)]
+    )
+    assert parse_rating_histogram(fetcher.fetch("the-dark-knight")).average == 4.5
+    assert sleeps == [2.0, 4.0]
+
+
+def test_missing_film_page_is_terminal_and_not_retried():
+    fetcher, sleeps = _fetcher([FakeResponse(404, "Not Found")])
+    assert fetcher.fetch("no-such-film") is None
+    assert sleeps == []
+
+
+def test_exhausted_retries_raise_rather_than_return_a_bad_value():
+    fetcher, _ = _fetcher([FakeResponse(500)] * 3, max_retries=3)
+    with pytest.raises(LetterboxdRatingError):
+        fetcher.fetch("the-dark-knight")
+
+
+def test_requested_url_is_the_lightweight_csi_include():
+    session = FakeHTTPSession([FakeResponse(200, HISTOGRAM_WITH_AVERAGE)])
+    LetterboxdRatingFetcher(session=session, impersonates=False, sleeper=lambda _: None).fetch(
+        "the-dark-knight"
+    )
+    assert session.calls == [
+        "https://letterboxd.com/csi/film/the-dark-knight/rating-histogram/"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Persistence, resume and isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    for table in (Profile.__table__, ProfileSync.__table__, Movie.__table__):
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def _add_movie(db: Session, movie_id: int, title: str, **overrides) -> Movie:
+    values = {
+        "id": movie_id,
+        "canonical_key": f"test:{movie_id}",
+        "title": title,
+        "normalized_title": title.casefold(),
+        "letterboxd_slug": title.casefold().replace(" ", "-"),
+        "letterboxd_url": None,
+    }
+    values.update(overrides)
+    movie = Movie(**values)
+    db.add(movie)
+    db.commit()
+    return movie
+
+
+class ScriptedFetcher:
+    """Returns a queued document (or raises) per slug; records call order."""
+
+    def __init__(self, by_slug):
+        self.by_slug = dict(by_slug)
+        self.calls = []
+
+    def fetch(self, slug):
+        self.calls.append(slug)
+        outcome = self.by_slug[slug]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+def test_successful_sync_writes_average_count_and_stamp(database):
+    _add_movie(database, 1, "The Dark Knight", letterboxd_slug="the-dark-knight")
+    fetcher = ScriptedFetcher({"the-dark-knight": HISTOGRAM_WITH_AVERAGE})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_average_rating == 4.5
+    assert movie.letterboxd_rating_count == 4_609_944
+    assert movie.letterboxd_rating_synced_at is not None
+    assert (stats.selected, stats.updated, stats.failed) == (1, 1, 0)
+
+
+def test_confirmed_absence_stamps_the_attempt_so_dead_films_are_not_retried(database):
+    _add_movie(database, 1, "Shrek 5", letterboxd_slug="shrek-5")
+    _add_movie(database, 2, "Gone", letterboxd_slug="gone-film")
+    fetcher = ScriptedFetcher({"shrek-5": EMPTY_INCLUDE, "gone-film": None})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    assert stats.unavailable == 2 and stats.updated == 0 and stats.failed == 0
+    for movie_id in (1, 2):
+        movie = database.get(Movie, movie_id)
+        assert movie.letterboxd_average_rating is None
+        assert movie.letterboxd_rating_count is None
+        assert movie.letterboxd_rating_synced_at is not None
+
+    # A second run inside the max-age window has nothing left to do.
+    resumed = sync_letterboxd_ratings(
+        database, ScriptedFetcher({}), sleeper=lambda _: None
+    )
+    assert resumed.selected == 0
+
+
+def test_a_failed_fetch_does_not_corrupt_existing_values_or_stop_the_run(database):
+    stamped = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    _add_movie(
+        database,
+        1,
+        "Interstellar",
+        letterboxd_slug="interstellar",
+        letterboxd_average_rating=4.36,
+        letterboxd_rating_count=1_000_000,
+        letterboxd_rating_synced_at=stamped,
+    )
+    _add_movie(database, 2, "Parasite", letterboxd_slug="parasite-2019")
+    fetcher = ScriptedFetcher(
+        {
+            "interstellar": LetterboxdRatingError("boom"),
+            "parasite-2019": HISTOGRAM_WITH_AVERAGE,
+        }
+    )
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, refresh=True, sleeper=lambda _: None
+    )
+
+    failed = database.get(Movie, 1)
+    assert failed.letterboxd_average_rating == 4.36
+    assert failed.letterboxd_rating_count == 1_000_000
+    # The stale stamp survives too, so the film is retried on the next run.
+    assert failed.letterboxd_rating_synced_at.replace(tzinfo=timezone.utc) == stamped
+
+    # The run continued past the failure.
+    assert database.get(Movie, 2).letterboxd_average_rating == 4.5
+    assert (stats.failed, stats.updated) == (1, 1)
+    assert stats.errors[0]["movie_id"] == 1
+
+
+def test_unknown_result_never_overwrites_a_known_average(database):
+    _add_movie(
+        database,
+        1,
+        "Interstellar",
+        letterboxd_slug="interstellar",
+        letterboxd_average_rating=4.36,
+        letterboxd_rating_count=1_000_000,
+    )
+    fetcher = ScriptedFetcher({"interstellar": HISTOGRAM_WITHOUT_AVERAGE})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_average_rating == 4.36
+    assert movie.letterboxd_rating_count == 1_000_000
+    assert movie.letterboxd_rating_synced_at is not None
+    assert stats.unavailable == 1
+
+
+def test_films_without_any_slug_are_reported_and_never_fetched(database):
+    _add_movie(database, 1, "No Identity", letterboxd_slug=None, letterboxd_url=None)
+    _add_movie(
+        database,
+        2,
+        "Url Only",
+        letterboxd_slug=None,
+        letterboxd_url="https://letterboxd.com/film/url-only-1999/",
+    )
+    fetcher = ScriptedFetcher({"url-only-1999": HISTOGRAM_WITH_AVERAGE})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    assert stats.skipped_no_slug == 1
+    assert stats.selected == 1
+    assert fetcher.calls == ["url-only-1999"]
+    assert database.get(Movie, 2).letterboxd_average_rating == 4.5
+
+
+def test_fresh_stamps_are_skipped_and_expired_ones_are_refetched(database):
+    now = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    _add_movie(
+        database,
+        1,
+        "Fresh",
+        letterboxd_slug="fresh",
+        letterboxd_rating_synced_at=now - timedelta(days=3),
+    )
+    _add_movie(
+        database,
+        2,
+        "Expired",
+        letterboxd_slug="expired",
+        letterboxd_rating_synced_at=now - timedelta(days=45),
+    )
+    fetcher = ScriptedFetcher({"expired": HISTOGRAM_WITH_AVERAGE})
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, max_age_days=30, now=now, sleeper=lambda _: None
+    )
+
+    assert fetcher.calls == ["expired"]
+    assert stats.selected == 1 and stats.updated == 1
+
+
+def test_refresh_overrides_a_fresh_stamp(database):
+    now = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    _add_movie(
+        database,
+        1,
+        "Fresh",
+        letterboxd_slug="fresh",
+        letterboxd_rating_synced_at=now - timedelta(days=1),
+    )
+    fetcher = ScriptedFetcher({"fresh": HISTOGRAM_WITH_AVERAGE})
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, refresh=True, now=now, sleeper=lambda _: None
+    )
+
+    assert fetcher.calls == ["fresh"] and stats.updated == 1
+
+
+def test_limit_bounds_the_run_and_never_synced_films_go_first(database):
+    now = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    _add_movie(
+        database,
+        1,
+        "Recently Expired",
+        letterboxd_slug="recently-expired",
+        letterboxd_rating_synced_at=now - timedelta(days=31),
+    )
+    _add_movie(
+        database,
+        2,
+        "Long Expired",
+        letterboxd_slug="long-expired",
+        letterboxd_rating_synced_at=now - timedelta(days=400),
+    )
+    _add_movie(database, 3, "Never Synced", letterboxd_slug="never-synced")
+    fetcher = ScriptedFetcher(
+        {"never-synced": HISTOGRAM_WITH_AVERAGE, "long-expired": HISTOGRAM_WITH_AVERAGE}
+    )
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, limit=2, now=now, sleeper=lambda _: None
+    )
+
+    assert fetcher.calls == ["never-synced", "long-expired"]
+    assert stats.selected == 2
+    assert database.get(Movie, 1).letterboxd_rating_synced_at.replace(
+        tzinfo=timezone.utc
+    ) == now - timedelta(days=31)
+
+
+def test_requests_are_paced_between_films(database):
+    _add_movie(database, 1, "One", letterboxd_slug="one")
+    _add_movie(database, 2, "Two", letterboxd_slug="two")
+    _add_movie(database, 3, "Three", letterboxd_slug="three")
+    fetcher = ScriptedFetcher({slug: HISTOGRAM_WITH_AVERAGE for slug in ("one", "two", "three")})
+    sleeps = []
+
+    sync_letterboxd_ratings(database, fetcher, delay_seconds=1.5, sleeper=sleeps.append)
+
+    # One sleep between requests, none before the first or after the last.
+    assert sleeps == [1.5, 1.5]
+
+
+def test_dry_run_counts_candidates_without_a_fetcher_or_writes(database):
+    _add_movie(database, 1, "The Dark Knight", letterboxd_slug="the-dark-knight")
+    _add_movie(database, 2, "No Identity", letterboxd_slug=None, letterboxd_url=None)
+
+    stats = sync_letterboxd_ratings(database, None, dry_run=True)
+
+    assert (stats.selected, stats.skipped_no_slug, stats.dry_run) == (1, 1, True)
+    assert database.get(Movie, 1).letterboxd_rating_synced_at is None
+
+
+def test_movie_id_filter_restricts_the_run(database):
+    _add_movie(database, 1, "One", letterboxd_slug="one")
+    _add_movie(database, 2, "Two", letterboxd_slug="two")
+    fetcher = ScriptedFetcher({"two": HISTOGRAM_WITH_AVERAGE})
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, movie_ids=[2], sleeper=lambda _: None
+    )
+
+    assert fetcher.calls == ["two"] and stats.selected == 1
+    assert database.get(Movie, 1).letterboxd_rating_synced_at is None
+
+
+def test_markup_drift_is_counted_as_a_failure_not_a_silent_zero(database):
+    _add_movie(database, 1, "Drifted", letterboxd_slug="drifted")
+    drifted = _histogram(
+        '<a class="averagerating tooltip"'
+        ' title="Weighted average of 9.10 based on 4,609,944 ratings"> 9.1 </a>'
+    )
+    fetcher = ScriptedFetcher({"drifted": drifted})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    assert stats.failed == 1 and stats.updated == 0 and stats.unavailable == 0
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_average_rating is None
+    assert movie.letterboxd_rating_synced_at is None

--- a/backend/tests/test_rating_comparison.py
+++ b/backend/tests/test_rating_comparison.py
@@ -85,8 +85,6 @@ def _film(
     *,
     year: Optional[int] = 2000,
     letterboxd_average: Optional[float] = None,
-    tmdb_vote_average: Optional[float] = None,
-    tmdb_vote_count: Optional[int] = None,
 ) -> Movie:
     movie_id = next(_MOVIE_IDS)
     movie = Movie(
@@ -99,22 +97,6 @@ def _film(
         letterboxd_average_rating=letterboxd_average,
     )
     database.add(movie)
-    if tmdb_vote_average is not None or tmdb_vote_count is not None:
-        details: dict[str, Any] = {}
-        if tmdb_vote_average is not None:
-            details["vote_average"] = tmdb_vote_average
-        if tmdb_vote_count is not None:
-            details["vote_count"] = tmdb_vote_count
-        database.add(
-            MovieEnrichment(
-                movie_id=movie_id,
-                genres=[],
-                keywords=[],
-                credits={},
-                production_countries=[],
-                raw_payload={"details": details},
-            )
-        )
     database.commit()
     return movie
 
@@ -335,62 +317,17 @@ def test_only_active_completed_profiles_count_towards_the_group(
     assert payload["most_generous"][0]["group_average"] == 3.0
 
 
-# --- TMDB is scored out of ten ----------------------------------------------
+# --- Letterboxd is the only external reference ------------------------------
 
 
-def test_tmdb_average_is_halved_onto_the_five_point_scale(database: Session) -> None:
-    subject = _profile(database, "subject")
-    circle = _circle(database)
-    _shared(
-        database,
-        subject,
-        circle,
-        "Eight Out Of Ten",
-        subject_rating=4.0,
-        other_ratings=[3.0, 3.0],
-        tmdb_vote_average=8.0,
-        tmdb_vote_count=1200,
-    )
-
-    payload = build_rating_comparison(database, subject)
-
-    # 8/10 is 4/5, so a 4.0 rating agrees exactly. Skipping the conversion
-    # would report a -4.0 delta against a nonsense 8-star crowd.
-    assert payload["most_generous"][0]["tmdb_average"] == 4.0
-    assert payload["summary"]["tmdb_delta"] == 0.0
-    assert payload["coverage"]["tmdb_average_films"] == 1
-
-
-def test_a_tmdb_film_with_no_votes_has_no_average(database: Session) -> None:
-    subject = _profile(database, "subject")
-    circle = _circle(database)
-    _shared(
-        database,
-        subject,
-        circle,
-        "Nobody Voted",
-        subject_rating=4.0,
-        other_ratings=[3.0, 3.0],
-        tmdb_vote_average=0.0,
-        tmdb_vote_count=0,
-    )
-
-    payload = build_rating_comparison(database, subject)
-
-    # An unvoted film reports 0.0; treating that as a crowd verdict would
-    # invent a +4.0 delta out of an absent opinion.
-    assert payload["coverage"]["tmdb_average_films"] == 0
-    assert payload["summary"]["tmdb_delta"] is None
-    assert payload["most_generous"][0]["tmdb_average"] is None
-
-
-def test_tmdb_delta_covers_every_rated_film_with_an_average(
+def test_letterboxd_delta_covers_every_rated_film_with_an_average(
     database: Session,
 ) -> None:
     subject = _profile(database, "subject")
     circle = _circle(database)
-    # Rated by the subject alone: no group comparison, but TMDB still applies.
-    lonely = _film(database, "Solo Watch", tmdb_vote_average=6.0, tmdb_vote_count=50)
+    # Rated by the subject alone: no group to compare against, but Letterboxd's
+    # crowd still has an opinion, so the film counts towards that reference.
+    lonely = _film(database, "Solo Watch", letterboxd_average=3.0)
     _rate(database, subject, lonely, 4.0)
     _shared(
         database,
@@ -399,16 +336,38 @@ def test_tmdb_delta_covers_every_rated_film_with_an_average(
         "Shared Watch",
         subject_rating=3.0,
         other_ratings=[3.0, 3.0],
-        tmdb_vote_average=7.0,
-        tmdb_vote_count=90,
+        letterboxd_average=3.5,
     )
 
     payload = build_rating_comparison(database, subject)
 
-    assert payload["coverage"]["tmdb_average_films"] == 2
+    assert payload["coverage"]["letterboxd_average_films"] == 2
     # (4.0 - 3.0) and (3.0 - 3.5) average to +0.25.
-    assert payload["summary"]["tmdb_delta"] == 0.25
+    assert payload["summary"]["letterboxd_delta"] == 0.25
     assert payload["coverage"]["compared_films"] == 1
+
+
+def test_a_zero_letterboxd_average_is_an_absent_opinion(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Zeroed Out",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+        letterboxd_average=0.0,
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # Letterboxd never publishes a 0.0 crowd average -- no film can be rated
+    # below half a star -- so a stored zero is a missing figure. Comparing
+    # against it would invent a +4.0 delta out of an absent opinion.
+    assert payload["coverage"]["letterboxd_average_films"] == 0
+    assert payload["summary"]["letterboxd_delta"] is None
+    assert payload["most_generous"][0]["letterboxd_average"] is None
 
 
 # --- Letterboxd degrades to null until its backfill lands -------------------
@@ -698,12 +657,10 @@ def test_a_profile_with_no_overlap_returns_a_valid_payload(database: Session) ->
         "compared_films": 0,
         "min_raters": 2,
         "letterboxd_average_films": 0,
-        "tmdb_average_films": 0,
     }
     assert payload["summary"] == {
         "group_delta": None,
         "letterboxd_delta": None,
-        "tmdb_delta": None,
         "lean": None,
         "agreement": None,
     }
@@ -796,7 +753,6 @@ def test_route_serves_the_payload_for_a_tracked_profile(
         "delta",
         "rater_count",
         "letterboxd_average",
-        "tmdb_average",
     }
     assert set(payload["most_divisive"][0]) == {
         "title",

--- a/backend/tests/test_rating_comparison.py
+++ b/backend/tests/test_rating_comparison.py
@@ -1,0 +1,844 @@
+"""Rating comparison: a profile measured against a circle it is not part of."""
+from __future__ import annotations
+
+from itertools import count
+from typing import Any, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from auth import ClerkUser
+from backend import main as backend_main
+from database.models import (
+    AppUser,
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileAccessRequest,
+    ProfileFilm,
+    UserTrackedProfile,
+)
+from services.rating_comparison import MAX_LIMIT, _clamp_limit, build_rating_comparison
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    Movie.__table__,
+    ProfileFilm.__table__,
+    MovieEnrichment.__table__,
+    AppUser.__table__,
+    UserTrackedProfile.__table__,
+    ProfileAccessRequest.__table__,
+)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+_MOVIE_IDS = count(1)
+
+
+def _profile(
+    database: Session,
+    username: str,
+    *,
+    is_active: bool = True,
+    scraping_status: str = "completed",
+) -> Profile:
+    profile = Profile(
+        username=username,
+        scraping_status=scraping_status,
+        is_active=is_active,
+    )
+    database.add(profile)
+    database.commit()
+    return profile
+
+
+def _film(
+    database: Session,
+    title: str,
+    *,
+    year: Optional[int] = 2000,
+    letterboxd_average: Optional[float] = None,
+    tmdb_vote_average: Optional[float] = None,
+    tmdb_vote_count: Optional[int] = None,
+) -> Movie:
+    movie_id = next(_MOVIE_IDS)
+    movie = Movie(
+        id=movie_id,
+        canonical_key=f"letterboxd:{title}-{movie_id}",
+        title=title,
+        normalized_title=title.casefold(),
+        release_year=year,
+        letterboxd_url=f"https://letterboxd.com/film/{movie_id}/",
+        letterboxd_average_rating=letterboxd_average,
+    )
+    database.add(movie)
+    if tmdb_vote_average is not None or tmdb_vote_count is not None:
+        details: dict[str, Any] = {}
+        if tmdb_vote_average is not None:
+            details["vote_average"] = tmdb_vote_average
+        if tmdb_vote_count is not None:
+            details["vote_count"] = tmdb_vote_count
+        database.add(
+            MovieEnrichment(
+                movie_id=movie_id,
+                genres=[],
+                keywords=[],
+                credits={},
+                production_countries=[],
+                raw_payload={"details": details},
+            )
+        )
+    database.commit()
+    return movie
+
+
+def _rate(
+    database: Session,
+    profile: Profile,
+    movie: Movie,
+    rating: Optional[float],
+) -> None:
+    database.add(
+        ProfileFilm(
+            profile_id=profile.id,
+            movie_id=movie.id,
+            rating=rating,
+            tags=[],
+            watch_count=1,
+            rewatch_count=0,
+        )
+    )
+    database.commit()
+
+
+def _circle(database: Session, size: int = 2) -> list[Profile]:
+    return [_profile(database, f"other{index}") for index in range(size)]
+
+
+def _shared(
+    database: Session,
+    subject: Profile,
+    circle: list[Profile],
+    title: str,
+    *,
+    subject_rating: Optional[float],
+    other_ratings: list[Optional[float]],
+    **film_kwargs: Any,
+) -> Movie:
+    """One film rated by the subject and by ``len(other_ratings)`` others."""
+
+    movie = _film(database, title, **film_kwargs)
+    _rate(database, subject, movie, subject_rating)
+    for profile, rating in zip(circle, other_ratings):
+        _rate(database, profile, movie, rating)
+    return movie
+
+
+# --- the group never contains the profile being measured --------------------
+
+
+def test_the_group_average_excludes_the_profile_being_measured(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    # Both others said 3.0. Excluding the subject the group is exactly 3.0;
+    # folding the subject in would drag it to 3.67 / 2.33 and halve both deltas.
+    _shared(
+        database,
+        subject,
+        circle,
+        "Loved It",
+        subject_rating=5.0,
+        other_ratings=[3.0, 3.0],
+    )
+    _shared(
+        database,
+        subject,
+        circle,
+        "Hated It",
+        subject_rating=1.0,
+        other_ratings=[3.0, 3.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["most_generous"][0]["title"] == "Loved It"
+    assert payload["most_generous"][0]["group_average"] == 3.0
+    assert payload["most_generous"][0]["delta"] == 2.0
+    assert payload["most_harsh"][0]["title"] == "Hated It"
+    assert payload["most_harsh"][0]["group_average"] == 3.0
+    assert payload["most_harsh"][0]["delta"] == -2.0
+    assert payload["summary"]["group_delta"] == 0.0
+    assert payload["summary"]["lean"] == "aligned"
+
+
+def test_a_profile_is_not_correlated_with_itself(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    # Everyone else rated every shared film 3.0, so the group has no variance
+    # to agree or disagree with. Leaving the subject inside its own group
+    # average would manufacture a perfect 1.0 correlation out of nothing.
+    for title, rating in (("First", 5.0), ("Second", 4.0), ("Third", 2.0)):
+        _shared(
+            database,
+            subject,
+            circle,
+            title,
+            subject_rating=rating,
+            other_ratings=[3.0, 3.0],
+        )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["compared_films"] == 3
+    assert payload["summary"]["agreement"] is None
+    assert payload["summary"]["group_delta"] == 0.67
+    assert payload["summary"]["lean"] == "generous"
+
+
+def test_agreement_needs_three_paired_films(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for title, subject_rating, others in (
+        ("Low", 1.0, [1.0, 1.5]),
+        ("High", 5.0, [4.5, 5.0]),
+    ):
+        _shared(
+            database,
+            subject,
+            circle,
+            title,
+            subject_rating=subject_rating,
+            other_ratings=others,
+        )
+
+    # Two points always correlate perfectly; that is arithmetic, not agreement.
+    assert build_rating_comparison(database, subject)["summary"]["agreement"] is None
+
+    _shared(
+        database,
+        subject,
+        circle,
+        "Middle",
+        subject_rating=3.0,
+        other_ratings=[3.0, 3.5],
+    )
+
+    assert build_rating_comparison(database, subject)["summary"]["agreement"] == 1.0
+
+
+# --- the two-other-raters floor ---------------------------------------------
+
+
+def test_a_film_needs_two_other_raters_before_it_is_compared(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=2)
+    _shared(
+        database,
+        subject,
+        circle,
+        "One Other Opinion",
+        subject_rating=5.0,
+        other_ratings=[1.0],
+    )
+    _shared(
+        database,
+        subject,
+        circle,
+        "An Actual Group",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["rated_films"] == 2
+    assert payload["coverage"]["compared_films"] == 1
+    assert payload["coverage"]["min_raters"] == 2
+    # The lone-other film carried the bigger gap and is still excluded.
+    assert [entry["title"] for entry in payload["most_generous"]] == ["An Actual Group"]
+    assert payload["most_generous"][0]["rater_count"] == 2
+    assert payload["summary"]["group_delta"] == 1.0
+
+
+def test_an_unrated_row_is_not_a_rater(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Logged But Unrated",
+        subject_rating=5.0,
+        other_ratings=[3.0, None],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # Only one of the two others actually rated it, so it is not comparable.
+    assert payload["coverage"]["compared_films"] == 0
+    assert payload["summary"]["group_delta"] is None
+    assert payload["summary"]["lean"] is None
+
+
+def test_only_active_completed_profiles_count_towards_the_group(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    usable = _circle(database)
+    pending = _profile(database, "pending", scraping_status="pending")
+    retired = _profile(database, "retired", is_active=False)
+    movie = _shared(
+        database,
+        subject,
+        usable,
+        "Shared",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+    )
+    _rate(database, pending, movie, 1.0)
+    _rate(database, retired, movie, 1.0)
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["most_generous"][0]["rater_count"] == 2
+    assert payload["most_generous"][0]["group_average"] == 3.0
+
+
+# --- TMDB is scored out of ten ----------------------------------------------
+
+
+def test_tmdb_average_is_halved_onto_the_five_point_scale(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Eight Out Of Ten",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+        tmdb_vote_average=8.0,
+        tmdb_vote_count=1200,
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # 8/10 is 4/5, so a 4.0 rating agrees exactly. Skipping the conversion
+    # would report a -4.0 delta against a nonsense 8-star crowd.
+    assert payload["most_generous"][0]["tmdb_average"] == 4.0
+    assert payload["summary"]["tmdb_delta"] == 0.0
+    assert payload["coverage"]["tmdb_average_films"] == 1
+
+
+def test_a_tmdb_film_with_no_votes_has_no_average(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Nobody Voted",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+        tmdb_vote_average=0.0,
+        tmdb_vote_count=0,
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # An unvoted film reports 0.0; treating that as a crowd verdict would
+    # invent a +4.0 delta out of an absent opinion.
+    assert payload["coverage"]["tmdb_average_films"] == 0
+    assert payload["summary"]["tmdb_delta"] is None
+    assert payload["most_generous"][0]["tmdb_average"] is None
+
+
+def test_tmdb_delta_covers_every_rated_film_with_an_average(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    # Rated by the subject alone: no group comparison, but TMDB still applies.
+    lonely = _film(database, "Solo Watch", tmdb_vote_average=6.0, tmdb_vote_count=50)
+    _rate(database, subject, lonely, 4.0)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Shared Watch",
+        subject_rating=3.0,
+        other_ratings=[3.0, 3.0],
+        tmdb_vote_average=7.0,
+        tmdb_vote_count=90,
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["tmdb_average_films"] == 2
+    # (4.0 - 3.0) and (3.0 - 3.5) average to +0.25.
+    assert payload["summary"]["tmdb_delta"] == 0.25
+    assert payload["coverage"]["compared_films"] == 1
+
+
+# --- Letterboxd degrades to null until its backfill lands -------------------
+
+
+def test_letterboxd_fields_are_null_before_the_backfill(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Unbackfilled",
+        subject_rating=4.5,
+        other_ratings=[3.0, 3.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["letterboxd_average_films"] == 0
+    assert payload["summary"]["letterboxd_delta"] is None
+    assert payload["most_generous"][0]["letterboxd_average"] is None
+    # The local comparison is unaffected by the missing crowd average.
+    assert payload["summary"]["group_delta"] == 1.5
+    assert payload["summary"]["lean"] == "generous"
+
+
+def test_letterboxd_delta_is_computed_once_the_average_exists(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Backfilled",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+        letterboxd_average=3.5,
+    )
+    _shared(
+        database,
+        subject,
+        circle,
+        "Still Pending",
+        subject_rating=4.0,
+        other_ratings=[3.0, 3.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["letterboxd_average_films"] == 1
+    assert payload["summary"]["letterboxd_delta"] == 0.5
+    assert payload["most_generous"][0]["letterboxd_average"] == 3.5
+    assert payload["most_generous"][1]["letterboxd_average"] is None
+
+
+# --- divisiveness is a property of the whole group --------------------------
+
+
+def test_a_spread_needs_three_raters(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=2)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Two Raters Wide Apart",
+        subject_rating=5.0,
+        other_ratings=[1.0],
+    )
+    _shared(
+        database,
+        subject,
+        circle,
+        "Three Raters Close Together",
+        subject_rating=4.5,
+        other_ratings=[4.5, 4.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # The four-star gap between two people is not a divided audience.
+    assert [entry["title"] for entry in payload["most_divisive"]] == [
+        "Three Raters Close Together"
+    ]
+    assert payload["most_divisive"][0]["rating_spread"] == 0.5
+    assert payload["most_divisive"][0]["rater_count"] == 3
+
+
+def test_divisiveness_is_the_group_spread_not_this_profiles_delta(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=3)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Split Down The Middle",
+        subject_rating=3.0,
+        other_ratings=[5.0, 1.0, 3.0],
+    )
+    _shared(
+        database,
+        subject,
+        circle,
+        "One Holdout",
+        subject_rating=4.0,
+        other_ratings=[5.0, 5.0, 2.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    # The subject sits on the group average for both films -- zero delta each --
+    # yet both are contested, and the four-star split outranks the holdout.
+    assert [entry["title"] for entry in payload["most_divisive"]] == [
+        "Split Down The Middle",
+        "One Holdout",
+    ]
+    assert payload["most_divisive"][0]["rating_spread"] == 4.0
+    assert payload["most_divisive"][0]["rater_count"] == 4
+    assert payload["most_divisive"][0]["profile_rating"] == 3.0
+    assert payload["most_divisive"][1]["rating_spread"] == 3.0
+    assert payload["most_generous"] == []
+    assert payload["most_harsh"] == []
+
+
+def test_a_divisive_film_the_profile_never_rated_reports_a_null_rating(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=3)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Logged Not Rated",
+        subject_rating=None,
+        other_ratings=[5.0, 3.0, 1.0],
+    )
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["rated_films"] == 0
+    entry = payload["most_divisive"][0]
+    assert entry["profile_rating"] is None
+    assert entry["rating_spread"] == 4.0
+    assert entry["rater_count"] == 3
+    assert entry["group_average"] == 3.0
+
+
+# --- lean thresholds --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("subject_rating", "expected_delta", "expected_lean"),
+    [
+        (3.5, 0.5, "generous"),
+        (3.16, 0.16, "generous"),
+        (3.15, 0.15, "aligned"),
+        (3.0, 0.0, "aligned"),
+        (2.85, -0.15, "aligned"),
+        (2.84, -0.16, "harsh"),
+        (2.5, -0.5, "harsh"),
+    ],
+)
+def test_lean_thresholds(
+    database: Session,
+    subject_rating: float,
+    expected_delta: float,
+    expected_lean: str,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Benchmark",
+        subject_rating=subject_rating,
+        other_ratings=[3.0, 3.0],
+    )
+
+    summary = build_rating_comparison(database, subject)["summary"]
+
+    assert summary["group_delta"] == expected_delta
+    # The lean reads the reported delta, so the label and the number agree.
+    assert summary["lean"] == expected_lean
+
+
+# --- list construction ------------------------------------------------------
+
+
+def test_generous_and_harsh_lists_only_hold_films_pointing_that_way(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for title, rating in (("Harsher", 1.0), ("Harsh", 2.0), ("Level", 3.0)):
+        _shared(
+            database,
+            subject,
+            circle,
+            title,
+            subject_rating=rating,
+            other_ratings=[3.0, 3.0],
+        )
+
+    payload = build_rating_comparison(database, subject)
+
+    # A uniformly harsh profile has no generous films; its least-harsh film is
+    # not a generous one.
+    assert payload["most_generous"] == []
+    assert [entry["title"] for entry in payload["most_harsh"]] == ["Harsher", "Harsh"]
+    assert payload["summary"]["lean"] == "harsh"
+
+
+def test_lists_respect_the_limit(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=3)
+    for index in range(15):
+        _shared(
+            database,
+            subject,
+            circle,
+            f"Film {index:02d}",
+            subject_rating=5.0,
+            other_ratings=[1.0, 2.0, 3.0],
+        )
+
+    default_payload = build_rating_comparison(database, subject)
+    limited = build_rating_comparison(database, subject, limit=3)
+
+    assert len(default_payload["most_generous"]) == 10
+    assert len(default_payload["most_divisive"]) == 10
+    assert len(limited["most_generous"]) == 3
+    assert len(limited["most_divisive"]) == 3
+    # The coverage counts are never truncated by the display limit.
+    assert limited["coverage"]["compared_films"] == 15
+
+
+def test_the_limit_is_clamped_to_the_documented_range() -> None:
+    assert _clamp_limit(None) == 10
+    assert _clamp_limit(0) == 1
+    assert _clamp_limit(500) == MAX_LIMIT
+    assert _clamp_limit("not a number") == 10
+
+
+def test_film_entries_carry_their_display_identity(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    movie = _shared(
+        database,
+        subject,
+        circle,
+        "Identified",
+        subject_rating=5.0,
+        other_ratings=[3.0, 3.0],
+        year=1994,
+    )
+
+    entry = build_rating_comparison(database, subject)["most_generous"][0]
+
+    assert entry["title"] == "Identified"
+    assert entry["year"] == 1994
+    assert entry["letterboxd_url"] == f"https://letterboxd.com/film/{movie.id}/"
+    assert entry["poster_url"] is None
+
+
+# --- graceful degradation ---------------------------------------------------
+
+
+def test_a_profile_with_no_overlap_returns_a_valid_payload(database: Session) -> None:
+    subject = _profile(database, "subject")
+    _circle(database)
+    for title in ("Alone One", "Alone Two"):
+        movie = _film(database, title)
+        _rate(database, subject, movie, 4.0)
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["username"] == "subject"
+    assert payload["coverage"] == {
+        "rated_films": 2,
+        "compared_films": 0,
+        "min_raters": 2,
+        "letterboxd_average_films": 0,
+        "tmdb_average_films": 0,
+    }
+    assert payload["summary"] == {
+        "group_delta": None,
+        "letterboxd_delta": None,
+        "tmdb_delta": None,
+        "lean": None,
+        "agreement": None,
+    }
+    assert payload["most_generous"] == []
+    assert payload["most_harsh"] == []
+    assert payload["most_divisive"] == []
+
+
+def test_a_profile_with_no_films_at_all_returns_a_valid_payload(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+
+    payload = build_rating_comparison(database, subject)
+
+    assert payload["coverage"]["rated_films"] == 0
+    assert payload["summary"]["group_delta"] is None
+    assert payload["most_divisive"] == []
+
+
+# --- route ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(database: Session):
+    backend_main.app.dependency_overrides[backend_main.get_db] = lambda: database
+    try:
+        yield lambda: TestClient(backend_main.app)
+    finally:
+        backend_main.app.dependency_overrides.clear()
+
+
+def _tracked_user(database: Session, profile: Optional[Profile]) -> ClerkUser:
+    app_user = AppUser(clerk_user_id="user_one", primary_profile_required=False)
+    database.add(app_user)
+    database.flush()
+    if profile is not None:
+        database.add(
+            UserTrackedProfile(
+                user_id=app_user.id,
+                profile_id=profile.id,
+                source="direct",
+            )
+        )
+    database.commit()
+    return ClerkUser(
+        user_id="user_one",
+        session_id="session",
+        is_admin=False,
+        letterboxd_username=None,
+    )
+
+
+def test_route_serves_the_payload_for_a_tracked_profile(
+    database: Session,
+    client,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _shared(
+        database,
+        subject,
+        circle,
+        "Tracked Film",
+        subject_rating=5.0,
+        other_ratings=[3.0, 3.0],
+    )
+    user = _tracked_user(database, subject)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client().get("/api/profiles/subject/rating-comparison")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {
+        "username",
+        "coverage",
+        "summary",
+        "most_generous",
+        "most_harsh",
+        "most_divisive",
+    }
+    assert set(payload["most_generous"][0]) == {
+        "title",
+        "year",
+        "poster_url",
+        "letterboxd_url",
+        "profile_rating",
+        "group_average",
+        "delta",
+        "rater_count",
+        "letterboxd_average",
+        "tmdb_average",
+    }
+    assert set(payload["most_divisive"][0]) == {
+        "title",
+        "year",
+        "poster_url",
+        "letterboxd_url",
+        "rating_spread",
+        "rater_count",
+        "group_average",
+        "profile_rating",
+    }
+    assert payload["summary"]["lean"] == "generous"
+
+
+def test_route_honours_the_limit_query_parameter(database: Session, client) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for index in range(4):
+        _shared(
+            database,
+            subject,
+            circle,
+            f"Film {index}",
+            subject_rating=5.0,
+            other_ratings=[3.0, 3.0],
+        )
+    user = _tracked_user(database, subject)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client().get("/api/profiles/subject/rating-comparison?limit=2")
+    rejected = client().get("/api/profiles/subject/rating-comparison?limit=51")
+
+    assert response.status_code == 200
+    assert len(response.json()["most_generous"]) == 2
+    assert rejected.status_code == 422
+
+
+def test_route_refuses_an_untracked_profile(database: Session, client) -> None:
+    _profile(database, "subject")
+    user = _tracked_user(database, None)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client().get("/api/profiles/subject/rating-comparison")
+
+    assert response.status_code == 403

--- a/backend/tests/test_route_access_matrix.py
+++ b/backend/tests/test_route_access_matrix.py
@@ -79,4 +79,7 @@ def test_existing_mutations_keep_admin_or_ingestion_auth():
     assert "get_active_upload_user" in _dependency_names(
         _route("POST", "/profiles/{username}/rename")
     )
+    assert "get_active_upload_user" in _dependency_names(
+        _route("POST", "/api/films/letterboxd-ratings")
+    )
     assert "get_current_user" in _dependency_names(_route("POST", "/profiles/{profile_id}/tracking"))

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -320,12 +320,10 @@ export const ratingComparison = {
     compared_films: 312,
     min_raters: 2,
     letterboxd_average_films: 268,
-    tmdb_average_films: 295,
   },
   summary: {
     group_delta: 0.31,
     letterboxd_delta: -0.12,
-    tmdb_delta: 0.04,
     lean: 'generous',
     agreement: 0.62,
   },
@@ -340,7 +338,6 @@ export const ratingComparison = {
       delta: 1.75,
       rater_count: 4,
       letterboxd_average: 3.21,
-      tmdb_average: 6.8,
     },
     {
       title: 'Unenriched Champion',
@@ -352,7 +349,6 @@ export const ratingComparison = {
       delta: 1.5,
       rater_count: 3,
       letterboxd_average: null,
-      tmdb_average: null,
     },
   ],
   most_harsh: [
@@ -366,7 +362,6 @@ export const ratingComparison = {
       delta: -2.33,
       rater_count: 5,
       letterboxd_average: 3.94,
-      tmdb_average: 7.6,
     },
   ],
   most_divisive: [

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -310,6 +310,89 @@ export const profileStats = {
   letterboxd_reported: { hours: 2_130, directors: 640, longest_streak: 19 },
 };
 
+// Ratings against the rest of the tracked circle. Deliberately mixed: one
+// champion without a Letterboxd crowd average and one divisive film this
+// profile never rated, so both omission branches render.
+export const ratingComparison = {
+  username: 'alpha',
+  coverage: {
+    rated_films: 900,
+    compared_films: 312,
+    min_raters: 2,
+    letterboxd_average_films: 268,
+    tmdb_average_films: 295,
+  },
+  summary: {
+    group_delta: 0.31,
+    letterboxd_delta: -0.12,
+    tmdb_delta: 0.04,
+    lean: 'generous',
+    agreement: 0.62,
+  },
+  most_generous: [
+    {
+      title: 'Champion Fixture Film',
+      year: 2019,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/champion-fixture-film/',
+      profile_rating: 4.5,
+      group_average: 2.75,
+      delta: 1.75,
+      rater_count: 4,
+      letterboxd_average: 3.21,
+      tmdb_average: 6.8,
+    },
+    {
+      title: 'Unenriched Champion',
+      year: null,
+      poster_url: null,
+      letterboxd_url: null,
+      profile_rating: 5,
+      group_average: 3.5,
+      delta: 1.5,
+      rater_count: 3,
+      letterboxd_average: null,
+      tmdb_average: null,
+    },
+  ],
+  most_harsh: [
+    {
+      title: 'Panned Fixture Film',
+      year: 2021,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/panned-fixture-film/',
+      profile_rating: 1.5,
+      group_average: 3.83,
+      delta: -2.33,
+      rater_count: 5,
+      letterboxd_average: 3.94,
+      tmdb_average: 7.6,
+    },
+  ],
+  most_divisive: [
+    {
+      title: 'Divisive Fixture Film',
+      year: 2017,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/divisive-fixture-film/',
+      rating_spread: 3,
+      rater_count: 6,
+      group_average: 3.08,
+      profile_rating: 4.5,
+    },
+    {
+      title: 'Unrated Divisive Fixture',
+      year: 2013,
+      poster_url: null,
+      letterboxd_url: null,
+      rating_spread: 2.5,
+      rater_count: 4,
+      group_average: 2.88,
+      profile_rating: null,
+    },
+  ],
+};
+
 const dataCoverage = {
   generated_at: '2026-07-29T12:00:00Z',
   overall_score: 100,
@@ -685,6 +768,17 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     const statsMatch = path.match(/^\/api\/profiles\/([^/]+)\/stats$/);
     if (statsMatch) {
       return json(route, { ...profileStats, username: decodeURIComponent(statsMatch[1]) });
+    }
+  }
+  {
+    // Rating comparison against the tracked circle. Contract-shaped so the
+    // Analysis panel renders instead of 404-ing into a console error.
+    const comparisonMatch = path.match(/^\/api\/profiles\/([^/]+)\/rating-comparison$/);
+    if (comparisonMatch) {
+      return json(route, {
+        ...ratingComparison,
+        username: decodeURIComponent(comparisonMatch[1]),
+      });
     }
   }
   {

--- a/frontend/src/components/FollowNetwork.tsx
+++ b/frontend/src/components/FollowNetwork.tsx
@@ -40,7 +40,11 @@ const EGO_LABEL_REACH = 166;
 /** The ego ring never pulls in tighter than this, however cramped the frame. */
 const MIN_EGO_RADIUS = 150;
 /** Ego view stays readable only if the fan of leaves stays small. */
-const MAX_EXTRA_LEAVES = 10;
+/** Counterparts outside the tracked group shown around an ego view. The
+ *  bundled layout stays readable to ~70 nodes, so this is generous enough
+ *  that most profiles show every connection; when it does bite, the header
+ *  says so rather than silently presenting a partial graph as complete. */
+const MAX_EXTRA_LEAVES = 45;
 
 const MUTUAL_COLOR = '#34d399'; // emerald-400
 const ONEWAY_COLOR = '#f57c00'; // cinema-400
@@ -322,7 +326,15 @@ function NodeAvatar({
  * the profile's deep dive and any tracked leaf re-centres the graph, so the
  * follow network can be walked one hop at a time.
  */
-export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] }) {
+export default function FollowNetwork({
+  profiles,
+  onFocusChange,
+}: {
+  profiles: ProfileInfo[];
+  /** Notified with the centred username, or null in the full view, so a
+   *  surrounding page can follow the selection instead of contradicting it. */
+  onFocusChange?: (username: string | null) => void;
+}) {
   const reactId = useId();
   const router = useRouter();
   const reduceMotion = useReducedMotion();
@@ -461,6 +473,11 @@ export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] })
 
   // Optional richer per-person edges, including counterparts outside the
   // tracked group. Failures stay silent: the group-only ego view still works.
+
+  // Keep the surrounding page in step with the centred profile.
+  useEffect(() => {
+    onFocusChange?.(focusNode?.username ?? null);
+  }, [focusNode?.username, onFocusChange]);
   const egoQuery = useQuery({
     queryKey: ['follow-graph', 'ego', focusNode?.username ?? ''],
     queryFn: () => followGraphApi.getFollowGraph(focusNode?.username ?? '', { direction: 'both', limit: 80 }),
@@ -505,6 +522,20 @@ export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] })
       )
       .slice(0, MAX_EXTRA_LEAVES);
   }, [focusNode, egoQuery.data?.edges, egoQuery.isError, groupIndexByKey]);
+
+  // How many outside counterparts exist versus how many the ring shows, so a
+  // truncated view can say so instead of looking complete.
+  const hiddenExtraCount = useMemo(() => {
+    if (!focusNode || egoQuery.isError) return 0;
+    const outside = new Set<string>();
+    (egoQuery.data?.edges ?? []).forEach((edge) => {
+      if (edge.removed_at) return;
+      const key = edge.counterpart_username?.toLowerCase();
+      if (!key || key === focusNode.key || groupIndexByKey.has(key)) return;
+      outside.add(key);
+    });
+    return Math.max(0, outside.size - extraNodes.length);
+  }, [focusNode, egoQuery.data?.edges, egoQuery.isError, groupIndexByKey, extraNodes.length]);
 
   // Leaves keep the ring's angular order so the collapse into ego view reads
   // as a fold-in rather than a shuffle; outside counterparts come last.
@@ -884,7 +915,9 @@ export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] })
           {!networkQuery.isLoading && groupNodes.length > 0 && (
             <span className="text-xs text-white/40">
               {focusNode
-                ? `@${focusNode.username} · ${egoLeafKeys.length} connection${egoLeafKeys.length === 1 ? '' : 's'}`
+                ? `@${focusNode.username} · ${egoLeafKeys.length} connection${egoLeafKeys.length === 1 ? '' : 's'}${
+                    hiddenExtraCount > 0 ? ` · ${hiddenExtraCount} more not shown` : ''
+                  }`
                 : `${groupNodes.length} profiles · ${mutualCount} mutual · ${onewayCount} one-way`}
             </span>
           )}
@@ -960,17 +993,27 @@ export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] })
               }
             >
               <defs>
+                {/* Arrowheads sit at the followed end of a one-way edge and
+                    are the only thing distinguishing direction, so they are
+                    drawn larger than the stroke and outlined against the
+                    panel to stay legible where curves converge. */}
                 <marker
                   id={`${reactId}-arrow`}
-                  viewBox="0 0 10 10"
-                  refX="9"
-                  refY="5"
-                  markerWidth="9"
-                  markerHeight="9"
+                  viewBox="0 0 12 12"
+                  refX="11"
+                  refY="6"
+                  markerWidth="13"
+                  markerHeight="13"
                   markerUnits="userSpaceOnUse"
                   orient="auto-start-reverse"
                 >
-                  <path d="M 0 0 L 10 5 L 0 10 z" fill={ONEWAY_COLOR} />
+                  <path
+                    d="M 0 0.5 L 12 6 L 0 11.5 z"
+                    fill={ONEWAY_COLOR}
+                    stroke="#0b1220"
+                    strokeWidth="1"
+                    strokeLinejoin="round"
+                  />
                 </marker>
                 {/* Nodes draw around their own origin, so one clip serves them all. */}
                 <clipPath id={`${reactId}-node-clip`}>
@@ -1021,7 +1064,7 @@ export default function FollowNetwork({ profiles }: { profiles: ProfileInfo[] })
                         stroke={edge.mutual ? MUTUAL_COLOR : ONEWAY_COLOR}
                         strokeWidth={incidentToFocus || incidentToHover ? 2.5 : 1.75}
                         strokeLinecap="round"
-                        strokeDasharray={untracked ? '5 5' : undefined}
+                        strokeDasharray={untracked ? '6 4' : undefined}
                         markerEnd={edge.mutual ? undefined : `url(#${reactId}-arrow)`}
                         style={{ pointerEvents: 'none' }}
                       />

--- a/frontend/src/components/insights/RatingComparisonPanel.tsx
+++ b/frontend/src/components/insights/RatingComparisonPanel.tsx
@@ -1,0 +1,431 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { Minus, Scale, TrendingDown, TrendingUp } from 'lucide-react';
+
+import { ratingComparisonApi } from '../../services/api';
+import type {
+  MovieSummary,
+  RatingComparisonDivisiveFilm,
+  RatingComparisonFilm,
+  RatingComparisonLean,
+} from '../../services/api';
+import { MoviePoster } from './InsightUI';
+
+/** The band the API documents for calling a profile generous or harsh. */
+const LEAN_BAND = 0.15;
+
+type Direction = 'above' | 'below' | 'level';
+
+const DIRECTION_STYLES: Record<Direction, {
+  panel: string;
+  text: string;
+  badge: string;
+}> = {
+  above: {
+    panel: 'border-emerald-400/25 bg-emerald-500/[0.08]',
+    text: 'text-emerald-300',
+    badge: 'border-emerald-400/25 bg-emerald-500/10 text-emerald-300',
+  },
+  below: {
+    panel: 'border-rose-400/25 bg-rose-500/[0.08]',
+    text: 'text-rose-300',
+    badge: 'border-rose-400/25 bg-rose-500/10 text-rose-300',
+  },
+  level: {
+    panel: 'border-white/10 bg-white/5',
+    text: 'text-white/80',
+    badge: 'border-white/10 bg-white/5 text-white/60',
+  },
+};
+
+const DIRECTION_ICONS: Record<Direction, typeof TrendingUp> = {
+  above: TrendingUp,
+  below: TrendingDown,
+  level: Minus,
+};
+
+function formatCount(value: number): string {
+  return value.toLocaleString();
+}
+
+/** Signed to two places, so a delta never reads as a plain rating. */
+function formatSignedDelta(value: number): string {
+  const rounded = Math.abs(value) < 0.005 ? 0 : value;
+  return `${rounded > 0 ? '+' : rounded < 0 ? '-' : ''}${Math.abs(rounded).toFixed(2)}`;
+}
+
+function directionOf(value: number, band = 0): Direction {
+  if (value > band) return 'above';
+  if (value < -band) return 'below';
+  return 'level';
+}
+
+/** The API's own rule, repeated only for responses that omit `lean`. */
+function leanFromDelta(value: number | null): RatingComparisonLean {
+  if (value === null) return 'aligned';
+  const direction = directionOf(value, LEAN_BAND);
+  if (direction === 'above') return 'generous';
+  if (direction === 'below') return 'harsh';
+  return 'aligned';
+}
+
+/**
+ * TMDB publishes its averages out of 10 while every other figure on this panel
+ * is out of 5. The API converts before differencing in `tmdb_delta`, but ships
+ * per-film averages in TMDB's own scale, so they are halved here and the panel
+ * says so once at the bottom rather than on every row.
+ */
+function tmdbToFiveScale(value: number): number {
+  return value / 2;
+}
+
+function filmLabel(film: { title: string; year: number | null }): string {
+  return film.year ? `${film.title} (${film.year})` : film.title;
+}
+
+/**
+ * The comparison endpoints return flat film shells rather than the full
+ * `MovieSummary` the shared poster expects; only the artwork is read from it.
+ */
+function toMovieSummary(film: {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+}): MovieSummary {
+  return {
+    movie_id: null,
+    tmdb_id: null,
+    letterboxd_slug: null,
+    letterboxd_url: film.letterboxd_url,
+    title: film.title,
+    year: film.year,
+    poster_url: film.poster_url,
+  };
+}
+
+function raterNote(count: number): string {
+  return `${formatCount(count)} ${count === 1 ? 'rater' : 'raters'}`;
+}
+
+function FilmTitle({ film }: { film: { title: string; year: number | null; letterboxd_url: string | null } }) {
+  const label = filmLabel(film);
+  return (
+    <p className="truncate text-sm font-medium text-white/85" title={label}>
+      {film.letterboxd_url ? (
+        <a
+          href={film.letterboxd_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-cinema-200 hover:underline"
+        >
+          {label}
+        </a>
+      ) : (
+        label
+      )}
+    </p>
+  );
+}
+
+function DeltaRow({ film }: { film: RatingComparisonFilm }) {
+  const direction = directionOf(film.delta);
+  const references = [
+    `${film.profile_rating.toFixed(1)} vs group ${film.group_average.toFixed(2)}`,
+    raterNote(film.rater_count),
+    film.letterboxd_average === null ? null : `Letterboxd ${film.letterboxd_average.toFixed(2)}`,
+    film.tmdb_average === null ? null : `TMDB ${tmdbToFiveScale(film.tmdb_average).toFixed(2)}`,
+  ].filter((item): item is string => item !== null);
+
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
+      <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+          {references.join(' · ')}
+        </p>
+      </div>
+      <span
+        className={`shrink-0 rounded-lg border px-2 py-1 text-xs font-semibold tabular-nums ${DIRECTION_STYLES[direction].badge}`}
+        title={`${Math.abs(film.delta).toFixed(2)} ${direction === 'below' ? 'below' : 'above'} the group average`}
+      >
+        {formatSignedDelta(film.delta)}
+      </span>
+    </li>
+  );
+}
+
+function DivisiveRow({ film, username }: { film: RatingComparisonDivisiveFilm; username: string }) {
+  const references = [
+    `group ${film.group_average.toFixed(2)}`,
+    raterNote(film.rater_count),
+    film.profile_rating === null ? `@${username} unrated` : `@${username} ${film.profile_rating.toFixed(1)}`,
+  ];
+
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
+      <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+          {references.join(' · ')}
+        </p>
+      </div>
+      <span
+        className="shrink-0 rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-2 py-1 text-center text-cinema-300"
+        title="Widest gap between any two ratings of this film"
+      >
+        <span className="block text-xs font-semibold tabular-nums">
+          {film.rating_spread.toFixed(2)}
+        </span>
+        <span className="block text-[9px] font-semibold uppercase tracking-wide text-cinema-300/70">
+          spread
+        </span>
+      </span>
+    </li>
+  );
+}
+
+function ListSection({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
+      <p className="mt-0.5 text-[11px] text-white/30">{subtitle}</p>
+      <ul className="mt-2 space-y-1.5">{children}</ul>
+    </div>
+  );
+}
+
+/** Plain-language reading of a Pearson correlation against the group. */
+function describeAgreement(value: number): string {
+  if (value >= 0.6) return 'closely tracks the group';
+  if (value >= 0.3) return 'broadly tracks the group';
+  if (value > -0.3) return 'little relation to the group';
+  return 'often runs opposite the group';
+}
+
+/**
+ * Where a member sits against the circle of profiles tracked alongside them:
+ * the films they champion, the ones they pan, and the ones that split everyone.
+ * The endpoint is optional from the page's point of view — any failure, and the
+ * panel simply is not there, the same way the archive and stats panels bow out.
+ */
+const RatingComparisonPanel: React.FC<{ username: string; delay?: number }> = ({
+  username,
+  delay = 0,
+}) => {
+  const comparisonQuery = useQuery({
+    queryKey: ['rating-comparison', username],
+    queryFn: () => ratingComparisonApi.getComparison(username),
+    enabled: Boolean(username),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const data = comparisonQuery.data;
+
+  // No hooks below this line: the panel disappears entirely when the endpoint
+  // is unavailable or has nothing worth comparing.
+  if (comparisonQuery.isError || !data) return null;
+
+  const summary = data.summary;
+  const coverage = data.coverage;
+  const champions = data.most_generous ?? [];
+  const pans = data.most_harsh ?? [];
+  const divisive = data.most_divisive ?? [];
+
+  const groupDelta = summary?.group_delta ?? null;
+  const hasLists = champions.length > 0 || pans.length > 0 || divisive.length > 0;
+  if (groupDelta === null && !hasLists) return null;
+
+  // `lean` decides whether the gap is worth calling a lean at all; the wording
+  // then follows the sign of the number itself, so the two can never disagree.
+  const lean: RatingComparisonLean = summary?.lean ?? leanFromDelta(groupDelta);
+  const headlineDirection: Direction = groupDelta === null || lean === 'aligned'
+    ? 'level'
+    : directionOf(groupDelta);
+  const headlineStyle = DIRECTION_STYLES[headlineDirection];
+  const HeadlineIcon = DIRECTION_ICONS[headlineDirection];
+  const comparedFilms = formatCount(coverage?.compared_films ?? 0);
+
+  const headline = groupDelta === null
+    ? 'Not enough shared ratings to place them against their circle'
+    : headlineDirection === 'level'
+      ? 'Rates in line with their circle'
+      : `Rates ${Math.abs(groupDelta).toFixed(2)} ${headlineDirection} their circle`;
+  const headlineDetail = groupDelta === null
+    ? 'The films below still show where the group splits.'
+    : headlineDirection === 'level'
+      ? `Effectively level with the group average across ${comparedFilms} comparable films.`
+      : `Averaged over ${comparedFilms} comparable films, ${headlineDirection === 'above' ? 'more generous' : 'harsher'} than the profiles tracked alongside them.`;
+
+  const agreement = summary?.agreement ?? null;
+
+  const referenceTiles = [
+    summary?.letterboxd_delta === null || summary?.letterboxd_delta === undefined
+      ? null
+      : {
+          key: 'letterboxd',
+          label: 'vs Letterboxd crowd',
+          value: summary.letterboxd_delta,
+          films: coverage?.letterboxd_average_films ?? 0,
+          noun: "Letterboxd's crowd average",
+        },
+    summary?.tmdb_delta === null || summary?.tmdb_delta === undefined
+      ? null
+      : {
+          key: 'tmdb',
+          label: 'vs TMDB audience',
+          value: summary.tmdb_delta,
+          films: coverage?.tmdb_average_films ?? 0,
+          noun: "TMDB's audience average",
+        },
+  ].filter((tile): tile is {
+    key: string;
+    label: string;
+    value: number;
+    films: number;
+    noun: string;
+  } => tile !== null);
+
+  const minRaters = coverage?.min_raters ?? 2;
+  const coverageNote = `${formatCount(coverage?.compared_films ?? 0)} of ${formatCount(coverage?.rated_films ?? 0)} rated films could be compared — a film only counts once at least ${formatCount(minRaters)} other tracked ${minRaters === 1 ? 'profile has' : 'profiles have'} rated it too.`;
+
+  // One quiet line for the whole panel rather than a caveat on every row.
+  const letterboxdPending = (coverage?.letterboxd_average_films ?? 0) === 0
+    ? 'Letterboxd’s own crowd average has not been fetched for these films yet, so that reference point is missing.'
+    : null;
+  const showsTmdb = referenceTiles.some((tile) => tile.key === 'tmdb')
+    || champions.some((film) => film.tmdb_average !== null)
+    || pans.some((film) => film.tmdb_average !== null);
+  const tmdbNote = showsTmdb
+    ? 'TMDB averages are rescaled from its 10-point scale to match Letterboxd’s five stars.'
+    : null;
+
+  return (
+    <motion.section
+      className="analysis-panel"
+      aria-labelledby="rating-comparison-title"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <div className="flex items-center gap-2">
+        <Scale className="h-5 w-5 text-cinema-400" aria-hidden="true" />
+        <h2 id="rating-comparison-title" className="text-xl font-semibold text-white">
+          Rating comparison
+        </h2>
+      </div>
+      <p className="mt-1 text-sm text-white/60">
+        Where @{username} sits against the profiles tracked alongside them, film by film.
+      </p>
+
+      <div
+        className={`mt-5 flex flex-col gap-4 rounded-2xl border px-4 py-4 sm:flex-row sm:items-center sm:justify-between ${headlineStyle.panel}`}
+      >
+        <div className="flex min-w-0 items-start gap-3">
+          <HeadlineIcon className={`mt-0.5 h-6 w-6 shrink-0 ${headlineStyle.text}`} aria-hidden="true" />
+          <div className="min-w-0">
+            <p className={`text-lg font-semibold ${headlineStyle.text}`}>{headline}</p>
+            <p className="mt-1 text-xs leading-5 text-white/45">{headlineDetail}</p>
+          </div>
+        </div>
+        {agreement !== null ? (
+          <div className="shrink-0 sm:text-right">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+              Agreement
+            </p>
+            <p className="mt-0.5 text-lg font-bold tabular-nums text-white">
+              {agreement.toFixed(2)}
+            </p>
+            <p className="text-[11px] text-white/40">{describeAgreement(agreement)}</p>
+          </div>
+        ) : null}
+      </div>
+
+      {referenceTiles.length > 0 ? (
+        <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {referenceTiles.map((tile) => {
+            const direction = directionOf(tile.value);
+            return (
+              <div
+                key={tile.key}
+                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5"
+              >
+                <dt className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+                  {tile.label}
+                </dt>
+                <dd className={`mt-1 text-lg font-bold tabular-nums ${DIRECTION_STYLES[direction].text}`}>
+                  {formatSignedDelta(tile.value)}
+                  <span className="ml-1.5 text-[11px] font-medium">
+                    {direction === 'level'
+                      ? 'in line'
+                      : direction === 'above'
+                        ? 'above'
+                        : 'below'}
+                  </span>
+                </dd>
+                <p className="mt-0.5 text-[10px] leading-4 text-white/35">
+                  {`${formatCount(tile.films)} films carry ${tile.noun}`}
+                </p>
+              </div>
+            );
+          })}
+        </dl>
+      ) : null}
+
+      {hasLists ? (
+        <div className="mt-6 grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+          {champions.length > 0 ? (
+            <ListSection title="Champions" subtitle="Rated furthest above the group">
+              {champions.map((film, index) => (
+                <DeltaRow key={`${film.title}-${film.year ?? 'na'}-${index}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
+          {pans.length > 0 ? (
+            <ListSection title="Pans" subtitle="Rated furthest below the group">
+              {pans.map((film, index) => (
+                <DeltaRow key={`${film.title}-${film.year ?? 'na'}-${index}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
+          {divisive.length > 0 ? (
+            <ListSection
+              title="Most divisive"
+              subtitle="Widest spread across everyone who rated them"
+            >
+              {divisive.map((film, index) => (
+                <DivisiveRow
+                  key={`${film.title}-${film.year ?? 'na'}-${index}`}
+                  film={film}
+                  username={username}
+                />
+              ))}
+            </ListSection>
+          ) : null}
+        </div>
+      ) : null}
+
+      <p className="mt-5 text-[11px] leading-5 text-white/30">
+        {[coverageNote, letterboxdPending, tmdbNote]
+          .filter((note): note is string => note !== null)
+          .join(' ')}
+      </p>
+    </motion.section>
+  );
+};
+
+export default RatingComparisonPanel;

--- a/frontend/src/components/insights/RatingComparisonPanel.tsx
+++ b/frontend/src/components/insights/RatingComparisonPanel.tsx
@@ -72,16 +72,6 @@ function leanFromDelta(value: number | null): RatingComparisonLean {
   return 'aligned';
 }
 
-/**
- * TMDB publishes its averages out of 10 while every other figure on this panel
- * is out of 5. The API converts before differencing in `tmdb_delta`, but ships
- * per-film averages in TMDB's own scale, so they are halved here and the panel
- * says so once at the bottom rather than on every row.
- */
-function tmdbToFiveScale(value: number): number {
-  return value / 2;
-}
-
 function filmLabel(film: { title: string; year: number | null }): string {
   return film.year ? `${film.title} (${film.year})` : film.title;
 }
@@ -131,23 +121,56 @@ function FilmTitle({ film }: { film: { title: string; year: number | null; lette
   );
 }
 
+/**
+ * One crowd this film's rating is read against. The circle and Letterboxd are
+ * drawn as peers: Letterboxd's average is the only outside opinion the panel
+ * carries, so it sits beside the group average rather than trailing it as fine
+ * print.
+ */
+function ReferenceChip({
+  label,
+  value,
+  note,
+  tone,
+}: {
+  label: string;
+  value: number;
+  note?: string;
+  tone: 'circle' | 'letterboxd';
+}) {
+  const styles = tone === 'letterboxd'
+    ? 'border-cinema-400/25 bg-cinema-500/10 text-cinema-200'
+    : 'border-white/10 bg-white/5 text-white/65';
+  return (
+    <span className={`rounded-md border px-1.5 py-0.5 ${styles}`}>
+      <span className="opacity-60">{label}</span>{' '}
+      <span className="font-semibold">{value.toFixed(2)}</span>
+      {note ? <span className="opacity-50">{` · ${note}`}</span> : null}
+    </span>
+  );
+}
+
 function DeltaRow({ film }: { film: RatingComparisonFilm }) {
   const direction = directionOf(film.delta);
-  const references = [
-    `${film.profile_rating.toFixed(1)} vs group ${film.group_average.toFixed(2)}`,
-    raterNote(film.rater_count),
-    film.letterboxd_average === null ? null : `Letterboxd ${film.letterboxd_average.toFixed(2)}`,
-    film.tmdb_average === null ? null : `TMDB ${tmdbToFiveScale(film.tmdb_average).toFixed(2)}`,
-  ].filter((item): item is string => item !== null);
 
   return (
     <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
       <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
       <div className="min-w-0 flex-1">
         <FilmTitle film={film} />
-        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
-          {references.join(' · ')}
-        </p>
+        <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] leading-4 tabular-nums">
+          <span className="font-semibold text-white/80">{film.profile_rating.toFixed(1)}</span>
+          <span className="text-white/30">vs</span>
+          <ReferenceChip
+            label="circle"
+            value={film.group_average}
+            note={raterNote(film.rater_count)}
+            tone="circle"
+          />
+          {film.letterboxd_average === null ? null : (
+            <ReferenceChip label="Letterboxd" value={film.letterboxd_average} tone="letterboxd" />
+          )}
+        </div>
       </div>
       <span
         className={`shrink-0 rounded-lg border px-2 py-1 text-xs font-semibold tabular-nums ${DIRECTION_STYLES[direction].badge}`}
@@ -273,45 +296,22 @@ const RatingComparisonPanel: React.FC<{ username: string; delay?: number }> = ({
 
   const agreement = summary?.agreement ?? null;
 
-  const referenceTiles = [
-    summary?.letterboxd_delta === null || summary?.letterboxd_delta === undefined
-      ? null
-      : {
-          key: 'letterboxd',
-          label: 'vs Letterboxd crowd',
-          value: summary.letterboxd_delta,
-          films: coverage?.letterboxd_average_films ?? 0,
-          noun: "Letterboxd's crowd average",
-        },
-    summary?.tmdb_delta === null || summary?.tmdb_delta === undefined
-      ? null
-      : {
-          key: 'tmdb',
-          label: 'vs TMDB audience',
-          value: summary.tmdb_delta,
-          films: coverage?.tmdb_average_films ?? 0,
-          noun: "TMDB's audience average",
-        },
-  ].filter((tile): tile is {
-    key: string;
-    label: string;
-    value: number;
-    films: number;
-    noun: string;
-  } => tile !== null);
+  // Letterboxd's own crowd average is the sole outside reference point, so it
+  // gets the same treatment as the headline rather than a footnote's worth.
+  const letterboxdDelta = summary?.letterboxd_delta ?? null;
+  const letterboxdFilms = coverage?.letterboxd_average_films ?? 0;
+  const letterboxdDirection: Direction = letterboxdDelta === null
+    ? 'level'
+    : directionOf(letterboxdDelta);
+  const letterboxdStyle = DIRECTION_STYLES[letterboxdDirection];
+  const LetterboxdIcon = DIRECTION_ICONS[letterboxdDirection];
 
   const minRaters = coverage?.min_raters ?? 2;
   const coverageNote = `${formatCount(coverage?.compared_films ?? 0)} of ${formatCount(coverage?.rated_films ?? 0)} rated films could be compared — a film only counts once at least ${formatCount(minRaters)} other tracked ${minRaters === 1 ? 'profile has' : 'profiles have'} rated it too.`;
 
   // One quiet line for the whole panel rather than a caveat on every row.
-  const letterboxdPending = (coverage?.letterboxd_average_films ?? 0) === 0
-    ? 'Letterboxd’s own crowd average has not been fetched for these films yet, so that reference point is missing.'
-    : null;
-  const showsTmdb = referenceTiles.some((tile) => tile.key === 'tmdb')
-    || champions.some((film) => film.tmdb_average !== null)
-    || pans.some((film) => film.tmdb_average !== null);
-  const tmdbNote = showsTmdb
-    ? 'TMDB averages are rescaled from its 10-point scale to match Letterboxd’s five stars.'
+  const letterboxdPending = letterboxdFilms === 0
+    ? 'Letterboxd’s own crowd average has not been fetched for these films yet, so the outside reference point is missing.'
     : null;
 
   return (
@@ -329,7 +329,8 @@ const RatingComparisonPanel: React.FC<{ username: string; delay?: number }> = ({
         </h2>
       </div>
       <p className="mt-1 text-sm text-white/60">
-        Where @{username} sits against the profiles tracked alongside them, film by film.
+        Where @{username} sits against the profiles tracked alongside them — and against
+        Letterboxd’s own crowd — film by film.
       </p>
 
       <div
@@ -355,35 +356,35 @@ const RatingComparisonPanel: React.FC<{ username: string; delay?: number }> = ({
         ) : null}
       </div>
 
-      {referenceTiles.length > 0 ? (
-        <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-          {referenceTiles.map((tile) => {
-            const direction = directionOf(tile.value);
-            return (
-              <div
-                key={tile.key}
-                className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5"
-              >
-                <dt className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
-                  {tile.label}
-                </dt>
-                <dd className={`mt-1 text-lg font-bold tabular-nums ${DIRECTION_STYLES[direction].text}`}>
-                  {formatSignedDelta(tile.value)}
-                  <span className="ml-1.5 text-[11px] font-medium">
-                    {direction === 'level'
-                      ? 'in line'
-                      : direction === 'above'
-                        ? 'above'
-                        : 'below'}
-                  </span>
-                </dd>
-                <p className="mt-0.5 text-[10px] leading-4 text-white/35">
-                  {`${formatCount(tile.films)} films carry ${tile.noun}`}
-                </p>
-              </div>
-            );
-          })}
-        </dl>
+      {letterboxdDelta !== null ? (
+        <div
+          className={`mt-3 flex flex-col gap-3 rounded-2xl border px-4 py-3.5 sm:flex-row sm:items-center sm:justify-between ${letterboxdStyle.panel}`}
+        >
+          <div className="flex min-w-0 items-start gap-3">
+            <LetterboxdIcon
+              className={`mt-0.5 h-5 w-5 shrink-0 ${letterboxdStyle.text}`}
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+                Against Letterboxd’s crowd
+              </p>
+              <p className={`mt-0.5 text-base font-semibold ${letterboxdStyle.text}`}>
+                {letterboxdDirection === 'level'
+                  ? 'Rates in line with the wider Letterboxd audience'
+                  : `Rates ${Math.abs(letterboxdDelta).toFixed(2)} ${letterboxdDirection} the wider Letterboxd audience`}
+              </p>
+              <p className="mt-1 text-xs leading-5 text-white/45">
+                {`Averaged over the ${formatCount(letterboxdFilms)} of ${formatCount(coverage?.rated_films ?? 0)} rated films that carry Letterboxd’s own average.`}
+              </p>
+            </div>
+          </div>
+          <p
+            className={`shrink-0 text-2xl font-bold tabular-nums sm:text-right ${letterboxdStyle.text}`}
+          >
+            {formatSignedDelta(letterboxdDelta)}
+          </p>
+        </div>
       ) : null}
 
       {hasLists ? (
@@ -420,7 +421,7 @@ const RatingComparisonPanel: React.FC<{ username: string; delay?: number }> = ({
       ) : null}
 
       <p className="mt-5 text-[11px] leading-5 text-white/30">
-        {[coverageNote, letterboxdPending, tmdbNote]
+        {[coverageNote, letterboxdPending]
           .filter((note): note is string => note !== null)
           .join(' ')}
       </p>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1280,8 +1280,8 @@ export interface RatingComparisonCoverage {
   compared_films: number;
   /** How many *other* profiles must have rated a film for it to count. */
   min_raters: number;
+  /** Rated films carrying Letterboxd's own crowd average, the one external reference. */
   letterboxd_average_films: number;
-  tmdb_average_films: number;
 }
 
 /** Which way this profile leans against its own circle. */
@@ -1290,10 +1290,11 @@ export type RatingComparisonLean = 'generous' | 'harsh' | 'aligned';
 export interface RatingComparisonSummary {
   /** Mean of (profile rating - group average). Null when nothing is comparable. */
   group_delta: number | null;
-  /** Null until the Letterboxd crowd-average backfill has run. */
+  /**
+   * Mean of (profile rating - Letterboxd crowd average) over the rated films
+   * that carry one. Null until the crowd-average backfill has reached them.
+   */
   letterboxd_delta: number | null;
-  /** Already rescaled to /5 by the API, unlike the per-film TMDB averages. */
-  tmdb_delta: number | null;
   lean: RatingComparisonLean | null;
   /** Pearson correlation of this profile's ratings against the group average. */
   agreement: number | null;
@@ -1309,9 +1310,8 @@ export interface RatingComparisonFilm {
   /** profile_rating - group_average: positive means rated above the circle. */
   delta: number;
   rater_count: number;
+  /** Letterboxd's crowd average, on the same five-point scale as every rating here. */
   letterboxd_average: number | null;
-  /** TMDB's own average, on TMDB's 10-point scale. */
-  tmdb_average: number | null;
 }
 
 export interface RatingComparisonDivisiveFilm {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1270,4 +1270,80 @@ export const profileStatsApi = {
   },
 };
 
+/**
+ * How much of the profile the rating comparison could actually be run over. A
+ * film is only comparable once enough other tracked profiles have rated it, so
+ * `compared_films` is always a subset of `rated_films`.
+ */
+export interface RatingComparisonCoverage {
+  rated_films: number;
+  compared_films: number;
+  /** How many *other* profiles must have rated a film for it to count. */
+  min_raters: number;
+  letterboxd_average_films: number;
+  tmdb_average_films: number;
+}
+
+/** Which way this profile leans against its own circle. */
+export type RatingComparisonLean = 'generous' | 'harsh' | 'aligned';
+
+export interface RatingComparisonSummary {
+  /** Mean of (profile rating - group average). Null when nothing is comparable. */
+  group_delta: number | null;
+  /** Null until the Letterboxd crowd-average backfill has run. */
+  letterboxd_delta: number | null;
+  /** Already rescaled to /5 by the API, unlike the per-film TMDB averages. */
+  tmdb_delta: number | null;
+  lean: RatingComparisonLean | null;
+  /** Pearson correlation of this profile's ratings against the group average. */
+  agreement: number | null;
+}
+
+export interface RatingComparisonFilm {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  profile_rating: number;
+  group_average: number;
+  /** profile_rating - group_average: positive means rated above the circle. */
+  delta: number;
+  rater_count: number;
+  letterboxd_average: number | null;
+  /** TMDB's own average, on TMDB's 10-point scale. */
+  tmdb_average: number | null;
+}
+
+export interface RatingComparisonDivisiveFilm {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  /** Widest gap between any two ratings of this film across all profiles. */
+  rating_spread: number;
+  rater_count: number;
+  group_average: number;
+  /** Null when this profile has not rated a film the rest of the group split over. */
+  profile_rating: number | null;
+}
+
+export interface RatingComparisonResponse {
+  username: string;
+  coverage: RatingComparisonCoverage;
+  summary: RatingComparisonSummary;
+  most_generous: RatingComparisonFilm[];
+  most_harsh: RatingComparisonFilm[];
+  most_divisive: RatingComparisonDivisiveFilm[];
+}
+
+export const ratingComparisonApi = {
+  getComparison: async (username: string, limit = 10): Promise<RatingComparisonResponse> => {
+    const response = await api.get(
+      `/api/profiles/${encodeURIComponent(username)}/rating-comparison`,
+      { params: { limit } },
+    );
+    return response.data;
+  },
+};
+
 export default api;

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -18,6 +18,7 @@ import ProfileHeader from '../components/ProfileHeader';
 import ProfilePicker from '../components/ProfilePicker';
 import ArchivePanel from '../components/insights/ArchivePanel';
 import ProfileStatsPanel from '../components/insights/ProfileStatsPanel';
+import RatingComparisonPanel from '../components/insights/RatingComparisonPanel';
 import TasteProfilePanel from '../components/insights/TasteProfilePanel';
 import TagsPanel, { TagChipList } from '../components/insights/TagsPanel';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
@@ -166,6 +167,8 @@ const Analysis: React.FC = () => {
           />
 
           <ProfileStatsPanel username={analysis.username} delay={0.08} />
+
+          <RatingComparisonPanel username={analysis.username} delay={0.1} />
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             <StatsCard

--- a/frontend/src/views/Network.tsx
+++ b/frontend/src/views/Network.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
 import { Trophy, Waypoints } from 'lucide-react';
@@ -10,6 +10,13 @@ import { followGraphApi } from '../services/api';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 
 export default function Network() {
+  // The graph reports which profile is centred so the ranking can follow the
+  // selection instead of sitting underneath it contradicting the view.
+  const [focusedUsername, setFocusedUsername] = useState<string | null>(null);
+  const handleFocusChange = useCallback((username: string | null) => {
+    setFocusedUsername(username);
+  }, []);
+
   const profilesQuery = useScopedProfiles();
   const completedProfiles = useMemo(
     () => (profilesQuery.data ?? []).filter((profile) => profile.scraping_status === 'completed'),
@@ -39,6 +46,16 @@ export default function Network() {
       .slice(0, 8);
   }, [mutualsQuery.data]);
 
+  // Where the centred profile sits in the ranking, so the panel answers a
+  // question about the selection rather than ignoring it.
+  const focusedEntry = useMemo(() => {
+    if (!focusedUsername) return null;
+    const index = ranking.findIndex(
+      (entry) => entry.username.toLowerCase() === focusedUsername.toLowerCase(),
+    );
+    return index === -1 ? null : { ...ranking[index], rank: index + 1 };
+  }, [focusedUsername, ranking]);
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 12 }}
@@ -56,29 +73,46 @@ export default function Network() {
         </p>
       </header>
 
-      <FollowNetwork profiles={completedProfiles} />
+      <FollowNetwork profiles={completedProfiles} onFocusChange={handleFocusChange} />
 
       {ranking.length > 0 && (
         <section className="rounded-xl border border-white/10 bg-white/5 p-4">
-          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold text-white/75">
+          <h2 className="mb-3 flex flex-wrap items-center gap-2 text-sm font-semibold text-white/75">
             <Trophy className="h-4 w-4 text-cinema-400" />
             Most connected
+            {focusedEntry && (
+              <span className="text-xs font-normal text-white/40">
+                @{focusedEntry.username} ranks #{focusedEntry.rank} of {ranking.length}
+              </span>
+            )}
           </h2>
           <ol className="grid gap-2 sm:grid-cols-2">
-            {ranking.map((entry, index) => (
-              <li
-                key={entry.username}
-                className="flex items-center justify-between rounded-lg border border-white/5 bg-black/20 px-3 py-2 text-sm"
-              >
-                <span className="flex items-center gap-2 text-white/80">
-                  <span className="w-5 text-right text-xs text-white/35">{index + 1}.</span>
-                  @{entry.username}
-                </span>
-                <span className="text-xs text-white/45">
-                  follows {entry.follows} · followed by {entry.followedBy}
-                </span>
-              </li>
-            ))}
+            {ranking.map((entry, index) => {
+              const isFocused =
+                focusedUsername != null &&
+                entry.username.toLowerCase() === focusedUsername.toLowerCase();
+              return (
+                <li
+                  key={entry.username}
+                  aria-current={isFocused ? 'true' : undefined}
+                  className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm transition-colors ${
+                    isFocused
+                      ? 'border-cinema-400/40 bg-cinema-500/10'
+                      : focusedUsername
+                        ? 'border-white/5 bg-black/20 opacity-50'
+                        : 'border-white/5 bg-black/20'
+                  }`}
+                >
+                  <span className="flex items-center gap-2 text-white/80">
+                    <span className="w-5 text-right text-xs text-white/35">{index + 1}.</span>
+                    @{entry.username}
+                  </span>
+                  <span className="text-xs text-white/45">
+                    follows {entry.follows} · followed by {entry.followedBy}
+                  </span>
+                </li>
+              );
+            })}
           </ol>
         </section>
       )}

--- a/scripts/enrich_letterboxd_ratings.py
+++ b/scripts/enrich_letterboxd_ratings.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Opt-in batch command for backfilling Letterboxd's own crowd rating per film."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+
+from dotenv import load_dotenv
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = REPO_ROOT / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+load_dotenv(REPO_ROOT / ".env")
+load_dotenv(BACKEND_DIR / ".env", override=False)
+
+from database.connection import SessionLocal  # noqa: E402
+from services.letterboxd_ratings import (  # noqa: E402
+    DEFAULT_BACKOFF_SECONDS,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_DELAY_SECONDS,
+    DEFAULT_MAX_AGE_DAYS,
+    DEFAULT_MAX_RETRIES,
+    LetterboxdRatingFetcher,
+    sync_letterboxd_ratings,
+)
+
+
+def positive_integer(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def non_negative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must not be negative")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill movies.letterboxd_average_rating / letterboxd_rating_count "
+            "from Letterboxd's rating-histogram include. Never run by ingestion; "
+            "deliberately paced, bounded by --limit and resumable via --max-age-days."
+        )
+    )
+    parser.add_argument(
+        "--limit",
+        type=positive_integer,
+        default=None,
+        help="Maximum number of films to process in this run.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=positive_integer,
+        default=int(os.getenv("LETTERBOXD_RATING_MAX_AGE_DAYS", str(DEFAULT_MAX_AGE_DAYS))),
+        help=(
+            "Skip films whose letterboxd_rating_synced_at is newer than this "
+            f"many days (default: {DEFAULT_MAX_AGE_DAYS}). This is what makes a "
+            "long run resumable."
+        ),
+    )
+    parser.add_argument(
+        "--delay",
+        type=non_negative_float,
+        default=float(os.getenv("LETTERBOXD_RATING_DELAY_SECONDS", str(DEFAULT_DELAY_SECONDS))),
+        help=f"Seconds to sleep between requests (default: {DEFAULT_DELAY_SECONDS}).",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=positive_integer,
+        default=DEFAULT_BATCH_SIZE,
+        help="Number of films committed per database batch.",
+    )
+    parser.add_argument(
+        "--max-retries",
+        type=positive_integer,
+        default=DEFAULT_MAX_RETRIES,
+        help="Attempts per film before it is logged as failed and skipped.",
+    )
+    parser.add_argument(
+        "--backoff",
+        type=non_negative_float,
+        default=DEFAULT_BACKOFF_SECONDS,
+        help="Base seconds for exponential retry backoff.",
+    )
+    parser.add_argument(
+        "--movie-id",
+        action="append",
+        type=positive_integer,
+        default=None,
+        help="Restrict to one canonical movie ID; repeat for multiple IDs.",
+    )
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Re-fetch selected films even when their sync stamp is still fresh.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count candidates without making requests or database writes.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(message)s")
+
+    fetcher = None
+    if not args.dry_run:
+        fetcher = LetterboxdRatingFetcher(
+            max_retries=args.max_retries,
+            backoff_seconds=args.backoff,
+        )
+
+    def print_progress(index, total, candidate) -> None:
+        print(f"[{index}/{total}] {candidate.title} ({candidate.slug})", file=sys.stderr)
+
+    with SessionLocal() as db:
+        try:
+            stats = sync_letterboxd_ratings(
+                db,
+                fetcher,
+                max_age_days=args.max_age_days,
+                delay_seconds=args.delay,
+                batch_size=args.batch_size,
+                limit=args.limit,
+                movie_ids=args.movie_id,
+                refresh=args.refresh,
+                dry_run=args.dry_run,
+                progress=None if args.dry_run else print_progress,
+            )
+        except Exception as exc:
+            db.rollback()
+            print(f"Letterboxd rating sync failed: {exc}", file=sys.stderr)
+            return 1
+
+    payload = stats.to_dict()
+    payload.update(
+        {
+            "max_age_days": args.max_age_days,
+            "delay_seconds": args.delay,
+            "batch_size": args.batch_size,
+            "refresh": args.refresh,
+        }
+    )
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if stats.failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/push_letterboxd_ratings.py
+++ b/scripts/push_letterboxd_ratings.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Push locally scraped Letterboxd film ratings to the Spyboxd API.
+
+``scripts/enrich_letterboxd_ratings.py`` can only run where the scraper runs:
+Letterboxd challenges datacenter IPs, so the backfill writes
+``movies.letterboxd_average_rating`` into the *local* database on a residential
+machine. This script is the second half of that trip — it reads those values
+back out and POSTs them to ``/api/films/letterboxd-ratings`` with the same
+``INGESTION_API_TOKEN`` that ``scripts/local_full_sync.py`` uses for ``/upload/``.
+
+Film ratings are film-level and shared by every profile, so nothing here is
+per-profile data: it is one modest ``(slug, average, count)`` dataset that the
+whole library reads. Batches are idempotent, so an interrupted run is safe to
+repeat.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Sequence
+
+import requests
+from dotenv import load_dotenv
+from sqlalchemy.orm import Session
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+
+def load_local_environment(env_file: Path = REPO_ROOT / ".env") -> None:
+    """Load ignored local credentials without overriding the caller's shell."""
+    load_dotenv(env_file, override=False)
+
+
+load_local_environment()
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from api.routes.film_ratings import MAX_BATCH_SIZE  # noqa: E402
+from database.connection import SessionLocal  # noqa: E402
+from database.models import Movie  # noqa: E402
+from services.letterboxd_ratings import resolve_slug  # noqa: E402
+
+
+RATINGS_PATH = "/api/films/letterboxd-ratings"
+DEFAULT_BATCH_SIZE = 500
+
+
+def positive_integer(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def batch_size_argument(value: str) -> int:
+    parsed = positive_integer(value)
+    if parsed > MAX_BATCH_SIZE:
+        raise argparse.ArgumentTypeError(f"must not exceed {MAX_BATCH_SIZE}")
+    return parsed
+
+
+def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[Dict[str, Any]], int]:
+    """Read every film that already carries a Letterboxd crowd average.
+
+    Films without a usable slug cannot be matched on the other side, so they are
+    counted and left out rather than sent. Returns ``(entries, skipped_no_slug)``.
+    """
+
+    query = (
+        db.query(
+            Movie.letterboxd_slug,
+            Movie.letterboxd_url,
+            Movie.letterboxd_average_rating,
+            Movie.letterboxd_rating_count,
+            Movie.letterboxd_rating_synced_at,
+        )
+        .filter(Movie.letterboxd_average_rating.isnot(None))
+        .order_by(Movie.id)
+    )
+    if limit is not None:
+        query = query.limit(limit)
+
+    entries: List[Dict[str, Any]] = []
+    skipped_no_slug = 0
+    for slug, url, average, count, synced_at in query.all():
+        resolved = resolve_slug(slug, url)
+        if not resolved:
+            skipped_no_slug += 1
+            continue
+        entries.append(
+            {
+                "slug": resolved,
+                "average_rating": float(average),
+                "rating_count": int(count) if count is not None else None,
+                "synced_at": synced_at.isoformat() if synced_at is not None else None,
+            }
+        )
+    return entries, skipped_no_slug
+
+
+def iter_batches(entries: Sequence[Dict[str, Any]], size: int) -> Iterator[List[Dict[str, Any]]]:
+    for start in range(0, len(entries), size):
+        yield list(entries[start : start + size])
+
+
+def push_batch(
+    *,
+    api_base_url: str,
+    entries: Sequence[Dict[str, Any]],
+    upload_token: Optional[str],
+    bearer_token: Optional[str],
+    timeout_seconds: int,
+) -> Dict[str, Any]:
+    headers = {}
+    if upload_token:
+        headers["X-Upload-Token"] = upload_token
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    response = requests.post(
+        f"{api_base_url.rstrip('/')}{RATINGS_PATH}",
+        json={"ratings": list(entries)},
+        headers=headers,
+        timeout=timeout_seconds,
+    )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        payload = {"raw_response": response.text}
+
+    if not response.ok:
+        raise RuntimeError(f"Rating push failed ({response.status_code}): {payload}")
+
+    return payload
+
+
+def push_ratings(
+    entries: Sequence[Dict[str, Any]],
+    *,
+    api_base_url: str,
+    upload_token: Optional[str],
+    bearer_token: Optional[str],
+    batch_size: int,
+    timeout_seconds: int,
+    progress=None,
+) -> Dict[str, Any]:
+    """Send every batch, accumulating the API's per-batch counts."""
+
+    totals = {"received": 0, "updated": 0, "unmatched": 0, "skipped": 0}
+    batches = 0
+    total_batches = (len(entries) + batch_size - 1) // batch_size
+    for batch in iter_batches(entries, batch_size):
+        batches += 1
+        if progress:
+            progress(batches, total_batches, len(batch))
+        payload = push_batch(
+            api_base_url=api_base_url,
+            entries=batch,
+            upload_token=upload_token,
+            bearer_token=bearer_token,
+            timeout_seconds=timeout_seconds,
+        )
+        for key in totals:
+            totals[key] += int(payload.get(key, 0) or 0)
+    return {"batches": batches, **totals}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Push locally backfilled Letterboxd film ratings (movies.letterboxd_*) "
+            "to the Spyboxd API, which cannot scrape them itself because Letterboxd "
+            "challenges datacenter IPs."
+        ),
+    )
+    parser.add_argument(
+        "--api-base-url",
+        default=os.environ.get("SPYBOXD_API_BASE_URL"),
+        help="Spyboxd API base URL, e.g. https://api.spyboxd.com",
+    )
+    parser.add_argument(
+        "--upload-token",
+        default=os.environ.get("INGESTION_API_TOKEN"),
+        help="Value for X-Upload-Token. Recommended for trusted local syncs.",
+    )
+    parser.add_argument(
+        "--bearer-token",
+        default=os.environ.get("SPYBOXD_BEARER_TOKEN"),
+        help="Clerk admin bearer token. Use this instead of --upload-token if preferred.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=positive_integer,
+        default=None,
+        help="Maximum number of films to push in this run.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=batch_size_argument,
+        default=DEFAULT_BATCH_SIZE,
+        help=f"Films per request (default: {DEFAULT_BATCH_SIZE}, API maximum: {MAX_BATCH_SIZE}).",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=positive_integer,
+        default=120,
+        help="HTTP timeout for each batch request.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be pushed without contacting the API.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    if not args.dry_run:
+        if not args.api_base_url:
+            print("Provide --api-base-url or set SPYBOXD_API_BASE_URL.", file=sys.stderr)
+            return 1
+        if not args.upload_token and not args.bearer_token:
+            print(
+                "Provide --upload-token (INGESTION_API_TOKEN) or --bearer-token.",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        with SessionLocal() as db:
+            entries, skipped_no_slug = collect_ratings(db, limit=args.limit)
+    except Exception as exc:
+        print(f"Reading local film ratings failed: {exc}", file=sys.stderr)
+        return 1
+
+    summary: Dict[str, Any] = {
+        "films": len(entries),
+        "skipped_no_slug": skipped_no_slug,
+        "batch_size": args.batch_size,
+        "batches": (len(entries) + args.batch_size - 1) // args.batch_size,
+        "api_base_url": args.api_base_url,
+        "dry_run": args.dry_run,
+    }
+
+    if args.dry_run:
+        summary["sample"] = entries[:3]
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    if not entries:
+        print("No locally backfilled Letterboxd ratings to push.", file=sys.stderr)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    def print_progress(index: int, total: int, size: int) -> None:
+        print(f"[{index}/{total}] pushing {size} films...", file=sys.stderr)
+
+    try:
+        result = push_ratings(
+            entries,
+            api_base_url=args.api_base_url,
+            upload_token=args.upload_token,
+            bearer_token=args.bearer_token,
+            batch_size=args.batch_size,
+            timeout_seconds=args.timeout_seconds,
+            progress=print_progress,
+        )
+    except Exception as exc:
+        print(f"Rating push failed: {exc}", file=sys.stderr)
+        return 1
+
+    summary.update(result)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Letterboxd knows how a film scored across its whole userbase. It **cannot** tell you how you rate against your own friends — it doesn't know who your circle is. We do.

`GET /api/profiles/{username}/rating-comparison` returns whether someone runs generous or harsh relative to their circle, their correlation with it, the films they champion, the ones they pan, and the films that split the group hardest. **Letterboxd's crowd average is the sole external reference** (TMDB was removed at the user's request — it remains the source of posters, runtime, credits and genres).

## The correctness crux: self-exclusion

The group average **excludes the profile being measured**. Verified on real data — *Everything Everywhere All at Once*, 7 raters, 25.5 stars:

| Rater | Rating | Group (excl. self) | Naive (incl. self) |
|---|---|---|---|
| sairohan | 5.0 | 3.42 | 3.64 |
| er3nweeber | 3.5 | 3.67 | 3.64 |
| whiteknight03x | 0.5 | **4.17** | 3.64 |

Every rater sees a different baseline, as they must. ≥2 other raters to compare, ≥3 for a spread.

**Real results:** whiteknight03x rates **0.27 below** his circle (correlation 0.44); er3nweeber **0.23 above** (0.59).

## The delivery gap this exposed

TMDB enrichment runs *on* the production server because TMDB has no IP restriction. **Letterboxd challenges datacenter IPs** — the entire reason this repo scrapes residentially. So the rating backfill wrote to a local database with no way to reach production.

`POST /api/films/letterboxd-ratings` closes it, on the same ingestion-token boundary as `/upload/`: bounded batches, case-insensitive slug matching, unknown slugs counted rather than fatal, out-of-range values skipped *before* the DB constraint sees them, and a null average never overwriting a known one. `scripts/push_letterboxd_ratings.py` ships from the residential side (dry-run: 635 films ready, 2 batches, 0 slug failures).

Live-verified averages: The Dark Knight 4.50, Parasite 4.52, Interstellar 4.45 — at 6KB per film via the rating-histogram include, versus 300KB for the film page.

## Network graph fixes from real use
- **Outside counterparts were capped at 10 with no indication**, so an ego view could present a partial picture as complete. Cap raised to 45 (bundled layout carries ~70) and the header now says how many aren't shown.
- **One-way arrowheads** were too small to read where curves converge — now larger and outlined.
- **The leaderboard ignored the centred profile** — it now highlights that row, dims the rest, and reports where they rank.

## Verification
**417 backend tests** (79 new). The insight service was independently reconciled against a raw-SQL + `statistics.correlation` recomputation. `tsc` + `eslint` + `next build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)