### PR TITLE
Watchlist queue, obscurity index, follow-aware signals, rewatch and review patterns

### DIFF
--- a/alembic/versions/20260801_0016_add_rating_distribution.py
+++ b/alembic/versions/20260801_0016_add_rating_distribution.py
@@ -1,0 +1,39 @@
+"""Keep the rating histogram's ten buckets, not just its average.
+
+The rating-histogram include already returns every half-star bucket and the
+parser already reads them; only the weighted average was persisted. Storing
+the shape lets a rating be placed against the crowd ("in the 2% who rated it
+half a star") rather than merely above or below the mean, and costs no extra
+requests.
+
+Revision ID: 20260801_0016
+Revises: 20260801_0015
+Create Date: 2026-08-01 15:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260801_0016"
+down_revision: Union[str, None] = "20260801_0015"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "movies",
+        sa.Column(
+            "letterboxd_rating_distribution",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("movies", "letterboxd_rating_distribution")

--- a/backend/api/routes/obscurity.py
+++ b/backend/api/routes/obscurity.py
@@ -1,0 +1,51 @@
+"""Obscurity index: how mainstream one profile's rated films are."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from services.obscurity import DEFAULT_LIMIT, MAX_LIMIT, build_obscurity_index
+from services.profile_access import require_profile_access
+
+
+router = APIRouter(prefix="/api", tags=["obscurity"])
+
+
+@router.get("/profiles/{username}/obscurity")
+def get_profile_obscurity(
+    username: str,
+    limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """How mainstream this profile's taste is, in audience size.
+
+    ``index.median_rating_count`` is the headline: the number of Letterboxd
+    ratings behind the *typical* film this person rated. It is a median rather
+    than a mean on purpose -- one blockbuster among five hundred arthouse films
+    would move a mean by orders of magnitude and describe a taste nobody has.
+    ``mean_rating_count`` sits beside it so that skew stays visible.
+
+    ``percentile_vs_group`` places that median against every *other* tracked
+    profile's median, as an obscurity percentile: 100 means every other tracked
+    profile watches bigger films. ``lean`` is read straight off it, so the label
+    and the number can never disagree, and both are null when there is no other
+    profile to compare against.
+
+    Letterboxd itself never shows any of this. It publishes a film's rating
+    count on that film's page and never aggregates those counts across a
+    member's history.
+
+    Coverage is reported rather than papered over. Films the crowd-rating
+    backfill has not reached are excluded from the median instead of counted as
+    an audience of zero, and ``coverage.films_with_rating_count`` says how many
+    of the profile's ``rated_films`` actually stood behind it.
+    ``crowd_position`` additionally needs ``letterboxd_rating_distribution``
+    and returns an empty list -- never null -- until that backfill is re-run
+    with ``--refresh``.
+    """
+
+    profile = require_profile_access(db, user, username)
+    return build_obscurity_index(db, profile, limit=limit)

--- a/backend/api/routes/watchlist_insights.py
+++ b/backend/api/routes/watchlist_insights.py
@@ -1,0 +1,43 @@
+"""Watchlist insights: an unwatched list ranked by the circle's own verdict."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from services.profile_access import require_profile_access
+from services.watchlist_insights import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    build_watchlist_insights,
+)
+
+
+router = APIRouter(prefix="/api", tags=["watchlist insights"])
+
+
+@router.get("/profiles/{username}/watchlist-insights")
+def get_watchlist_insights(
+    username: str,
+    limit: int = Query(default=DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+):
+    """What to watch next off this profile's watchlist, ranked by the group.
+
+    Letterboxd keeps a watchlist as an undifferentiated list and can only ever
+    annotate it with its own site-wide average. Every tracked profile's rating
+    is already held locally, so each unwatched film here carries the average
+    over the *other* members who have seen it, the number of them behind it,
+    and who they were.
+
+    Only films with no ``profile_films`` row for this profile are recommended,
+    and a film needs at least one other rater to be ranked at all. ``coverage``
+    reports the size of that unwatched pool, how much of it the group has rated
+    and how much carries a Letterboxd crowd average, so a client can qualify a
+    partial queue instead of presenting it as the whole watchlist.
+    """
+
+    profile = require_profile_access(db, user, username)
+    return build_watchlist_insights(db, profile, limit=limit)

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -575,6 +575,9 @@ class Movie(Base):
     # whole library.
     letterboxd_average_rating = Column(Float, nullable=True)
     letterboxd_rating_count = Column(BigInteger, nullable=True)
+    # The ten half-star buckets behind that average, keyed "0.5".."5.0", so a
+    # rating can be placed against the crowd's shape rather than only its mean.
+    letterboxd_rating_distribution = Column(_json_type(), nullable=True)
     letterboxd_rating_synced_at = Column(DateTime(timezone=True), nullable=True)
     tmdb_lookup_attempted_at = Column(DateTime(timezone=True), nullable=True)
     tmdb_lookup_expires_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,8 +20,10 @@ from api.routes.film_ratings import router as film_ratings_router
 from api.routes.follow_graph import router as follow_graph_router
 from api.routes.insights import router as insights_router
 from api.routes.member_archive import router as member_archive_router
+from api.routes.obscurity import router as obscurity_router
 from api.routes.profile_access import router as profile_access_router
 from api.routes.profile_stats import router as profile_stats_router
+from api.routes.watchlist_insights import router as watchlist_insights_router
 from api.routes.rating_comparison import router as rating_comparison_router
 from auth import ClerkUser, get_admin_user, get_current_user, get_upload_user
 from database.connection import engine, get_db, init_db
@@ -382,6 +384,8 @@ app.include_router(follow_graph_router)
 app.include_router(member_archive_router)
 app.include_router(profile_stats_router)
 app.include_router(rating_comparison_router)
+app.include_router(watchlist_insights_router)
+app.include_router(obscurity_router)
 # Letterboxd film ratings can only be scraped from a residential IP, so they
 # arrive over the same ingestion-token boundary as /upload/ rather than being
 # enriched on this server the way TMDB data is.

--- a/backend/services/insights.py
+++ b/backend/services/insights.py
@@ -19,6 +19,7 @@ from database.models import (
     MovieWatchProvider,
     Profile,
     ProfileFilm,
+    ProfileFollowEdge,
     ProfileSync,
     Review,
     SyncDataset,
@@ -133,6 +134,151 @@ class ProviderAvailability:
     logo_path: Optional[str]
     display_priority: Optional[int]
     regions: Tuple[str, ...]
+
+
+def _and_unknown(left: Optional[bool], right: Optional[bool]) -> Optional[bool]:
+    """Three-valued AND: a known ``False`` decides, an unknown does not.
+
+    Used so "mutual" reads False when one direction is authoritatively absent
+    even if the other direction was never observable, instead of pretending an
+    unknown is a no.
+    """
+    if left is False or right is False:
+        return False
+    if left is None or right is None:
+        return None
+    return bool(left and right)
+
+
+@dataclass(frozen=True)
+class FollowGraph:
+    """Active follow edges among a selected group, loaded once per request.
+
+    A follow edge is a social link one member published on their own
+    following/followers pages. It says these two accounts are connected; it is
+    not evidence that either member's watch caused the other's. Nothing derived
+    from this class may be presented as influence, only as context for a
+    co-watch that already exists in the diary data.
+
+    Presence of an edge is positive evidence regardless of import authority,
+    because an observed edge cannot be observed by accident. Absence only means
+    something when the profile whose page would have listed it carries an
+    authoritative social import, so unobservable directions stay ``None``
+    rather than collapsing into ``False``.
+    """
+
+    # (profile_id, counterpart_username_normalized) for each direction.
+    active_following: frozenset
+    active_followers: frozenset
+    # Profiles whose latest sync owns an authoritative following/followers
+    # surface, i.e. the only profiles whose *missing* edges mean anything.
+    authoritative_following: frozenset
+    authoritative_followers: frozenset
+    normalized_username_by_profile_id: Mapping[int, str]
+    username_by_profile_id: Mapping[int, str]
+
+    @classmethod
+    def unknown(cls, profiles: Sequence[Profile] = ()) -> "FollowGraph":
+        """A graph with no observations, so every relationship reads unknown."""
+        return cls(
+            active_following=frozenset(),
+            active_followers=frozenset(),
+            authoritative_following=frozenset(),
+            authoritative_followers=frozenset(),
+            normalized_username_by_profile_id={
+                profile.id: profile.username.casefold() for profile in profiles
+            },
+            username_by_profile_id={
+                profile.id: profile.username for profile in profiles
+            },
+        )
+
+    def has_authoritative_social_sync(self, profile_id: int) -> bool:
+        """Whether this profile's own social surface was imported authoritatively."""
+        return (
+            profile_id in self.authoritative_following
+            or profile_id in self.authoritative_followers
+        )
+
+    def follows(
+        self, source_profile_id: int, target_profile_id: int
+    ) -> Optional[bool]:
+        """Does ``source`` actively follow ``target``? ``None`` when unobservable.
+
+        ``False`` is only returned when an authoritative import covers the
+        direction and did not list the edge. Never read this as a statement
+        about who watched what.
+        """
+        source_normalized = self.normalized_username_by_profile_id.get(source_profile_id)
+        target_normalized = self.normalized_username_by_profile_id.get(target_profile_id)
+        if source_normalized is None or target_normalized is None:
+            return None
+        if (source_profile_id, target_normalized) in self.active_following:
+            return True
+        # The counterpart's own followers page corroborates the same edge.
+        if (target_profile_id, source_normalized) in self.active_followers:
+            return True
+        if (
+            source_profile_id in self.authoritative_following
+            or target_profile_id in self.authoritative_followers
+        ):
+            return False
+        return None
+
+    def _observed_by(self, left_profile_id: int, right_profile_id: int) -> List[str]:
+        return [
+            self.username_by_profile_id[profile_id]
+            for profile_id in (left_profile_id, right_profile_id)
+            if profile_id in self.username_by_profile_id
+            and self.has_authoritative_social_sync(profile_id)
+        ]
+
+    def relationship(
+        self,
+        left_profile_id: int,
+        right_profile_id: int,
+        *,
+        left_username: str,
+        right_username: str,
+        left_date: Optional[date] = None,
+        right_date: Optional[date] = None,
+    ) -> Dict[str, Any]:
+        """Describe the social link between two profiles in a co-watch event.
+
+        ``follows_earlier_watcher`` is the strongest honest reading available:
+        the later watcher already followed the earlier one when this pair of
+        diary entries landed. It is a directional hint about reach, not a claim
+        that the earlier watch caused the later one, and it is ``None`` whenever
+        the order is unknown or the social link is unobservable.
+        """
+        left_follows_right = self.follows(left_profile_id, right_profile_id)
+        right_follows_left = self.follows(right_profile_id, left_profile_id)
+        earlier_username: Optional[str] = None
+        later_username: Optional[str] = None
+        follows_earlier_watcher: Optional[bool] = None
+        if left_date is not None and right_date is not None and left_date != right_date:
+            if left_date < right_date:
+                earlier_username, later_username = left_username, right_username
+                follows_earlier_watcher = right_follows_left
+            else:
+                earlier_username, later_username = right_username, left_username
+                follows_earlier_watcher = left_follows_right
+        return {
+            "a": left_username,
+            "b": right_username,
+            "a_follows_b": left_follows_right,
+            "b_follows_a": right_follows_left,
+            "mutual": _and_unknown(left_follows_right, right_follows_left),
+            # False means no authoritative social import covers either
+            # direction, which is not the same as an observed absence.
+            "known": left_follows_right is not None or right_follows_left is not None,
+            # Which of the two members' own social imports are authoritative,
+            # so a UI can say who the reading is sourced from.
+            "observed_by": self._observed_by(left_profile_id, right_profile_id),
+            "earlier_watcher": earlier_username,
+            "later_watcher": later_username,
+            "follows_earlier_watcher": follows_earlier_watcher,
+        }
 
 
 def _safe_float(value: Any) -> Optional[float]:
@@ -670,6 +816,144 @@ class InsightsService:
             )
             for event, profile, movie in rows
         ]
+
+    def _follow_graph(self, profiles: Sequence[Profile]) -> FollowGraph:
+        """Load every active follow edge inside the selection in one query.
+
+        Signals run over thousands of films, so the graph is resolved once for
+        the selected profiles and then consulted in memory; no event triggers a
+        query of its own.
+        """
+        profile_ids = [profile.id for profile in profiles]
+        if not profile_ids or self.db is None:
+            return FollowGraph.unknown(profiles)
+
+        normalized_by_profile_id = {
+            profile.id: profile.username.casefold() for profile in profiles
+        }
+        rows = (
+            self.db.query(
+                ProfileFollowEdge.profile_id,
+                ProfileFollowEdge.direction,
+                ProfileFollowEdge.counterpart_username_normalized,
+            )
+            .filter(
+                ProfileFollowEdge.profile_id.in_(profile_ids),
+                ProfileFollowEdge.counterpart_username_normalized.in_(
+                    sorted(set(normalized_by_profile_id.values()))
+                ),
+                ProfileFollowEdge.removed_at.is_(None),
+            )
+            .all()
+        )
+        active_following = set()
+        active_followers = set()
+        for profile_id, direction, counterpart in rows:
+            if direction == "following":
+                active_following.add((profile_id, counterpart))
+            elif direction == "follower":
+                active_followers.add((profile_id, counterpart))
+
+        authoritative_following = set()
+        authoritative_followers = set()
+        for profile_id, (sync, datasets) in self._latest_sync_context(profiles).items():
+            following_dataset = self._dataset(datasets, "following")
+            followers_dataset = self._dataset(datasets, "followers")
+            if (
+                following_dataset is not None
+                and following_dataset.is_authoritative
+                and not self._dataset_unavailable_reason(
+                    sync, following_dataset, "following"
+                )
+            ):
+                authoritative_following.add(profile_id)
+            if (
+                followers_dataset is not None
+                and followers_dataset.is_authoritative
+                and not self._dataset_unavailable_reason(
+                    sync, followers_dataset, "followers"
+                )
+            ):
+                authoritative_followers.add(profile_id)
+
+        return FollowGraph(
+            active_following=frozenset(active_following),
+            active_followers=frozenset(active_followers),
+            authoritative_following=frozenset(authoritative_following),
+            authoritative_followers=frozenset(authoritative_followers),
+            normalized_username_by_profile_id=normalized_by_profile_id,
+            username_by_profile_id={
+                profile.id: profile.username for profile in profiles
+            },
+        )
+
+    @staticmethod
+    def _follow_backed(relationships: Sequence[Mapping[str, Any]]) -> Optional[bool]:
+        """Whether any later watcher in this event already followed an earlier one.
+
+        ``True`` records that the social link existed, not that it carried the
+        film across. ``False`` needs every ordered pair to be authoritatively
+        unconnected; anything unobservable keeps the event undetermined.
+        """
+        reads = [
+            relationship["follows_earlier_watcher"]
+            for relationship in relationships
+            if relationship["later_watcher"] is not None
+        ]
+        if not reads:
+            return None
+        if any(read is True for read in reads):
+            return True
+        if all(read is False for read in reads):
+            return False
+        return None
+
+    @staticmethod
+    def _follow_graph_summary(
+        graph: FollowGraph,
+        profiles: Sequence[Profile],
+        events: Sequence[Mapping[str, Any]],
+    ) -> Dict[str, Any]:
+        """Count how many gap events sit on an observed follow, and say what is unknown.
+
+        The split is descriptive: a follow-backed gap event is one where the
+        later watcher already followed the earlier one. It is never a count of
+        films that travelled along the graph, and the undetermined bucket is
+        reported rather than folded into either side.
+        """
+        gap_events = [event for event in events if (event.get("day_gap") or 0) > 0]
+        covered = [
+            profile.username
+            for profile in profiles
+            if graph.has_authoritative_social_sync(profile.id)
+        ]
+        coverage_ratio = len(covered) / len(profiles) if profiles else None
+        warnings = [
+            "A follow edge is an observed social link, not evidence that one "
+            "member's watch caused another's.",
+        ]
+        if profiles and len(covered) < len(profiles):
+            warnings.append(
+                f"{len(covered)} of {len(profiles)} selected profiles have an "
+                "authoritative following/followers import; pairs without one "
+                "stay undetermined rather than counting as unconnected."
+            )
+        return {
+            "gap_events": len(gap_events),
+            "follow_backed_gap_events": sum(
+                event.get("follow_backed") is True for event in gap_events
+            ),
+            "coincidental_gap_events": sum(
+                event.get("follow_backed") is False for event in gap_events
+            ),
+            "undetermined_gap_events": sum(
+                event.get("follow_backed") is None for event in gap_events
+            ),
+            "same_day_events": len(events) - len(gap_events),
+            "profiles_with_social_sync": covered,
+            "social_sync_coverage_ratio": _round(coverage_ratio, 3),
+            "warnings": warnings,
+        }
 
     def _latest_sync_context(
         self, profiles: Sequence[Profile]
@@ -1306,6 +1590,7 @@ class InsightsService:
         start_date: date,
         end_date: date,
         pair_count: int,
+        follow_graph: Optional[FollowGraph] = None,
     ) -> Dict[str, Any]:
         by_profile: Dict[int, EventRow] = {}
         for participant in participants:
@@ -1319,6 +1604,28 @@ class InsightsService:
             key=lambda item: (item.watched_date, item.username.casefold()),
         )
         ratings = [item.rating for item in unique if item.rating is not None]
+
+        # Order the pair by each profile's earliest watch inside this window,
+        # which is what "watched after" can be said about; the displayed
+        # participant row may be a later, better-rated entry for the same
+        # profile.
+        graph = follow_graph or FollowGraph.unknown()
+        earliest_by_profile: Dict[int, date] = {}
+        for participant in participants:
+            current_date = earliest_by_profile.get(participant.profile_id)
+            if current_date is None or participant.watched_date < current_date:
+                earliest_by_profile[participant.profile_id] = participant.watched_date
+        relationships = [
+            graph.relationship(
+                left.profile_id,
+                right.profile_id,
+                left_username=left.username,
+                right_username=right.username,
+                left_date=earliest_by_profile[left.profile_id],
+                right_date=earliest_by_profile[right.profile_id],
+            )
+            for left, right in combinations(unique, 2)
+        ]
         return {
             "title": movie.title,
             "year": movie.release_year,
@@ -1340,6 +1647,16 @@ class InsightsService:
             "max_rating_gap": _round(max(ratings) - min(ratings), 2) if len(ratings) >= 2 else None,
             "rewatch_count": sum(item.rewatch for item in participants),
             "day_gap": (end_date - start_date).days,
+            # Social context for the co-watch, additive to the timing evidence
+            # above. `follow_relationship` is the two-profile case; group events
+            # keep every pair in `follow_relationships` instead of inventing a
+            # single relationship that does not exist.
+            "follow_relationship": relationships[0] if len(unique) == 2 else None,
+            "follow_relationships": relationships,
+            "follows_earlier_watcher": (
+                relationships[0]["follows_earlier_watcher"] if len(unique) == 2 else None
+            ),
+            "follow_backed": InsightsService._follow_backed(relationships),
         }
 
     def _matched_events(
@@ -1349,6 +1666,7 @@ class InsightsService:
         gap_days: int,
         from_date: Optional[date] = None,
         to_date: Optional[date] = None,
+        follow_graph: Optional[FollowGraph] = None,
     ) -> List[Dict[str, Any]]:
         by_movie: Dict[int, List[EventRow]] = defaultdict(list)
         for event in events:
@@ -1367,7 +1685,14 @@ class InsightsService:
                     pair_count = len(same_day_profiles) * (len(same_day_profiles) - 1) // 2
                     if (from_date is None or start >= from_date) and (to_date is None or start <= to_date):
                         matches.append(
-                            self._event_payload(movie, by_date[start], start, start, pair_count)
+                            self._event_payload(
+                                movie,
+                                by_date[start],
+                                start,
+                                start,
+                                pair_count,
+                                follow_graph,
+                            )
                         )
                 for end in dates[start_index + 1:]:
                     distance = (end - start).days
@@ -1394,6 +1719,7 @@ class InsightsService:
                             start,
                             end,
                             pair_count,
+                            follow_graph,
                         )
                     )
         matches.sort(
@@ -1494,6 +1820,7 @@ class InsightsService:
             if state.enrichment is not None
         }
         classified = self._classified_daily_events(events)
+        follow_graph = self._follow_graph(profiles)
 
         by_movie: Dict[int, List[Dict[str, Any]]] = defaultdict(list)
         for item in classified:
@@ -1534,6 +1861,14 @@ class InsightsService:
                           for item in ordered),
                     ]
                 )
+                relationship = follow_graph.relationship(
+                    ordered[0]["event"].profile_id,
+                    ordered[-1]["event"].profile_id,
+                    left_username=ordered[0]["event"].username,
+                    right_username=ordered[-1]["event"].username,
+                    left_date=ordered[0]["watched_date"],
+                    right_date=ordered[-1]["watched_date"],
+                )
                 echoes.append(
                     {
                         # Stable UI identifier only; preserve the public 16-hex
@@ -1567,6 +1902,12 @@ class InsightsService:
                             }
                             for item in ordered
                         ],
+                        # Who follows whom, alongside the timing the echo
+                        # already proves. Neither field asserts that the
+                        # earlier watch prompted the later one.
+                        "follow_relationship": relationship,
+                        "follows_earlier_watcher": relationship["follows_earlier_watcher"],
+                        "follow_backed": self._follow_backed([relationship]),
                     }
                 )
 
@@ -1624,6 +1965,7 @@ class InsightsService:
                 ),
                 "date_coverage_ratio": _round(date_coverage_ratio, 3),
             },
+            "follow_graph": self._follow_graph_summary(follow_graph, profiles, echoes),
             "echoes": returned_echoes,
         }
 
@@ -1667,7 +2009,12 @@ class InsightsService:
         correlation_component = (correlation + 1) / 2 if correlation is not None else 0.5
         gap_component = max(0.0, 1.0 - ((average_gap or 0) / 2.5))
 
-        matched = self._matched_events(events, gap_days=gap_days)
+        follow_graph = self._follow_graph(profiles)
+        matched = self._matched_events(
+            events,
+            gap_days=gap_days,
+            follow_graph=follow_graph,
+        )
         timing_component = min(len(matched) / max(len(shared), 1), 1.0)
         alignment_score = 100 * (
             0.45 * correlation_component
@@ -1749,6 +2096,13 @@ class InsightsService:
                             "leader_date": leader.watched_date.isoformat(),
                             "follower_date": follower.watched_date.isoformat(),
                             "gap_days": abs(delta),
+                            # `leader`/`follower` here are watch order, not the
+                            # social graph. This field is the social question:
+                            # was the later watcher already following the
+                            # earlier one? None when that is unobservable.
+                            "follows_earlier_watcher": follow_graph.follows(
+                                follower.profile_id, leader.profile_id
+                            ),
                         }
                     )
         influence_paths.sort(key=lambda item: (item["gap_days"], item["leader_date"], item["movie"]["title"]))
@@ -1807,6 +2161,16 @@ class InsightsService:
                     3,
                 ) if total_states else None,
             },
+            "follow_graph": {
+                **self._follow_graph_summary(follow_graph, profiles, matched),
+                # The pair's own social link, independent of any single event.
+                "relationship": follow_graph.relationship(
+                    ordered_profile_ids[0],
+                    ordered_profile_ids[1],
+                    left_username=profiles[0].username,
+                    right_username=profiles[1].username,
+                ),
+            },
             "co_watches": matched[:100],
             "influence_paths": influence_paths[:100],
             "agreements": agreements,
@@ -1830,11 +2194,13 @@ class InsightsService:
         if range_from > range_to:
             raise InsightRequestError({"message": "from must be on or before to"})
 
+        follow_graph = self._follow_graph(profiles)
         matches = self._matched_events(
             events,
             gap_days=gap_days,
             from_date=range_from,
             to_date=range_to,
+            follow_graph=follow_graph,
         )
         calendar_events = []
         for event in matches:
@@ -1895,6 +2261,9 @@ class InsightsService:
             "from": range_from.isoformat(),
             "to": range_to.isoformat(),
             "coverage": self._feature_coverage(profiles, "signal_calendar", events),
+            "follow_graph": self._follow_graph_summary(
+                follow_graph, profiles, calendar_events
+            ),
             "buckets": bucket_payload,
             "events": calendar_events,
             "monthly_summary": monthly_payload,

--- a/backend/services/letterboxd_ratings.py
+++ b/backend/services/letterboxd_ratings.py
@@ -11,9 +11,21 @@ page. Its ``averagerating`` anchor carries the authoritative phrase::
 
     Weighted average of 4.50 based on 4,609,944 ratings
 
-Both numbers are read from that phrase alone. The per-bucket bar labels in the
-same document use abbreviated forms ("27.6K", "2.2M") and are never used as a
-rating count.
+The average and the total are read from that phrase alone, and never by summing
+the ten half-star buckets in the same document.
+
+Those ten buckets are read too, and stored as the film's rating distribution.
+Each bucket row carries its size twice::
+
+    <a class="barcolumn tooltip" title="2,230,960 ★★★★★ ratings (48%)">
+      <span class="_sr-only">2.2M (48%)</span>
+
+The exact figure in the ``title`` attribute is preferred; the visible label is
+abbreviated and lossy ("2.2M" is 30,960 ratings short of the truth, and the ten
+labels together miss that film's real total by 80,202) so it is only expanded
+as a fallback if that attribute ever goes away. Either way the bucket sum stays
+a *shape*, not a total: ``letterboxd_rating_count`` always comes from the
+weighted-average phrase.
 """
 
 from __future__ import annotations
@@ -53,13 +65,38 @@ DEFAULT_TIMEOUT_SECONDS = 30
 RATING_HISTOGRAM_URL_TEMPLATE = "https://letterboxd.com/csi/film/{slug}/rating-histogram/"
 
 # Letterboxd renders the weighted average only once a film has enough ratings.
-# Everything else in the include (the ten half-star buckets) is deliberately
-# ignored: its visible labels are abbreviated and lossy.
 _WEIGHTED_AVERAGE_RE = re.compile(
     r"Weighted\s+average\s+of\s+(\d+(?:\.\d+)?)\s+based\s+on\s+([\d,]+)\s+ratings?",
     re.IGNORECASE,
 )
 _FILM_SLUG_RE = re.compile(r"/film/([^/?#]+)")
+
+# One ``<tr class="column">`` per half-star bucket. The ``<thead>`` row carries
+# no such class, so the header never enters the distribution.
+_BUCKET_ROW_RE = re.compile(
+    r"<tr\b[^>]*\bclass=\"[^\"]*\bcolumn\b[^\"]*\"[^>]*>(.*?)</tr>",
+    re.IGNORECASE | re.DOTALL,
+)
+_BAR_ANCHOR_RE = re.compile(r"<a\b[^>]*\bbarcolumn\b[^>]*>", re.IGNORECASE)
+_TITLE_ATTR_RE = re.compile(r"\btitle=\"([^\"]*)\"", re.IGNORECASE)
+_ROW_HEADER_RE = re.compile(r"<th\b[^>]*>(.*?)</th>", re.IGNORECASE | re.DOTALL)
+_SR_ONLY_RE = re.compile(
+    r"<span\b[^>]*\b_sr-only\b[^>]*>(.*?)</span>",
+    re.IGNORECASE | re.DOTALL,
+)
+_TAG_RE = re.compile(r"<[^>]*>")
+# "2,230,960 ★★★★★ ratings (48%)" -> the exact size and the star label.
+_BUCKET_TITLE_RE = re.compile(
+    r"^\s*([\d,]+(?:\.\d+)?\s*[KMB]?)\s+(.+?)\s+ratings?\b",
+    re.IGNORECASE,
+)
+# "2.2M (48%)" / "2,789 (0%)" -> the leading size, abbreviated or not.
+_LEADING_COUNT_RE = re.compile(r"^\s*([\d,]+(?:\.\d+)?\s*[KMB]?)\b", re.IGNORECASE)
+_ABBREVIATED_COUNT_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*([KMB]?)$", re.IGNORECASE)
+_COUNT_MULTIPLIERS = {"": 1, "K": 1_000, "M": 1_000_000, "B": 1_000_000_000}
+
+# The ten half-star keys, in the order Letterboxd renders them.
+BUCKET_KEYS: tuple[str, ...] = tuple(f"{index / 2:.1f}" for index in range(1, 11))
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
@@ -81,10 +118,17 @@ class RatingCandidate:
 
 @dataclass(frozen=True)
 class ParsedRating:
-    """A film's crowd rating, where ``None`` means "Letterboxd did not say"."""
+    """A film's crowd rating, where ``None`` means "Letterboxd did not say".
+
+    ``distribution`` is the ten half-star buckets keyed ``"0.5"``..``"5.0"``, or
+    ``None`` when the document carried no buckets at all. It is never an empty
+    dict: "no histogram" and "a histogram of zeros" are different claims, and
+    only the second one would be a number.
+    """
 
     average: Optional[float]
     count: Optional[int]
+    distribution: Optional[Dict[str, int]] = None
 
     @property
     def is_known(self) -> bool:
@@ -130,22 +174,133 @@ def resolve_slug(letterboxd_slug: Optional[str], letterboxd_url: Optional[str]) 
     return None
 
 
-def parse_rating_histogram(document: Optional[str]) -> ParsedRating:
-    """Parse Letterboxd's weighted-average phrase out of the CSI include.
+def _expand_count_label(raw: str) -> Optional[int]:
+    """Turn one bar label into an integer, expanding Letterboxd's abbreviations.
 
-    Returns an all-``None`` result when the film has too few ratings for
+    ``"2,230,960"`` is exact and survives untouched; ``"2.2M"`` expands to
+    2,200,000, which is the best the abbreviated form can say. That loss is why
+    the exact ``title`` attribute is always preferred over the visible label,
+    and why no caller may add these buckets up to obtain a rating count.
+    """
+
+    text = (raw or "").strip().replace(",", "").replace(" ", "")
+    match = _ABBREVIATED_COUNT_RE.match(text)
+    if match is None:
+        return None
+    multiplier = _COUNT_MULTIPLIERS[match.group(2).upper()]
+    return int(round(float(match.group(1)) * multiplier))
+
+
+def _bucket_key(label: str) -> Optional[str]:
+    """Map a star label ("★★½", "half-★") to its ``"0.5"``..``"5.0"`` key."""
+
+    text = _TAG_RE.sub("", label or "").strip()
+    if not text:
+        return None
+    if text.casefold().startswith("half"):
+        value = 0.5
+    else:
+        stars = text.count("★")
+        if stars == 0:
+            return None
+        value = stars + (0.5 if "½" in text else 0.0)
+    key = f"{value:.1f}"
+    return key if key in BUCKET_KEYS else None
+
+
+def _parse_buckets(unescaped: str) -> Optional[Dict[str, int]]:
+    """Read the half-star buckets out of an already-unescaped include.
+
+    Returns ``None`` when the document has no bucket rows -- an empty include,
+    or a film Letterboxd has no histogram for. A row that *is* a bucket but
+    whose label or size cannot be read raises, because a partially readable
+    histogram is markup drift, and half a distribution stored as if it were
+    whole would silently misplace every rating measured against it.
+    """
+
+    buckets: Dict[str, int] = {}
+    for row in _BUCKET_ROW_RE.findall(unescaped):
+        anchor = _BAR_ANCHOR_RE.search(row)
+        if anchor is None:
+            continue
+
+        title_match = _TITLE_ATTR_RE.search(anchor.group(0))
+        title = title_match.group(1) if title_match else ""
+        titled = _BUCKET_TITLE_RE.match(title)
+
+        # The star label is written twice -- as the row header and inside the
+        # tooltip -- so either one alone is enough to place the bucket.
+        header = _ROW_HEADER_RE.search(row)
+        labels: List[str] = []
+        if header is not None:
+            labels.append(header.group(1))
+        if titled is not None:
+            labels.append(titled.group(2))
+        key = next(
+            (candidate for candidate in map(_bucket_key, labels) if candidate),
+            None,
+        )
+        if key is None:
+            raise LetterboxdRatingParseError(
+                "Unreadable rating-histogram bucket label "
+                f"{(labels[0].strip() if labels else '')!r}"
+            )
+
+        # The title carries the exact figure; the visible label is abbreviated
+        # and is only read when that attribute is missing.
+        count = _expand_count_label(titled.group(1)) if titled else None
+        if count is None:
+            visible = _SR_ONLY_RE.findall(row)
+            for candidate in visible:
+                leading = _LEADING_COUNT_RE.match(_TAG_RE.sub("", candidate).strip())
+                if leading is not None:
+                    count = _expand_count_label(leading.group(1))
+                    if count is not None:
+                        break
+        if count is None:
+            raise LetterboxdRatingParseError(
+                f"Unreadable rating-histogram bucket size for {key} stars"
+            )
+        if key in buckets:
+            raise LetterboxdRatingParseError(
+                f"Rating histogram repeated the {key}-star bucket"
+            )
+        buckets[key] = count
+
+    if not buckets:
+        return None
+    return {key: buckets[key] for key in BUCKET_KEYS if key in buckets}
+
+
+def parse_rating_buckets(document: Optional[str]) -> Optional[Dict[str, int]]:
+    """Public entry point for the half-star buckets of a raw CSI include."""
+
+    if not document:
+        return None
+    return _parse_buckets(html_module.unescape(document))
+
+
+def parse_rating_histogram(document: Optional[str]) -> ParsedRating:
+    """Parse Letterboxd's weighted-average phrase and buckets out of the include.
+
+    Returns a null average and count when the film has too few ratings for
     Letterboxd to publish an average (the include is then empty, or renders the
     histogram without an ``averagerating`` anchor). That is "unknown", not zero.
+    The buckets are read independently: a document can show the shape of its
+    ratings without Letterboxd publishing a headline average for them.
 
     Raises ``LetterboxdRatingParseError`` when the phrase is present but carries
     a value outside Letterboxd's 0-5 scale, which would mean the markup drifted.
     """
     if not document:
-        return ParsedRating(average=None, count=None)
+        return ParsedRating(average=None, count=None, distribution=None)
 
-    match = _WEIGHTED_AVERAGE_RE.search(html_module.unescape(document))
+    unescaped = html_module.unescape(document)
+    distribution = _parse_buckets(unescaped)
+
+    match = _WEIGHTED_AVERAGE_RE.search(unescaped)
     if match is None:
-        return ParsedRating(average=None, count=None)
+        return ParsedRating(average=None, count=None, distribution=distribution)
 
     raw_average, raw_count = match.group(1), match.group(2)
     try:
@@ -160,7 +315,7 @@ def parse_rating_histogram(document: Optional[str]) -> ParsedRating:
         )
     if count < 0:  # pragma: no cover - regex already constrains this
         raise LetterboxdRatingParseError(f"Negative rating count {count}")
-    return ParsedRating(average=average, count=count)
+    return ParsedRating(average=average, count=count, distribution=distribution)
 
 
 def _build_session():
@@ -326,9 +481,12 @@ def _persist_rating(
 ) -> None:
     """Stamp the attempt, and write values only when Letterboxd published them.
 
-    An "unknown" result never overwrites a previously fetched average: the
-    absent phrase means Letterboxd declined to publish one, not that the film's
-    rating became zero.
+    An "unknown" result never overwrites a previously fetched value: the absent
+    phrase means Letterboxd declined to publish one, not that the film's rating
+    became zero. The distribution follows the same rule but on its own -- a
+    document can carry buckets without a headline average, and a film that has
+    an average already keeps it while ``--refresh`` fills in the buckets behind
+    it.
     """
     movie = db.get(Movie, candidate.movie_id)
     if movie is None:
@@ -336,6 +494,8 @@ def _persist_rating(
     if parsed.is_known:
         movie.letterboxd_average_rating = parsed.average
         movie.letterboxd_rating_count = parsed.count
+    if parsed.distribution is not None:
+        movie.letterboxd_rating_distribution = parsed.distribution
     movie.letterboxd_rating_synced_at = synced_at
     db.flush()
 

--- a/backend/services/obscurity.py
+++ b/backend/services/obscurity.py
@@ -1,0 +1,414 @@
+"""How mainstream one profile's taste is, measured in audience size.
+
+``movies.letterboxd_rating_count`` across this library runs from 205 to
+6,110,855 -- a 30,000x spread. That range is what makes "how mainstream is this
+person's taste" an answerable question rather than a vibe, and Letterboxd never
+puts it on screen: it shows a film's rating count on the film's own page and
+never aggregates those counts over a member's history.
+
+Three deliberate choices hold this module up.
+
+* **The headline is the median, never the mean.** Audience sizes are wildly
+  right-skewed. One 6-million-rating blockbuster among five hundred
+  two-hundred-rating obscurities drags a mean into six figures and reports a
+  mainstream taste that nobody has; the median stays where the person actually
+  lives. The mean is reported beside it precisely so the gap between the two is
+  visible -- a mean far above the median *is* the blockbuster showing up.
+* **A lean is only ever relative.** "Mainstream" is not a property of a number;
+  200,000 ratings is obscure next to one crowd and enormous next to another.
+  ``lean`` is therefore read off ``percentile_vs_group`` and is null exactly
+  when that percentile is null, so the two can never contradict each other. A
+  profile with no group to compare against gets a median and no lean, rather
+  than a lean invented from a threshold nobody chose.
+* **Nothing is extrapolated over missing data.** The crowd-rating backfill has
+  not reached every film, and ``letterboxd_rating_distribution`` is unpopulated
+  until that backfill re-runs. Films without a known audience size are dropped
+  from the median rather than counted as zero, ``coverage`` reports exactly how
+  many survived so the UI can qualify a partial figure, and ``crowd_position``
+  is an empty list -- not null, not fabricated -- while distributions are
+  missing, so the endpoint is useful before the re-backfill lands.
+
+The universe throughout is the profile's *rated* films. A rating is the
+evidence that the film was actually engaged with, and it is also the number
+``crowd_position`` places against the crowd's curve, so keeping one universe
+means the coverage funnel, the headline median and the three film lists all
+describe the same set of films.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy.orm import Session, load_only
+
+from database.models import Movie, MovieEnrichment, Profile, ProfileFilm
+from services.insights import InsightsService, _round, _safe_float
+
+
+DEFAULT_LIMIT = 10
+MAX_LIMIT = 50
+
+# How far from the middle of the group a profile must sit before its taste is
+# named. Inside this band the profile is simply where most people are.
+LEAN_PERCENTILE_MARGIN = 15.0
+
+# Half-star ratings are exact multiples of 0.5, but they arrive as floats;
+# compare with a tolerance so 3.5 is never excluded from its own bucket.
+_RATING_EPSILON = 1e-9
+
+
+@dataclass(frozen=True)
+class _RatedFilm:
+    """One film this profile rated, with whatever the crowd data can say."""
+
+    movie_id: int
+    title: str
+    profile_rating: float
+    rating_count: Optional[int]
+    crowd_average: Optional[float]
+    distribution: Optional[Mapping[str, Any]]
+
+    @property
+    def has_audience(self) -> bool:
+        return self.rating_count is not None
+
+
+def _clamp_limit(limit: Optional[int]) -> int:
+    try:
+        value = int(limit) if limit is not None else DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+    return max(1, min(value, MAX_LIMIT))
+
+
+def _audience(value: Any) -> Optional[int]:
+    """A film's rating count, where anything non-positive means "not synced".
+
+    The backfill only ever writes a count alongside a published average, so a
+    zero here is a placeholder rather than a film nobody rated. Treating it as
+    an audience of zero would make every unsynced film the most obscure thing
+    the profile has ever seen.
+    """
+
+    number = _safe_float(value)
+    if number is None or number <= 0:
+        return None
+    return int(number)
+
+
+def _crowd_average(value: Any) -> Optional[float]:
+    average = _safe_float(value)
+    return average if average is not None and average > 0 else None
+
+
+def _whole(value: Optional[float]) -> Optional[int]:
+    """Round an audience size to a whole person, half away from zero."""
+
+    if value is None:
+        return None
+    return int(value + 0.5) if value >= 0 else -int(-value + 0.5)
+
+
+def _rated_films(db: Session, profile_id: int) -> List[_RatedFilm]:
+    """Bulk-load the profile's rated films and their crowd figures in one query.
+
+    Only the six columns this module reads are selected, so a 1,600-film
+    library never drags whole ``Movie`` rows across to reach a rating count.
+    """
+
+    rows = (
+        db.query(
+            ProfileFilm.movie_id,
+            ProfileFilm.rating,
+            Movie.title,
+            Movie.letterboxd_rating_count,
+            Movie.letterboxd_average_rating,
+            Movie.letterboxd_rating_distribution,
+        )
+        .join(Movie, Movie.id == ProfileFilm.movie_id)
+        .filter(
+            ProfileFilm.profile_id == profile_id,
+            ProfileFilm.removed_at.is_(None),
+            ProfileFilm.rating.isnot(None),
+        )
+        .all()
+    )
+    films: List[_RatedFilm] = []
+    for row in rows:
+        rating = _safe_float(row.rating)
+        if rating is None:
+            continue
+        films.append(
+            _RatedFilm(
+                movie_id=int(row.movie_id),
+                title=row.title or "",
+                profile_rating=rating,
+                rating_count=_audience(row.letterboxd_rating_count),
+                crowd_average=_crowd_average(row.letterboxd_average_rating),
+                distribution=row.letterboxd_rating_distribution,
+            )
+        )
+    return films
+
+
+def _group_medians(db: Session, *, exclude_profile_id: int) -> List[float]:
+    """Every *other* tracked profile's median audience size, in one query.
+
+    One pass over every tracked profile's rated films, grouped in memory --
+    seventeen profiles must never mean seventeen round trips. Only active,
+    completed profiles count, matching the rule the rest of the app uses for a
+    usable imported profile, and a profile with no film of known audience size
+    contributes no median rather than a zero.
+    """
+
+    rows = (
+        db.query(ProfileFilm.profile_id, Movie.letterboxd_rating_count)
+        .join(Movie, Movie.id == ProfileFilm.movie_id)
+        .join(Profile, Profile.id == ProfileFilm.profile_id)
+        .filter(
+            ProfileFilm.profile_id != exclude_profile_id,
+            ProfileFilm.removed_at.is_(None),
+            ProfileFilm.rating.isnot(None),
+            Movie.letterboxd_rating_count.isnot(None),
+            Profile.is_active.is_(True),
+            Profile.scraping_status == "completed",
+        )
+        .all()
+    )
+    grouped: Dict[int, List[int]] = {}
+    for profile_id, rating_count in rows:
+        audience = _audience(rating_count)
+        if audience is not None:
+            grouped.setdefault(int(profile_id), []).append(audience)
+    return [median(counts) for counts in grouped.values() if counts]
+
+
+def _percentile_vs_group(
+    subject_median: Optional[float],
+    other_medians: Sequence[float],
+) -> Optional[float]:
+    """Where this profile sits among its peers, as an *obscurity* percentile.
+
+    100 means every other tracked profile watches bigger films; 0 means every
+    other one watches smaller. A profile tied with the rest of the group lands
+    at 50 rather than 0 or 100, because ties are counted at their midpoint --
+    being level with everybody is the middle of the pack, not either end of it.
+
+    Null when there is nobody to compare against. A group of one has no
+    percentile, and inventing 50 for it would claim a placement we never made.
+    """
+
+    if subject_median is None or not other_medians:
+        return None
+    greater = sum(1 for value in other_medians if value > subject_median)
+    equal = sum(1 for value in other_medians if value == subject_median)
+    return 100.0 * (greater + 0.5 * equal) / len(other_medians)
+
+
+def _lean(percentile: Optional[float]) -> Optional[str]:
+    """Name the taste from the reported percentile, so the two always agree."""
+
+    if percentile is None:
+        return None
+    if percentile > 50.0 + LEAN_PERCENTILE_MARGIN:
+        return "obscure"
+    if percentile < 50.0 - LEAN_PERCENTILE_MARGIN:
+        return "mainstream"
+    return "balanced"
+
+
+def _numeric_buckets(distribution: Any) -> Dict[float, int]:
+    """Coerce a stored ``{"0.5": int}`` distribution into numeric buckets.
+
+    Unreadable keys and values are dropped rather than guessed at; a bucket we
+    cannot place on the star scale cannot be counted on either side of a
+    rating.
+    """
+
+    if not isinstance(distribution, Mapping):
+        return {}
+    buckets: Dict[float, int] = {}
+    for raw_key, raw_value in distribution.items():
+        star = _safe_float(raw_key)
+        size = _safe_float(raw_value)
+        if star is None or size is None or size < 0:
+            continue
+        buckets[star] = buckets.get(star, 0) + int(size)
+    return buckets
+
+
+def _share_at_or_below(distribution: Any, rating: float) -> Optional[float]:
+    """The fraction of the crowd that rated this film at or below ``rating``.
+
+    The denominator is the bucket total, not ``letterboxd_rating_count``: this
+    is a share *of the histogram*, and dividing one source by another would
+    drift whenever the two were captured at different moments.
+    """
+
+    buckets = _numeric_buckets(distribution)
+    total = sum(buckets.values())
+    if total <= 0:
+        return None
+    at_or_below = sum(
+        size for star, size in buckets.items() if star <= rating + _RATING_EPSILON
+    )
+    return at_or_below / total
+
+
+def _film_identities(db: Session, movie_ids: Iterable[int]) -> Dict[int, Dict[str, Any]]:
+    """Display fields for the handful of films that reached an output list.
+
+    Poster hygiene (TMDB path, placeholder rejection, Letterboxd image
+    endpoints) already lives in ``InsightsService._movie_summary``; this reuses
+    it rather than growing a second copy of those rules.
+    """
+
+    wanted = {int(movie_id) for movie_id in movie_ids}
+    if not wanted:
+        return {}
+    rows = (
+        db.query(Movie, MovieEnrichment)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .options(load_only(MovieEnrichment.movie_id, MovieEnrichment.poster_path))
+        .filter(Movie.id.in_(wanted))
+        .all()
+    )
+    identities: Dict[int, Dict[str, Any]] = {}
+    for movie, enrichment in rows:
+        summary = InsightsService._movie_summary(movie, enrichment)
+        identities[movie.id] = {
+            "title": summary["title"],
+            "year": summary["year"],
+            "poster_url": summary["poster_url"],
+            "letterboxd_url": summary["letterboxd_url"],
+        }
+    return identities
+
+
+def _audience_entry(film: _RatedFilm, identity: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        **identity,
+        "rating_count": film.rating_count,
+        "profile_rating": _round(film.profile_rating, 2),
+    }
+
+
+def _crowd_entry(
+    film: _RatedFilm,
+    share: float,
+    identity: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        **identity,
+        "profile_rating": _round(film.profile_rating, 2),
+        "share_at_or_below": round(share, 4),
+        "crowd_average": _round(film.crowd_average, 2),
+    }
+
+
+def build_obscurity_index(
+    db: Session,
+    profile: Profile,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> Dict[str, Any]:
+    """Measure how mainstream one profile's rated films are.
+
+    ``index.median_rating_count`` is the headline: the audience size of the
+    typical film this person rated. ``percentile_vs_group`` places that median
+    among every other tracked profile's median, and ``lean`` names it.
+
+    ``most_obscure`` and ``most_mainstream`` are the two ends of the same
+    ordering. ``crowd_position`` is a different question -- not how big the
+    crowd was, but where inside it this rating fell -- and it stays empty until
+    ``letterboxd_rating_distribution`` is populated.
+    """
+
+    limit = _clamp_limit(limit)
+    films = _rated_films(db, profile.id)
+    with_audience = [film for film in films if film.has_audience]
+
+    audiences = [float(film.rating_count) for film in with_audience]
+    subject_median = median(audiences) if audiences else None
+    subject_mean = (sum(audiences) / len(audiences)) if audiences else None
+
+    percentile = _percentile_vs_group(
+        subject_median,
+        _group_medians(db, exclude_profile_id=profile.id),
+    )
+
+    ordered_by_audience = sorted(
+        with_audience,
+        key=lambda film: (film.rating_count, film.title.casefold(), film.movie_id),
+    )
+    most_obscure = ordered_by_audience[:limit]
+    # The mainstream end of the same ordering, reversed so the biggest crowd
+    # leads. Slicing the tail first would silently return fewer than ``limit``
+    # films whenever the library is smaller than twice the limit.
+    most_mainstream = sorted(
+        with_audience,
+        key=lambda film: (-film.rating_count, film.title.casefold(), film.movie_id),
+    )[:limit]
+
+    positioned: List[Tuple[_RatedFilm, float]] = []
+    for film in films:
+        share = _share_at_or_below(film.distribution, film.profile_rating)
+        if share is not None:
+            positioned.append((film, share))
+    # Most contrarian first: the smallest share is the film this profile rated
+    # above almost the entire crowd. Ties break towards the larger crowd, where
+    # standing apart took more disagreeing with.
+    positioned.sort(
+        key=lambda pair: (
+            pair[1],
+            -(pair[0].rating_count or 0),
+            pair[0].title.casefold(),
+            pair[0].movie_id,
+        )
+    )
+    crowd_position = positioned[:limit]
+
+    identities = _film_identities(
+        db,
+        [
+            film.movie_id
+            for film in (
+                *most_obscure,
+                *most_mainstream,
+                *(pair[0] for pair in crowd_position),
+            )
+        ],
+    )
+
+    def identity(film: _RatedFilm) -> Dict[str, Any]:
+        return identities.get(
+            film.movie_id,
+            {
+                "title": film.title,
+                "year": None,
+                "poster_url": None,
+                "letterboxd_url": None,
+            },
+        )
+
+    return {
+        "username": profile.username,
+        "coverage": {
+            "rated_films": len(films),
+            "films_with_rating_count": len(with_audience),
+        },
+        "index": {
+            "median_rating_count": _whole(subject_median),
+            "mean_rating_count": _whole(subject_mean),
+            "percentile_vs_group": _round(percentile, 1),
+            "lean": _lean(percentile),
+        },
+        "most_obscure": [_audience_entry(film, identity(film)) for film in most_obscure],
+        "most_mainstream": [
+            _audience_entry(film, identity(film)) for film in most_mainstream
+        ],
+        "crowd_position": [
+            _crowd_entry(film, share, identity(film)) for film, share in crowd_position
+        ],
+    }

--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -12,6 +12,13 @@ that was, so a client can qualify the number instead of presenting a partial
 sum as a total. Where enrichment supplies no evidence at all, the payload says
 ``null`` rather than ``0`` -- an unenriched profile has an unknown director
 count, not zero directors.
+
+The ``rewatches`` and ``reviews`` blocks read rows nothing else analysed:
+``profile_films.rewatch_count`` and the ``reviews`` table. Both offer a pair
+of averages -- rewatched against watched-once, reviewed against unreviewed --
+and both pairs are averages over two disjoint, self-selected sets of one
+profile's films. Neither is a paired test, and neither says that rewatching or
+reviewing changes a rating.
 """
 from __future__ import annotations
 
@@ -22,13 +29,16 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Opt
 
 from sqlalchemy.orm import Session
 
-from database.models import Movie, MovieEnrichment, Profile, ProfileFilm, WatchEvent
+from database.models import Movie, MovieEnrichment, Profile, ProfileFilm, Review, WatchEvent
 from services.insights import _as_string_list, _average, _round, _safe_float
 
 
 # Every list surface is a "top" list, not an export: a stats page that renders
 # 800 directors is a database dump, not a summary.
 MAX_LIST_ENTRIES = 10
+
+# The most-liked reviews are a shortlist next to the counts, not a leaderboard.
+MAX_LIKED_REVIEWS = 5
 
 # A single five-star film is not a favourite genre. "Highest rated" needs
 # enough rated films behind the average for the number to mean anything.
@@ -51,7 +61,12 @@ class _Value(NamedTuple):
 class _FilmRow:
     """One active profile_films row, joined to whatever enrichment exists."""
 
+    movie_id: int
+    title: str
+    poster_url: Optional[str]
+    letterboxd_url: Optional[str]
     rating: Optional[float]
+    watch_count: int
     rewatch_count: int
     release_year: Optional[int]
     enriched: bool
@@ -162,9 +177,14 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
     rows = (
         db.query(
             ProfileFilm.rating,
+            ProfileFilm.watch_count,
             ProfileFilm.rewatch_count,
+            Movie.id.label("movie_id"),
+            Movie.title,
+            Movie.poster_url,
+            Movie.letterboxd_url,
             Movie.release_year,
-            MovieEnrichment.movie_id,
+            MovieEnrichment.movie_id.label("enrichment_movie_id"),
             MovieEnrichment.runtime_minutes,
             MovieEnrichment.original_language,
             MovieEnrichment.release_date,
@@ -185,14 +205,19 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
 
     films: List[_FilmRow] = []
     for row in rows:
-        enriched = row.movie_id is not None
+        enriched = row.enrichment_movie_id is not None
         release_year = row.release_year
         if not release_year and row.release_date is not None:
             release_year = row.release_date.year
         credits = row.credits if isinstance(row.credits, Mapping) else {}
         films.append(
             _FilmRow(
+                movie_id=int(row.movie_id),
+                title=row.title,
+                poster_url=row.poster_url,
+                letterboxd_url=row.letterboxd_url,
                 rating=_safe_float(row.rating),
+                watch_count=int(row.watch_count or 0),
                 rewatch_count=int(row.rewatch_count or 0),
                 release_year=int(release_year) if release_year else None,
                 enriched=enriched,
@@ -351,6 +376,237 @@ def _distinct(buckets: Mapping[str, Dict[str, Any]]) -> Optional[int]:
     return len(buckets) or None
 
 
+# --- rewatches --------------------------------------------------------------
+
+
+def _rewatch_block(films: Sequence[_FilmRow]) -> Dict[str, Any]:
+    """What a profile returns to, and how it rates the films it returns to.
+
+    ``average_rating_rewatched`` and ``average_rating_once`` are two ordinary
+    averages over two disjoint halves of the same profile's library -- the
+    films carrying at least one rewatch, and the films seen exactly once. They
+    are not a paired measurement: nobody rated the same film twice here, the
+    films someone chooses to revisit are self-selected, and each side ignores
+    the films that profile never rated. A gap between them describes which
+    films get revisited, not what revisiting does to a rating.
+
+    ``most_rewatched`` ranks by ``watch_count`` because that is the figure it
+    reports, and lists only films with a rewatch -- a film seen once is not a
+    quiet entry at the bottom of a rewatch list. Deeper rewatches break ties,
+    because equal watch counts do not mean equal returning.
+
+    A ``watch_count`` of 1 next to a rewatch is real: Letterboxd lets a diary
+    entry be flagged as a rewatch when the original viewing was never logged,
+    and 166 rows in the current database look exactly like that. The count
+    stays as the column holds it rather than being nudged up to two, which
+    would be inventing a viewing nobody recorded.
+    """
+
+    rewatched = [film for film in films if film.rewatch_count > 0]
+    watched_once = [film for film in films if film.rewatch_count == 0]
+    ranked = sorted(
+        rewatched,
+        key=lambda film: (
+            -film.watch_count,
+            -film.rewatch_count,
+            film.title.casefold(),
+            film.title,
+        ),
+    )[:MAX_LIST_ENTRIES]
+
+    return {
+        "total_rewatches": sum(film.rewatch_count for film in films),
+        "films_rewatched": len(rewatched),
+        # An empty library has no rewatch rate; it does not have a rate of zero.
+        "rewatch_rate": _round(len(rewatched) / len(films), 4) if films else None,
+        "most_rewatched": [
+            {
+                "title": film.title,
+                "year": film.release_year,
+                "poster_url": film.poster_url,
+                "letterboxd_url": film.letterboxd_url,
+                "watch_count": film.watch_count,
+                "rating": _round(film.rating, 2),
+            }
+            for film in ranked
+        ],
+        "average_rating_rewatched": _round(
+            _average([film.rating for film in rewatched]), 2
+        ),
+        "average_rating_once": _round(
+            _average([film.rating for film in watched_once]), 2
+        ),
+    }
+
+
+# --- reviews ----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ReviewRow:
+    """One active review, resolved to a display title where a film matched."""
+
+    movie_id: Optional[int]
+    title: str
+    year: Optional[int]
+    length_chars: Optional[int]
+    contains_spoilers: bool
+    likes_count: int
+    published_date: Optional[date]
+
+
+def _review_rows(db: Session, profile_id: int) -> List[_ReviewRow]:
+    """Bulk-load one profile's active reviews in a single query.
+
+    A review row carries its own ``movie_title``/``movie_year`` because a
+    review can exist without ever resolving to a film in ``movies``, so the
+    canonical row wins where the match exists and the review's own copy is the
+    fallback. Review text is short enough to read in full -- unlike the TMDB
+    payloads above -- so lengths are measured in Python, where stripping
+    trailing whitespace means the same thing it does everywhere else.
+    """
+
+    rows = (
+        db.query(
+            Review.movie_id,
+            Review.movie_title,
+            Review.movie_year,
+            Review.review_text,
+            Review.contains_spoilers,
+            Review.likes_count,
+            Review.published_date,
+            Movie.title.label("canonical_title"),
+            Movie.release_year.label("canonical_year"),
+        )
+        .outerjoin(Movie, Movie.id == Review.movie_id)
+        .filter(
+            Review.profile_id == profile_id,
+            Review.removed_at.is_(None),
+        )
+        .all()
+    )
+
+    reviews: List[_ReviewRow] = []
+    for row in rows:
+        text = (row.review_text or "").strip()
+        year = row.canonical_year if row.canonical_year is not None else row.movie_year
+        reviews.append(
+            _ReviewRow(
+                movie_id=int(row.movie_id) if row.movie_id is not None else None,
+                title=(row.canonical_title or row.movie_title or "").strip(),
+                year=int(year) if year else None,
+                # A rating logged without prose has no length, not a length of 0.
+                length_chars=len(text) if text else None,
+                contains_spoilers=bool(row.contains_spoilers),
+                likes_count=int(row.likes_count or 0),
+                published_date=row.published_date,
+            )
+        )
+    return reviews
+
+
+def median_length_chars(lengths: Sequence[int]) -> Optional[int]:
+    """The middle review length, in whole characters.
+
+    An even-sized sample has no single middle review, so the two middle
+    lengths are averaged and floored: the answer is a character count, and a
+    half-character would be a fiction of the arithmetic.
+    """
+
+    if not lengths:
+        return None
+    ordered = sorted(lengths)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return (ordered[middle - 1] + ordered[middle]) // 2
+
+
+def _review_block(
+    reviews: Sequence[_ReviewRow],
+    films: Sequence[_FilmRow],
+) -> Dict[str, Any]:
+    """Writing habits, and how a profile rates the films it writes about.
+
+    ``average_rating_reviewed`` and ``average_rating_unreviewed`` both read
+    ``profile_films.rating`` -- the profile's own rating of the film, not the
+    rating attached to the review -- so the two sides are the same scale over
+    the same library, split by whether a review resolved to that film. Reviews
+    that never matched a film cannot place one on either side and are counted
+    only in the totals. As with rewatches, these are two averages over two
+    self-selected sets, not a before-and-after.
+
+    ``reviews_by_year`` counts only reviews carrying a publication date; a
+    review with no date belongs to no year and is left out of the series
+    rather than being assigned to one.
+    """
+
+    written = [review for review in reviews if review.length_chars is not None]
+    longest = min(
+        written,
+        key=lambda review: (-(review.length_chars or 0), review.title.casefold()),
+        default=None,
+    )
+    # A review nobody liked is not one of the most-liked reviews.
+    ranked = sorted(
+        (review for review in reviews if review.likes_count > 0),
+        key=lambda review: (
+            -review.likes_count,
+            -(review.published_date.toordinal() if review.published_date else 0),
+            review.title.casefold(),
+        ),
+    )[:MAX_LIKED_REVIEWS]
+    per_year = Counter(
+        review.published_date.year
+        for review in reviews
+        if review.published_date is not None
+    )
+
+    reviewed_movie_ids = {
+        review.movie_id for review in reviews if review.movie_id is not None
+    }
+    reviewed = [film.rating for film in films if film.movie_id in reviewed_movie_ids]
+    unreviewed = [
+        film.rating for film in films if film.movie_id not in reviewed_movie_ids
+    ]
+
+    return {
+        "total_reviews": len(reviews),
+        "with_text": len(written),
+        "spoiler_reviews": sum(1 for review in reviews if review.contains_spoilers),
+        "median_length_chars": median_length_chars(
+            [review.length_chars for review in written if review.length_chars is not None]
+        ),
+        "longest": (
+            {
+                "title": longest.title,
+                "year": longest.year,
+                "length_chars": longest.length_chars,
+            }
+            if longest is not None
+            else None
+        ),
+        "most_liked": [
+            {
+                "title": review.title,
+                "year": review.year,
+                "likes_count": review.likes_count,
+                "published_date": (
+                    review.published_date.isoformat()
+                    if review.published_date is not None
+                    else None
+                ),
+            }
+            for review in ranked
+        ],
+        "reviews_by_year": [
+            {"year": year, "count": per_year[year]} for year in sorted(per_year)
+        ],
+        "average_rating_reviewed": _round(_average(reviewed), 2),
+        "average_rating_unreviewed": _round(_average(unreviewed), 2),
+    }
+
+
 def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
     """Recompute the Letterboxd stats page for one profile from local rows.
 
@@ -359,10 +615,16 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
     never the source: the two will differ because Letterboxd counts its own
     runtime data over a member's whole library while we count TMDB runtimes
     over the films we managed to match.
+
+    ``rewatches`` and ``reviews`` are always present, even for a profile that
+    has neither: their counts fall to zero and every average, median and
+    headline film falls to null, so a client renders "none yet" rather than
+    guessing whether the block failed to compute.
     """
 
     films = _film_rows(db, profile.id)
     watch_dates = _dated_watch_dates(db, profile.id)
+    reviews = _review_rows(db, profile.id)
 
     films_total = len(films)
     films_enriched = sum(1 for film in films if film.enriched)
@@ -387,6 +649,12 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "enrichment_ratio": _round(films_enriched / films_total, 4) if films_total else 0.0,
             "dated_events": len(watch_dates),
             "rated_films": len(ratings),
+            # How many reviews could be placed against a film in the library at
+            # all: the ratings comparison in ``reviews`` is blind to the rest.
+            "reviews_total": len(reviews),
+            "reviews_matched_to_films": sum(
+                1 for review in reviews if review.movie_id is not None
+            ),
         },
         "totals": {
             "films": films_total,
@@ -414,5 +682,7 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "decade": _highest_rated(decades),
             "director": _highest_rated(directors, label_key="name"),
         },
+        "rewatches": _rewatch_block(films),
+        "reviews": _review_block(reviews, films),
         "letterboxd_reported": profile.stats_snapshot,
     }

--- a/backend/services/watchlist_insights.py
+++ b/backend/services/watchlist_insights.py
@@ -1,0 +1,484 @@
+"""A watchlist ranked by the verdict of the circle that already saw the films.
+
+A Letterboxd watchlist is a bag: it remembers what a member meant to watch and
+nothing about whether it was worth watching. Letterboxd can only ever answer
+that with its own site-wide average, which says what several hundred thousand
+strangers thought. We already hold every tracked profile's rating, so a film
+sitting unwatched on one watchlist can carry the far more useful number -- what
+*this member's own people* scored it -- and that is the ranking built here.
+
+Three rules keep the ranking honest.
+
+* **Only unwatched films are recommended.** A watchlist row for a film that
+  already has a ``profile_films`` row for this profile is stale bookkeeping,
+  not a suggestion, so it is dropped from every list and from ``coverage``.
+  Any such row counts, removed ones included: a film that later left the
+  library was still watched.
+* **The group average for a film always excludes the profile being served.**
+  This falls out of the rule above for recommendations, and is enforced in the
+  query regardless so no surface can ever recommend a film to someone on the
+  strength of their own rating.
+* **A recommendation needs at least one other rater.** With no rating behind
+  it there is no verdict to rank on, so the film stays a candidate -- counted
+  in ``coverage.watchlist_films``, eligible for ``longest_waiting`` and
+  ``genre_skew`` -- but never appears in ``recommendations``.
+
+Nothing here extrapolates. ``coverage`` reports how much of the watchlist each
+figure was computed over so a client can qualify a partial answer, and every
+unknown is null rather than zero: a film with no ``added_date`` has an unknown
+wait, not a zero-day one, and is left out of the wait statistics entirely
+instead of being counted as freshly added.
+
+The Letterboxd crowd average is the only external reference and is never
+required. ``movies.letterboxd_average_rating`` is backfilled separately, so
+``letterboxd_average`` is simply null for a film that backfill has not reached
+and the rest of the payload is unaffected.
+"""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from statistics import median
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, aliased, load_only
+
+from database.models import (
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileFilm,
+    WatchlistItem,
+)
+from services.insights import InsightsService, _as_string_list, _average, _round, _safe_float
+
+
+# One other rater is enough to rank on -- it is a verdict, thin but real --
+# and below it there is nothing to rank at all.
+MIN_GROUP_RATERS = 1
+
+# The ranked queue a client actually renders. Its cap is the request's
+# ``limit``; the supporting lists are summaries and keep a fixed ceiling.
+DEFAULT_LIMIT = 20
+MAX_LIMIT = 50
+
+# Enough names to show who liked it without turning a card into a roster.
+SHRINKAGE_PRIOR_RATERS = 2
+
+MAX_RATERS_LISTED = 6
+
+# ``longest_waiting`` and ``genre_skew`` are summaries, not exports.
+MAX_SECONDARY_ENTRIES = 10
+
+
+class _Rater(NamedTuple):
+    """One other member's rating for a film on this profile's watchlist."""
+
+    username: str
+    rating: float
+
+
+@dataclass(frozen=True)
+class _Opinions:
+    """What the rest of the circle did with one film."""
+
+    raters: Tuple[_Rater, ...] = ()
+    liked_by: int = 0
+
+    @property
+    def group_average(self) -> Optional[float]:
+        return _average([rater.rating for rater in self.raters])
+
+    @property
+    def is_recommendable(self) -> bool:
+        return len(self.raters) >= MIN_GROUP_RATERS
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """One active watchlist row for a film this profile has not watched."""
+
+    movie_id: int
+    title: str
+    added_date: Optional[date]
+    letterboxd_average: Optional[float]
+    genres: Tuple[str, ...]
+    opinions: _Opinions
+
+    def days_waiting(self, today: date) -> Optional[int]:
+        """Days since it was added, or null when the import carried no date.
+
+        Letterboxd only publishes an added date on some watchlist surfaces, so
+        a null here is a genuine unknown. A row dated in the future is clamped
+        to zero rather than reported as a negative wait.
+        """
+
+        if self.added_date is None:
+            return None
+        return max(0, (today - self.added_date).days)
+
+
+def _letterboxd_average(value: Any) -> Optional[float]:
+    """The Letterboxd crowd average, or null while the backfill is pending."""
+
+    average = _safe_float(value)
+    return average if average is not None and average > 0 else None
+
+
+def _watchlist_movie_ids(profile_id: int):
+    """Subquery: the movies on this profile's active watchlist."""
+
+    watchlist = aliased(WatchlistItem)
+    return select(watchlist.movie_id).where(
+        watchlist.profile_id == profile_id,
+        watchlist.removed_at.is_(None),
+    )
+
+
+
+def _group_baseline_rating(db: Session, profile_id: int) -> float:
+    """What a film typically scores from this circle, across everything rated.
+
+    The prior has to come from general behaviour, not from the watchlist
+    candidates: those are films people chose to queue, so their mean runs high
+    and shrinking toward it barely moves a lone five-star rating. Averaging the
+    circle's whole rated history gives the honest "expected" score to pull
+    thin verdicts back toward.
+    """
+
+    baseline = (
+        db.query(func.avg(ProfileFilm.rating))
+        .join(Profile, Profile.id == ProfileFilm.profile_id)
+        .filter(
+            ProfileFilm.profile_id != profile_id,
+            ProfileFilm.rating.isnot(None),
+            ProfileFilm.removed_at.is_(None),
+            Profile.is_active.is_(True),
+            Profile.scraping_status == "completed",
+        )
+        .scalar()
+    )
+    return float(baseline) if baseline is not None else 0.0
+
+
+def _group_opinions(db: Session, profile_id: int) -> Dict[int, _Opinions]:
+    """Every *other* tracked profile's rating and like for the watchlist films.
+
+    Restricted to the watchlist by subquery, so a shared movie table spanning
+    thousands of films never leaves the database, and gathered in one query
+    rather than one per film. Only active, completed profiles count towards the
+    group, matching the rule the rest of the app uses for a usable profile.
+    """
+
+    rows = (
+        db.query(
+            ProfileFilm.movie_id,
+            ProfileFilm.rating,
+            ProfileFilm.is_liked,
+            Profile.username,
+        )
+        .join(Profile, Profile.id == ProfileFilm.profile_id)
+        .filter(
+            ProfileFilm.profile_id != profile_id,
+            ProfileFilm.removed_at.is_(None),
+            Profile.is_active.is_(True),
+            Profile.scraping_status == "completed",
+            ProfileFilm.movie_id.in_(_watchlist_movie_ids(profile_id)),
+        )
+        .all()
+    )
+
+    raters: Dict[int, List[_Rater]] = {}
+    likes: Counter[int] = Counter()
+    for movie_id, rating, is_liked, username in rows:
+        key = int(movie_id)
+        value = _safe_float(rating)
+        if value is not None:
+            raters.setdefault(key, []).append(_Rater(username or "", value))
+        if is_liked:
+            likes[key] += 1
+
+    return {
+        movie_id: _Opinions(
+            raters=tuple(
+                sorted(
+                    raters.get(movie_id, ()),
+                    key=lambda rater: (-rater.rating, rater.username.casefold()),
+                )
+            ),
+            liked_by=likes.get(movie_id, 0),
+        )
+        for movie_id in set(raters) | set(likes)
+    }
+
+
+def _candidates(db: Session, profile_id: int) -> List[_Candidate]:
+    """Bulk-load the unwatched watchlist in one query, opinions in a second.
+
+    Films the profile already has a ``profile_films`` row for are excluded in
+    SQL by subquery, so a large library is never shipped to Python to be
+    filtered. Only the columns this module reads are selected -- in particular
+    never ``MovieEnrichment.raw_payload``, which holds the whole TMDB response.
+    """
+
+    watched = select(ProfileFilm.movie_id).where(ProfileFilm.profile_id == profile_id)
+    rows = (
+        db.query(
+            WatchlistItem.movie_id,
+            WatchlistItem.added_date,
+            Movie.title,
+            Movie.letterboxd_average_rating,
+            MovieEnrichment.genres,
+        )
+        .join(Movie, Movie.id == WatchlistItem.movie_id)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(
+            WatchlistItem.profile_id == profile_id,
+            WatchlistItem.removed_at.is_(None),
+            WatchlistItem.movie_id.notin_(watched),
+        )
+        .all()
+    )
+    opinions = _group_opinions(db, profile_id)
+    return [
+        _Candidate(
+            movie_id=int(row.movie_id),
+            title=row.title or "",
+            added_date=row.added_date,
+            letterboxd_average=_letterboxd_average(row.letterboxd_average_rating),
+            genres=tuple(_as_string_list(row.genres)),
+            opinions=opinions.get(int(row.movie_id), _Opinions()),
+        )
+        for row in rows
+    ]
+
+
+def _film_identities(db: Session, movie_ids: Sequence[int]) -> Dict[int, Dict[str, Any]]:
+    """Display fields for the handful of films that reached an output list.
+
+    Poster hygiene (TMDB path, placeholder rejection, Letterboxd image
+    endpoints) already lives in ``InsightsService._movie_summary``; this reuses
+    it rather than growing a second copy of those rules.
+    """
+
+    if not movie_ids:
+        return {}
+    rows = (
+        db.query(Movie, MovieEnrichment)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .options(load_only(MovieEnrichment.movie_id, MovieEnrichment.poster_path))
+        .filter(Movie.id.in_(set(movie_ids)))
+        .all()
+    )
+    identities: Dict[int, Dict[str, Any]] = {}
+    for movie, enrichment in rows:
+        summary = InsightsService._movie_summary(movie, enrichment)
+        identities[movie.id] = {
+            "title": summary["title"],
+            "year": summary["year"],
+            "poster_url": summary["poster_url"],
+            "letterboxd_url": summary["letterboxd_url"],
+        }
+    return identities
+
+
+def _whole_days(value: Optional[float]) -> Optional[int]:
+    """Round a day count half-up, so a 30.5-day median never reads as 30."""
+
+    if value is None:
+        return None
+    return int(math.floor(value + 0.5))
+
+
+def median_days_waiting(waits: Sequence[int]) -> Optional[int]:
+    """The middle wait, over dated rows only -- unknown when none are dated.
+
+    Undated rows are absent from ``waits`` rather than folded in as zero, which
+    would drag the median toward "just added" for a watchlist whose dates the
+    import never captured.
+    """
+
+    if not waits:
+        return None
+    return _whole_days(median(waits))
+
+
+def _genre_skew(candidates: Sequence[_Candidate]) -> List[Dict[str, Any]]:
+    """The genres piling up unwatched, over every candidate that is enriched.
+
+    Counted across the whole unwatched watchlist rather than the recommended
+    slice, because the question is what the member keeps postponing, not what
+    the group happens to have rated.
+    """
+
+    counts: Counter[str] = Counter()
+    labels: Dict[str, str] = {}
+    for candidate in candidates:
+        for genre in candidate.genres:
+            key = genre.casefold()
+            labels.setdefault(key, genre)
+            counts[key] += 1
+    ordered = sorted(counts.items(), key=lambda item: (-item[1], labels[item[0]].casefold()))
+    return [
+        {"label": labels[key], "count": count}
+        for key, count in ordered[:MAX_SECONDARY_ENTRIES]
+    ]
+
+
+def _recommendation(
+    candidate: _Candidate,
+    identity: Dict[str, Any],
+    today: date,
+) -> Dict[str, Any]:
+    opinions = candidate.opinions
+    return {
+        **identity,
+        "group_average": _round(opinions.group_average, 2),
+        "group_raters": len(opinions.raters),
+        "liked_by": opinions.liked_by,
+        "letterboxd_average": _round(candidate.letterboxd_average, 2),
+        "added_date": candidate.added_date.isoformat() if candidate.added_date else None,
+        "days_waiting": candidate.days_waiting(today),
+        "raters": [
+            {"username": rater.username, "rating": _round(rater.rating, 2)}
+            for rater in opinions.raters[:MAX_RATERS_LISTED]
+        ],
+    }
+
+
+def _waiting_entry(
+    candidate: _Candidate,
+    identity: Dict[str, Any],
+    today: date,
+) -> Dict[str, Any]:
+    return {
+        **identity,
+        "added_date": candidate.added_date.isoformat() if candidate.added_date else None,
+        "days_waiting": candidate.days_waiting(today),
+    }
+
+
+def _clamp_limit(limit: Optional[int]) -> int:
+    try:
+        value = int(limit) if limit is not None else DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+    return max(1, min(value, MAX_LIMIT))
+
+
+def build_watchlist_insights(
+    db: Session,
+    profile: Profile,
+    *,
+    limit: int = DEFAULT_LIMIT,
+    today: Optional[date] = None,
+) -> Dict[str, Any]:
+    """Rank one profile's unwatched watchlist by what its circle scored.
+
+    ``recommendations`` is ordered by ``group_average`` and then by how many
+    other members are behind that average, so a 4.5 from four people outranks a
+    4.5 from one. Every film in it has at least one other rater and no
+    ``profile_films`` row for this profile; ``group_average``, ``group_raters``
+    and ``liked_by`` are computed over *other* profiles only.
+
+    ``coverage`` qualifies all of it. ``watchlist_films`` is the size of the
+    unwatched candidate pool -- the denominator for everything else here, and
+    smaller than the raw watchlist wherever a film was watched after being
+    added. ``rated_by_group`` is how many of those the circle can speak to at
+    all, and ``with_letterboxd_average`` how many carry the external crowd
+    number. A client showing a partial queue can say so from these three.
+
+    ``longest_waiting`` and the wait totals read only rows carrying an
+    ``added_date``; an undated row has an unknown wait and is omitted rather
+    than counted as new.
+    """
+
+    limit = _clamp_limit(limit)
+    today = today or date.today()
+    candidates = _candidates(db, profile.id)
+
+    recommendable = [
+        candidate for candidate in candidates if candidate.opinions.is_recommendable
+    ]
+    # Rank on a confidence-weighted score, not the raw average. A single 5.0
+    # is weaker evidence than five people at 4.6, and sorting on the mean puts
+    # the lone opinion on top: across the tracked set, most of what surfaced
+    # that way rested on one rater. Shrinking each film's average toward the
+    # pool mean in proportion to how few people rated it keeps the ordering
+    # honest without discarding thinly-rated films entirely. group_average and
+    # group_raters are still reported verbatim, so the panel can show the real
+    # figures and badge a thin verdict.
+    prior = _group_baseline_rating(db, profile.id)
+
+    def confidence_weighted(candidate) -> float:
+        average = candidate.opinions.group_average
+        if average is None:
+            return 0.0
+        raters = len(candidate.opinions.raters)
+        # k is the number of notional prior raters; at k=2 a single rating is
+        # pulled a third of the way back toward the pool, five barely move.
+        weight = raters / (raters + SHRINKAGE_PRIOR_RATERS)
+        return weight * average + (1 - weight) * prior
+
+    ranked = sorted(
+        recommendable,
+        key=lambda candidate: (
+            -confidence_weighted(candidate),
+            -len(candidate.opinions.raters),
+            candidate.title.casefold(),
+            candidate.movie_id,
+        ),
+    )[:limit]
+
+    dated = [
+        (candidate, candidate.days_waiting(today))
+        for candidate in candidates
+        if candidate.added_date is not None
+    ]
+    longest = sorted(
+        dated,
+        key=lambda pair: (-pair[1], pair[0].title.casefold(), pair[0].movie_id),
+    )[:MAX_SECONDARY_ENTRIES]
+    waits = [days for _, days in dated]
+
+    identities = _film_identities(
+        db,
+        [candidate.movie_id for candidate in (*ranked, *(pair[0] for pair in longest))],
+    )
+
+    def identity(candidate: _Candidate) -> Dict[str, Any]:
+        return identities.get(
+            candidate.movie_id,
+            {
+                "title": candidate.title,
+                "year": None,
+                "poster_url": None,
+                "letterboxd_url": None,
+            },
+        )
+
+    return {
+        "username": profile.username,
+        "coverage": {
+            "watchlist_films": len(candidates),
+            "rated_by_group": len(recommendable),
+            "with_letterboxd_average": sum(
+                1 for candidate in candidates if candidate.letterboxd_average is not None
+            ),
+        },
+        "recommendations": [
+            _recommendation(candidate, identity(candidate), today) for candidate in ranked
+        ],
+        "longest_waiting": [
+            _waiting_entry(candidate, identity(candidate), today)
+            for candidate, _ in longest
+        ],
+        "genre_skew": _genre_skew(candidates),
+        "totals": {
+            "median_days_waiting": median_days_waiting(waits),
+            "oldest_days_waiting": max(waits) if waits else None,
+        },
+    }

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260801_0015"
+HEAD_REVISION = "20260801_0016"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260801_0014"
+            script.get_revision(HEAD_REVISION).down_revision, "20260801_0015"
+        )
+        self.assertEqual(
+            script.get_revision("20260801_0015").down_revision, "20260801_0014"
         )
         self.assertEqual(
             script.get_revision("20260801_0014").down_revision, "20260801_0013"

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -4,7 +4,7 @@ from datetime import date, datetime, timezone
 import unittest
 from unittest.mock import MagicMock
 
-from sqlalchemy import create_engine, inspect as sqlalchemy_inspect
+from sqlalchemy import create_engine, event as sqlalchemy_event, inspect as sqlalchemy_inspect
 from sqlalchemy.orm import sessionmaker
 
 from backend.database.models import (
@@ -22,11 +22,13 @@ from database.models import (
     MovieEnrichment as ServiceMovieEnrichment,
     Profile as ServiceProfile,
     ProfileFilm as ServiceProfileFilm,
+    ProfileFollowEdge as ServiceProfileFollowEdge,
     ProfileSync as ServiceProfileSync,
     SyncDataset as ServiceSyncDataset,
 )
 from backend.services.insights import (
     EventRow,
+    FollowGraph,
     InsightsService,
     ProviderAvailability,
     StateRow,
@@ -67,6 +69,27 @@ def event(
         tags=[],
         source_kind="diary_csv",
         movie=movie,
+    )
+
+
+def follow_graph(
+    profiles,
+    *,
+    following=(),
+    followers=(),
+    authoritative_following=(),
+    authoritative_followers=(),
+) -> FollowGraph:
+    """Build a graph directly so annotation logic is testable without a session."""
+    return FollowGraph(
+        active_following=frozenset(following),
+        active_followers=frozenset(followers),
+        authoritative_following=frozenset(authoritative_following),
+        authoritative_followers=frozenset(authoritative_followers),
+        normalized_username_by_profile_id={
+            profile.id: profile.username.casefold() for profile in profiles
+        },
+        username_by_profile_id={profile.id: profile.username for profile in profiles},
     )
 
 
@@ -287,6 +310,61 @@ class InsightCalculationTests(unittest.TestCase):
                 by_kind["first_known_watch"]["classification_basis"],
                 "earliest_observed_unmarked_event",
             )
+
+    def test_rewatch_echoes_carry_the_follow_reading_and_its_coverage(self) -> None:
+        profiles = [
+            Profile(id=1, username="leader", is_active=True, scraping_status="completed"),
+            Profile(id=2, username="follower", is_active=True, scraping_status="completed"),
+        ]
+        rows = [
+            event(
+                event_id=1,
+                profile_id=1,
+                username="leader",
+                watched_date=date(2026, 7, 10),
+                movie=self.movie,
+                rewatch=True,
+            ),
+            event(
+                event_id=2,
+                profile_id=2,
+                username="follower",
+                watched_date=date(2026, 7, 11),
+                movie=self.movie,
+            ),
+        ]
+        self.service._resolve_profiles = lambda *_args, **_kwargs: profiles
+        self.service._event_rows = lambda *_args, **_kwargs: rows
+        self.service._state_rows = lambda *_args, **_kwargs: []
+        self.service._feature_coverage = lambda *_args, **_kwargs: {
+            "status": "ready",
+            "score": 100,
+            "dated_watch_events": len(rows),
+            "total_watch_events": len(rows),
+            "blockers": [],
+            "warnings": [],
+            "last_updated": None,
+        }
+        self.service._follow_graph = lambda _profiles: follow_graph(
+            profiles,
+            following=[(2, "leader")],
+            authoritative_following=[2],
+        )
+
+        payload = self.service.rewatch_echoes(
+            [profile.username for profile in profiles],
+            gap_days=1,
+            limit=10,
+        )
+
+        echo = payload["echoes"][0]
+        self.assertTrue(echo["follows_earlier_watcher"])
+        self.assertTrue(echo["follow_relationship"]["b_follows_a"])
+        self.assertEqual(echo["follow_relationship"]["earlier_watcher"], "leader")
+        self.assertEqual(payload["follow_graph"]["follow_backed_gap_events"], 1)
+        self.assertEqual(payload["follow_graph"]["coincidental_gap_events"], 0)
+        self.assertEqual(payload["follow_graph"]["profiles_with_social_sync"], ["follower"])
+        self.assertEqual(payload["follow_graph"]["social_sync_coverage_ratio"], 0.5)
 
     def test_taste_timeline_groups_december_into_following_winter(self) -> None:
         profiles = [
@@ -1033,6 +1111,399 @@ class InsightCalculationTests(unittest.TestCase):
         )
         self.assertAlmostEqual(_pearson([1, 2, 3], [2, 4, 6]), 1.0)
         self.assertIsNone(_pearson([1], [1]))
+
+
+class FollowAwareSignalTests(unittest.TestCase):
+    """The social graph annotates co-watch events without asserting influence."""
+
+    def setUp(self) -> None:
+        self.service = InsightsService(db=None)
+        self.movie = Movie(
+            id=10,
+            canonical_key="letterboxd:test-film",
+            title="Test Film",
+            normalized_title="test film",
+            release_year=2026,
+            letterboxd_slug="test-film",
+        )
+        self.profiles = [
+            Profile(id=1, username="Leader", is_active=True, scraping_status="completed"),
+            Profile(id=2, username="Follower", is_active=True, scraping_status="completed"),
+        ]
+        self.gap_rows = [
+            event(
+                event_id=1,
+                profile_id=1,
+                username="Leader",
+                watched_date=date(2026, 7, 1),
+                movie=self.movie,
+            ),
+            event(
+                event_id=2,
+                profile_id=2,
+                username="Follower",
+                watched_date=date(2026, 7, 2),
+                movie=self.movie,
+            ),
+        ]
+
+    def _gap_event(self, graph: FollowGraph) -> dict:
+        matches = self.service._matched_events(
+            self.gap_rows,
+            gap_days=1,
+            follow_graph=graph,
+        )
+        return next(match for match in matches if match["day_gap"] == 1)
+
+    def test_events_without_a_graph_report_unknown_rather_than_no_follow(self) -> None:
+        match = self._gap_event(follow_graph(self.profiles))
+
+        relationship = match["follow_relationship"]
+        self.assertFalse(relationship["known"])
+        self.assertIsNone(relationship["a_follows_b"])
+        self.assertIsNone(relationship["b_follows_a"])
+        self.assertIsNone(relationship["mutual"])
+        self.assertEqual(relationship["observed_by"], [])
+        self.assertIsNone(match["follows_earlier_watcher"])
+        self.assertIsNone(match["follow_backed"])
+
+    def test_later_watcher_following_the_earlier_one_is_the_directional_read(self) -> None:
+        match = self._gap_event(
+            follow_graph(
+                self.profiles,
+                following=[(2, "leader")],
+                authoritative_following=[2],
+            )
+        )
+
+        relationship = match["follow_relationship"]
+        self.assertEqual(relationship["earlier_watcher"], "Leader")
+        self.assertEqual(relationship["later_watcher"], "Follower")
+        self.assertTrue(relationship["b_follows_a"])
+        self.assertFalse(relationship["a_follows_b"])
+        self.assertFalse(relationship["mutual"])
+        self.assertTrue(relationship["known"])
+        self.assertTrue(match["follows_earlier_watcher"])
+        self.assertTrue(match["follow_backed"])
+
+    def test_follow_pointing_the_other_way_is_not_a_follow_backed_gap(self) -> None:
+        match = self._gap_event(
+            follow_graph(
+                self.profiles,
+                following=[(1, "follower")],
+                authoritative_following=[1, 2],
+            )
+        )
+
+        relationship = match["follow_relationship"]
+        self.assertTrue(relationship["a_follows_b"])
+        self.assertFalse(relationship["b_follows_a"])
+        self.assertFalse(match["follows_earlier_watcher"])
+        self.assertFalse(match["follow_backed"])
+
+    def test_a_followers_page_corroborates_the_same_edge(self) -> None:
+        # Only the earlier watcher was synced, and their followers page lists
+        # the later watcher: the same edge, observed from the other side.
+        match = self._gap_event(
+            follow_graph(
+                self.profiles,
+                followers=[(1, "follower")],
+                authoritative_followers=[1],
+            )
+        )
+
+        self.assertTrue(match["follow_relationship"]["b_follows_a"])
+        self.assertTrue(match["follows_earlier_watcher"])
+
+    def test_authoritative_absence_reads_false_and_silence_reads_unknown(self) -> None:
+        authoritative = self._gap_event(
+            follow_graph(self.profiles, authoritative_following=[1, 2])
+        )
+        silent = self._gap_event(follow_graph(self.profiles))
+
+        self.assertTrue(authoritative["follow_relationship"]["known"])
+        self.assertFalse(authoritative["follow_relationship"]["b_follows_a"])
+        self.assertFalse(authoritative["follow_backed"])
+        self.assertFalse(silent["follow_relationship"]["known"])
+        self.assertIsNone(silent["follow_backed"])
+
+    def test_mutual_stays_unknown_until_both_directions_are_observable(self) -> None:
+        match = self._gap_event(
+            follow_graph(
+                self.profiles,
+                following=[(2, "leader")],
+                authoritative_following=[2],
+            )
+        )
+        # The earlier watcher has no social import, so "does Leader follow
+        # Follower?" is unanswered; a one-way observation cannot settle mutual.
+        self.assertIsNone(match["follow_relationship"]["a_follows_b"])
+        self.assertIsNone(match["follow_relationship"]["mutual"])
+
+    def test_same_day_events_carry_the_edge_but_no_directional_read(self) -> None:
+        rows = [
+            event(
+                event_id=1,
+                profile_id=1,
+                username="Leader",
+                watched_date=date(2026, 7, 1),
+                movie=self.movie,
+            ),
+            event(
+                event_id=2,
+                profile_id=2,
+                username="Follower",
+                watched_date=date(2026, 7, 1),
+                movie=self.movie,
+            ),
+        ]
+        graph = follow_graph(
+            self.profiles,
+            following=[(2, "leader")],
+            authoritative_following=[2],
+        )
+
+        match = self.service._matched_events(rows, gap_days=1, follow_graph=graph)[0]
+
+        # Same-day pairs sort by username, so the later watcher is `a` here.
+        relationship = match["follow_relationship"]
+        self.assertEqual((relationship["a"], relationship["b"]), ("Follower", "Leader"))
+        self.assertTrue(relationship["a_follows_b"])
+        self.assertIsNone(match["follow_relationship"]["earlier_watcher"])
+        self.assertIsNone(match["follows_earlier_watcher"])
+        self.assertIsNone(match["follow_backed"])
+
+    def test_group_events_keep_every_pair_instead_of_one_relationship(self) -> None:
+        profiles = [
+            *self.profiles,
+            Profile(id=3, username="Third", is_active=True, scraping_status="completed"),
+        ]
+        rows = [
+            *self.gap_rows,
+            event(
+                event_id=3,
+                profile_id=3,
+                username="Third",
+                watched_date=date(2026, 7, 2),
+                movie=self.movie,
+            ),
+        ]
+        graph = follow_graph(
+            profiles,
+            following=[(2, "leader")],
+            authoritative_following=[2],
+        )
+
+        match = next(
+            item
+            for item in self.service._matched_events(rows, gap_days=1, follow_graph=graph)
+            if item["profile_count"] == 3
+        )
+
+        self.assertIsNone(match["follow_relationship"])
+        self.assertIsNone(match["follows_earlier_watcher"])
+        self.assertEqual(len(match["follow_relationships"]), 3)
+        self.assertEqual(
+            {
+                (item["a"], item["b"], item["follows_earlier_watcher"])
+                for item in match["follow_relationships"]
+            },
+            {
+                ("Leader", "Follower", True),
+                ("Leader", "Third", None),
+                ("Follower", "Third", None),
+            },
+        )
+        # One observed edge is enough to call the event follow-backed, but the
+        # unresolved pairs are still reported rather than assumed absent.
+        self.assertTrue(match["follow_backed"])
+
+    def test_summary_splits_follow_backed_from_coincidental_and_undetermined(self) -> None:
+        summary = self.service._follow_graph_summary(
+            follow_graph(self.profiles, authoritative_following=[1]),
+            self.profiles,
+            [
+                {"day_gap": 1, "follow_backed": True},
+                {"day_gap": 2, "follow_backed": False},
+                {"day_gap": 3, "follow_backed": None},
+                {"day_gap": 0, "follow_backed": None},
+            ],
+        )
+
+        self.assertEqual(summary["gap_events"], 3)
+        self.assertEqual(summary["follow_backed_gap_events"], 1)
+        self.assertEqual(summary["coincidental_gap_events"], 1)
+        self.assertEqual(summary["undetermined_gap_events"], 1)
+        self.assertEqual(summary["same_day_events"], 1)
+        self.assertEqual(summary["social_sync_coverage_ratio"], 0.5)
+        self.assertTrue(
+            any("not evidence" in warning for warning in summary["warnings"])
+        )
+        self.assertTrue(
+            any("undetermined" in warning for warning in summary["warnings"])
+        )
+
+    def test_pair_dossier_annotates_paths_and_keeps_existing_fields(self) -> None:
+        self.service._resolve_profiles = lambda *_args, **_kwargs: self.profiles
+        self.service._event_rows = lambda *_args, **_kwargs: self.gap_rows
+        self.service._state_rows = lambda *_args, **_kwargs: []
+        self.service._feature_coverage = lambda *_args, **_kwargs: {
+            "status": "ready",
+            "score": 100,
+            "dated_watch_events": 2,
+            "total_watch_events": 2,
+            "blockers": [],
+            "warnings": [],
+            "last_updated": None,
+        }
+        self.service._follow_graph = lambda _profiles: follow_graph(
+            self.profiles,
+            following=[(2, "leader")],
+            authoritative_following=[2],
+        )
+        self.service.db = MagicMock()
+        self.service.db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        payload = self.service.pair_dossier(["Leader", "Follower"], gap_days=1)
+
+        path = payload["influence_paths"][0]
+        self.assertEqual(path["leader"], "Leader")
+        self.assertEqual(path["follower"], "Follower")
+        self.assertTrue(path["follows_earlier_watcher"])
+        self.assertEqual(payload["follow_graph"]["follow_backed_gap_events"], 1)
+        self.assertEqual(payload["follow_graph"]["coincidental_gap_events"], 0)
+        self.assertTrue(payload["follow_graph"]["relationship"]["b_follows_a"])
+        # The pair's own relationship is not tied to any single event.
+        self.assertIsNone(payload["follow_graph"]["relationship"]["later_watcher"])
+        self.assertEqual(payload["summary"]["directional_leader"], "Leader")
+
+    def test_edges_and_authority_load_in_bounded_queries(self) -> None:
+        engine = create_engine("sqlite:///:memory:")
+        ServiceBase.metadata.create_all(
+            engine,
+            tables=[
+                ServiceProfile.__table__,
+                ServiceProfileSync.__table__,
+                ServiceSyncDataset.__table__,
+                ServiceProfileFollowEdge.__table__,
+            ],
+        )
+        db = sessionmaker(bind=engine)()
+        statements: list[str] = []
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        try:
+            leader = ServiceProfile(id=1, username="leader", scraping_status="completed")
+            watcher = ServiceProfile(id=2, username="watcher", scraping_status="completed")
+            bystander = ServiceProfile(id=3, username="bystander", scraping_status="completed")
+            sync = ServiceProfileSync(
+                id=10,
+                profile_id=watcher.id,
+                source_kind="uploaded_csv_bundle",
+                source_fingerprint="bundle",
+                importer_version="test",
+                status="completed",
+                completed_at=datetime(2026, 7, 30, tzinfo=timezone.utc),
+                manifest={},
+                coverage={},
+                stats={},
+            )
+            db.add_all(
+                [
+                    leader,
+                    watcher,
+                    bystander,
+                    sync,
+                    ServiceSyncDataset(
+                        id=100,
+                        profile_sync_id=sync.id,
+                        dataset_name="following",
+                        source_row_count=2,
+                        imported_row_count=2,
+                        is_authoritative=True,
+                        metadata_payload={},
+                    ),
+                    ServiceProfileFollowEdge(
+                        id=200,
+                        profile_id=watcher.id,
+                        direction="following",
+                        counterpart_username="Leader",
+                        counterpart_username_normalized="leader",
+                    ),
+                    ServiceProfileFollowEdge(
+                        id=201,
+                        profile_id=watcher.id,
+                        direction="following",
+                        counterpart_username="Unrelated",
+                        counterpart_username_normalized="unrelated",
+                    ),
+                    ServiceProfileFollowEdge(
+                        id=202,
+                        profile_id=watcher.id,
+                        direction="following",
+                        counterpart_username="Bystander",
+                        counterpart_username_normalized="bystander",
+                        removed_at=datetime(2026, 7, 29, tzinfo=timezone.utc),
+                    ),
+                ]
+            )
+            db.commit()
+
+            profiles = db.query(ServiceProfile).order_by(ServiceProfile.id).all()
+            sqlalchemy_event.listen(engine, "before_cursor_execute", record)
+            graph = InsightsService(db)._follow_graph(profiles)
+            sqlalchemy_event.remove(engine, "before_cursor_execute", record)
+
+            edge_queries = [
+                statement
+                for statement in statements
+                if "profile_follow_edges" in statement
+            ]
+            self.assertEqual(len(edge_queries), 1)
+            # Edges, latest syncs, the legacy-sync fallback and datasets: four
+            # bounded statements, and the count does not grow with the group.
+            self.assertLessEqual(len(statements), 4)
+
+            self.assertTrue(graph.follows(watcher.id, leader.id))
+            # An unfollow is soft-removed, so it must not read as an edge, and
+            # the watcher's authoritative following list makes that a real no.
+            self.assertFalse(graph.follows(watcher.id, bystander.id))
+            # Nobody imported the leader's or bystander's social surfaces.
+            self.assertIsNone(graph.follows(leader.id, watcher.id))
+            self.assertIsNone(graph.follows(bystander.id, leader.id))
+            self.assertTrue(graph.has_authoritative_social_sync(watcher.id))
+            self.assertFalse(graph.has_authoritative_social_sync(leader.id))
+        finally:
+            db.close()
+            engine.dispose()
+
+    def test_an_unavailable_social_surface_never_becomes_authoritative_absence(self) -> None:
+        service = InsightsService(db=MagicMock())
+        service.db.query.return_value.filter.return_value.all.return_value = []
+        profiles = [
+            Profile(id=1, username="left", is_active=True, scraping_status="completed"),
+            Profile(id=2, username="right", is_active=True, scraping_status="completed"),
+        ]
+        sync = ProfileSync(id=10, profile_id=1, status="completed")
+        blocked = SyncDataset(
+            profile_sync_id=sync.id,
+            dataset_name="following",
+            source_row_count=0,
+            imported_row_count=0,
+            is_authoritative=True,
+            metadata_payload={"unavailable_reason": "forbidden/private"},
+        )
+        service._latest_sync_context = lambda _profiles: {
+            1: (sync, {"following": blocked}),
+            2: (None, {}),
+        }
+
+        graph = service._follow_graph(profiles)
+
+        self.assertFalse(graph.has_authoritative_social_sync(1))
+        self.assertIsNone(graph.follows(1, 2))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_letterboxd_ratings.py
+++ b/backend/tests/test_letterboxd_ratings.py
@@ -10,9 +10,11 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from backend.database.models import Movie, Profile, ProfileSync
 from backend.services.letterboxd_ratings import (
+    BUCKET_KEYS,
     LetterboxdRatingError,
     LetterboxdRatingFetcher,
     LetterboxdRatingParseError,
+    parse_rating_buckets,
     parse_rating_histogram,
     resolve_slug,
     sync_letterboxd_ratings,
@@ -83,6 +85,82 @@ EMPTY_INCLUDE = "\n\n\n"
 
 
 # ---------------------------------------------------------------------------
+# The full ten-bucket document, from a live capture of
+# letterboxd.com/csi/film/the-dark-knight/rating-histogram/ on 2026-08-01.
+# Every figure, star label and abbreviation below is verbatim from that
+# response; only whitespace between tags has been collapsed.
+#
+# Note what the two labels on each row disagree about: the ``title`` attribute
+# carries the exact size, the visible ``_sr-only`` span carries an abbreviation
+# ("2.2M" for 2,230,960 -- 30,960 ratings short). The parser prefers the exact
+# one, and expanding the abbreviation is only a fallback.
+# ---------------------------------------------------------------------------
+
+REAL_CAPTURE = (
+    # (star label, href fragment, exact count, visible abbreviated label)
+    ("half-★", "%C2%BD", 2_789, "2,789"),
+    ("★", "1", 7_099, "7,099"),
+    ("★½", "1%C2%BD", 4_180, "4,180"),
+    ("★★", "2", 27_619, "27.6K"),
+    ("★★½", "2%C2%BD", 27_402, "27.4K"),
+    ("★★★", "3", 198_521, "199K"),
+    ("★★★½", "3%C2%BD", 238_110, "238K"),
+    ("★★★★", "4", 1_049_276, "1M"),
+    ("★★★★½", "4%C2%BD", 824_314, "824K"),
+    ("★★★★★", "5", 2_230_960, "2.2M"),
+)
+
+REAL_DISTRIBUTION = {
+    "0.5": 2_789,
+    "1.0": 7_099,
+    "1.5": 4_180,
+    "2.0": 27_619,
+    "2.5": 27_402,
+    "3.0": 198_521,
+    "3.5": 238_110,
+    "4.0": 1_049_276,
+    "4.5": 824_314,
+    "5.0": 2_230_960,
+}
+
+REAL_RATING_COUNT = 4_610_270
+
+
+def _real_row(stars: str, href: str, count: int, visible: str, *, titled: bool = True) -> str:
+    title = f' title="{count:,} {stars} ratings (1%)"' if titled else ""
+    return (
+        '<tr class="column" style="--value: 0.5;">'
+        f'<th scope="row" class="_sr-only">{stars}</th>'
+        '<td class="cell">'
+        f'<a href="/film/the-dark-knight/ratings/rated/{href}/by/rating/"'
+        f' class="barcolumn tooltip"{title}>'
+        f'<span class="_sr-only">{visible} (1%)</span>'
+        '<span class="bar"><span class="fill"></span></span>'
+        "</a></td></tr>"
+    )
+
+
+def _real_histogram(*, titled: bool = True, average: bool = True) -> str:
+    rows = "".join(_real_row(*bucket, titled=titled) for bucket in REAL_CAPTURE)
+    anchor = (
+        '<a href="/film/the-dark-knight/ratings/" class="averagerating tooltip"'
+        f' title="Weighted average of 4.50 based on {REAL_RATING_COUNT:,} ratings"> 4.5 </a>'
+        if average
+        else ""
+    )
+    return (
+        '<div class="rating-histogram"> <div class="layout">'
+        '<table class="chart"><caption class="_sr-only">Rating Distribution</caption>'
+        '<thead class="_sr-only"><tr><th scope="col">Rating</th>'
+        '<th scope="col">Count</th></tr></thead>'
+        f'<tbody class="plot">{rows}</tbody></table>{anchor}</div> </div>'
+    )
+
+
+REAL_HISTOGRAM = _real_histogram()
+
+
+# ---------------------------------------------------------------------------
 # Parsing
 # ---------------------------------------------------------------------------
 
@@ -147,6 +225,111 @@ def test_out_of_scale_average_is_loud_markup_drift():
     )
     with pytest.raises(LetterboxdRatingParseError):
         parse_rating_histogram(document)
+
+
+# ---------------------------------------------------------------------------
+# The ten half-star buckets
+# ---------------------------------------------------------------------------
+
+
+def test_the_real_capture_yields_all_ten_half_star_buckets():
+    parsed = parse_rating_histogram(REAL_HISTOGRAM)
+
+    assert parsed.distribution == REAL_DISTRIBUTION
+    assert list(parsed.distribution) == list(BUCKET_KEYS)
+    assert (parsed.average, parsed.count) == (4.5, REAL_RATING_COUNT)
+
+
+def test_the_exact_bucket_figure_is_preferred_over_the_abbreviated_label():
+    # The 5-star row says "2,230,960" in its title and "2.2M" in its visible
+    # label. Storing the abbreviation would throw away 30,960 ratings, and the
+    # ten abbreviated labels together would miss the real total by 80,202.
+    parsed = parse_rating_histogram(REAL_HISTOGRAM)
+
+    assert parsed.distribution["5.0"] == 2_230_960
+    assert parsed.distribution["5.0"] != 2_200_000
+    assert parsed.distribution["2.0"] == 27_619 and parsed.distribution["2.0"] != 27_600
+    assert sum(parsed.distribution.values()) == REAL_RATING_COUNT
+
+
+def test_an_abbreviated_label_round_trips_when_the_exact_figure_is_gone():
+    # Same document with the title attribute stripped from every bar: the
+    # visible labels are all that is left, so they are expanded. "2.2M" must
+    # become 2,200,000 rather than 2.2, 22, or a discarded bucket.
+    document = _real_histogram(titled=False)
+
+    distribution = parse_rating_buckets(document)
+
+    assert distribution["5.0"] == 2_200_000
+    assert distribution["4.0"] == 1_000_000
+    assert distribution["3.0"] == 199_000
+    assert distribution["2.0"] == 27_600
+    assert distribution["2.5"] == 27_400
+    assert distribution["0.5"] == 2_789  # small buckets are never abbreviated
+    assert list(distribution) == list(BUCKET_KEYS)
+
+
+def test_the_bucket_sum_is_never_used_as_the_rating_count():
+    # The abbreviated labels sum to 4,530,068 -- 80,202 short of the real
+    # total. Even at full precision the buckets are only ever a shape; the
+    # count comes from the weighted-average phrase.
+    abbreviated = parse_rating_buckets(_real_histogram(titled=False))
+    assert sum(abbreviated.values()) == 4_530_068
+    assert sum(abbreviated.values()) != REAL_RATING_COUNT
+
+    parsed = parse_rating_histogram(_real_histogram(titled=False))
+    assert parsed.count == REAL_RATING_COUNT
+
+
+def test_buckets_are_read_even_when_letterboxd_withholds_the_average():
+    parsed = parse_rating_histogram(_real_histogram(average=False))
+
+    assert (parsed.average, parsed.count) == (None, None)
+    assert parsed.is_known is False
+    assert parsed.distribution == REAL_DISTRIBUTION
+
+
+def test_a_histogram_with_no_buckets_is_null_not_an_empty_dict():
+    for document in (EMPTY_INCLUDE, "", None):
+        assert parse_rating_buckets(document) is None
+        assert parse_rating_histogram(document).distribution is None
+
+    # A document that renders the table but plots nothing is still "no shape".
+    plotted_nothing = (
+        '<div class="rating-histogram"><table class="chart">'
+        '<tbody class="plot"></tbody></table></div>'
+    )
+    assert parse_rating_buckets(plotted_nothing) is None
+
+
+def test_the_header_row_is_not_mistaken_for_a_bucket():
+    # <thead> carries <th scope="col">Rating</th> but no class="column" row and
+    # no barcolumn anchor, so it must never enter the distribution.
+    assert len(parse_rating_buckets(REAL_HISTOGRAM)) == 10
+
+
+def test_an_unreadable_bucket_label_is_loud_markup_drift():
+    drifted = (
+        '<div class="rating-histogram"><table class="chart"><tbody class="plot">'
+        '<tr class="column"><th scope="row" class="_sr-only">six stars</th>'
+        '<td class="cell"><a class="barcolumn tooltip" title="10 six stars ratings (1%)">'
+        '<span class="_sr-only">10 (1%)</span></a></td></tr>'
+        "</tbody></table></div>"
+    )
+    with pytest.raises(LetterboxdRatingParseError):
+        parse_rating_buckets(drifted)
+
+
+def test_a_bucket_with_no_readable_size_is_loud_markup_drift():
+    drifted = (
+        '<div class="rating-histogram"><table class="chart"><tbody class="plot">'
+        '<tr class="column"><th scope="row" class="_sr-only">★★★</th>'
+        '<td class="cell"><a class="barcolumn tooltip">'
+        '<span class="_sr-only">plenty (1%)</span></a></td></tr>'
+        "</tbody></table></div>"
+    )
+    with pytest.raises(LetterboxdRatingParseError):
+        parse_rating_buckets(drifted)
 
 
 # ---------------------------------------------------------------------------
@@ -298,6 +481,74 @@ def test_successful_sync_writes_average_count_and_stamp(database):
     assert movie.letterboxd_rating_count == 4_609_944
     assert movie.letterboxd_rating_synced_at is not None
     assert (stats.selected, stats.updated, stats.failed) == (1, 1, 0)
+
+
+def test_successful_sync_persists_the_ten_bucket_distribution(database):
+    _add_movie(database, 1, "The Dark Knight", letterboxd_slug="the-dark-knight")
+    fetcher = ScriptedFetcher({"the-dark-knight": REAL_HISTOGRAM})
+
+    sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_rating_distribution == REAL_DISTRIBUTION
+    # The stored total still comes from the weighted-average phrase.
+    assert movie.letterboxd_rating_count == REAL_RATING_COUNT
+
+
+def test_refresh_backfills_the_distribution_behind_an_existing_average(database):
+    # The state every already-synced row is in today: an average and a count,
+    # and a distribution column that was thrown away at parse time.
+    now = datetime(2026, 8, 1, tzinfo=timezone.utc)
+    _add_movie(
+        database,
+        1,
+        "The Dark Knight",
+        letterboxd_slug="the-dark-knight",
+        letterboxd_average_rating=4.5,
+        letterboxd_rating_count=REAL_RATING_COUNT,
+        letterboxd_rating_distribution=None,
+        letterboxd_rating_synced_at=now - timedelta(days=1),
+    )
+    fetcher = ScriptedFetcher({"the-dark-knight": REAL_HISTOGRAM})
+
+    stats = sync_letterboxd_ratings(
+        database, fetcher, refresh=True, now=now, sleeper=lambda _: None
+    )
+
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_rating_distribution == REAL_DISTRIBUTION
+    assert movie.letterboxd_average_rating == 4.5
+    assert stats.updated == 1
+
+
+def test_a_missing_distribution_never_clears_a_stored_one(database):
+    _add_movie(
+        database,
+        1,
+        "The Dark Knight",
+        letterboxd_slug="the-dark-knight",
+        letterboxd_rating_distribution=REAL_DISTRIBUTION,
+    )
+    # Letterboxd served the include but plotted nothing this time.
+    fetcher = ScriptedFetcher({"the-dark-knight": EMPTY_INCLUDE})
+
+    sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    assert database.get(Movie, 1).letterboxd_rating_distribution == REAL_DISTRIBUTION
+
+
+def test_buckets_are_stored_even_when_the_average_is_withheld(database):
+    _add_movie(database, 1, "Barely Rated", letterboxd_slug="barely-rated")
+    fetcher = ScriptedFetcher({"barely-rated": _real_histogram(average=False)})
+
+    stats = sync_letterboxd_ratings(database, fetcher, sleeper=lambda _: None)
+
+    movie = database.get(Movie, 1)
+    assert movie.letterboxd_rating_distribution == REAL_DISTRIBUTION
+    assert movie.letterboxd_average_rating is None
+    assert movie.letterboxd_rating_count is None
+    # The headline is what is unavailable, so that is what the stat reports.
+    assert stats.unavailable == 1
 
 
 def test_confirmed_absence_stamps_the_attempt_so_dead_films_are_not_retried(database):

--- a/backend/tests/test_obscurity.py
+++ b/backend/tests/test_obscurity.py
@@ -1,0 +1,754 @@
+"""Obscurity index: a taste measured in audience size, not in stars.
+
+The properties under test are the ones that make the number honest: the median
+resists a single blockbuster, unsynced films are absent rather than zero, the
+percentile places a profile against peers it is not itself part of, and
+``crowd_position`` degrades to an empty list while distributions are missing.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from itertools import count
+from typing import Any, Dict, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from api.routes.obscurity import router as obscurity_router
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from database.models import (
+    AppUser,
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileAccessRequest,
+    ProfileFilm,
+    UserTrackedProfile,
+)
+from services.obscurity import (
+    DEFAULT_LIMIT,
+    MAX_LIMIT,
+    _clamp_limit,
+    _percentile_vs_group,
+    _share_at_or_below,
+    build_obscurity_index,
+)
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    Movie.__table__,
+    ProfileFilm.__table__,
+    MovieEnrichment.__table__,
+    AppUser.__table__,
+    UserTrackedProfile.__table__,
+    ProfileAccessRequest.__table__,
+)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+_MOVIE_IDS = count(1)
+
+
+def _profile(
+    database: Session,
+    username: str,
+    *,
+    is_active: bool = True,
+    scraping_status: str = "completed",
+) -> Profile:
+    profile = Profile(
+        username=username,
+        scraping_status=scraping_status,
+        is_active=is_active,
+    )
+    database.add(profile)
+    database.commit()
+    return profile
+
+
+def _film(
+    database: Session,
+    title: str,
+    *,
+    rating_count: Optional[int] = None,
+    crowd_average: Optional[float] = None,
+    distribution: Optional[Dict[str, int]] = None,
+    year: Optional[int] = 2000,
+) -> Movie:
+    movie_id = next(_MOVIE_IDS)
+    movie = Movie(
+        id=movie_id,
+        canonical_key=f"letterboxd:{title}-{movie_id}",
+        title=title,
+        normalized_title=title.casefold(),
+        release_year=year,
+        letterboxd_url=f"https://letterboxd.com/film/{movie_id}/",
+        letterboxd_rating_count=rating_count,
+        letterboxd_average_rating=crowd_average,
+        letterboxd_rating_distribution=distribution,
+    )
+    database.add(movie)
+    database.commit()
+    return movie
+
+
+def _rate(
+    database: Session,
+    profile: Profile,
+    movie: Movie,
+    rating: Optional[float],
+    *,
+    removed_at: Any = None,
+) -> None:
+    database.add(
+        ProfileFilm(
+            profile_id=profile.id,
+            movie_id=movie.id,
+            rating=rating,
+            tags=[],
+            watch_count=1,
+            rewatch_count=0,
+            removed_at=removed_at,
+        )
+    )
+    database.commit()
+
+
+def _library(database: Session, profile: Profile, audiences, **film_kwargs) -> None:
+    """Give a profile one rated film per audience size."""
+
+    for index, audience in enumerate(audiences):
+        movie = _film(
+            database,
+            f"{profile.username} film {index}",
+            rating_count=audience,
+            **film_kwargs,
+        )
+        _rate(database, profile, movie, 4.0)
+
+
+# --- the median is the headline ---------------------------------------------
+
+
+def test_one_blockbuster_cannot_drag_the_headline_off_an_obscure_taste(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    # Nine films nobody watched, and one everybody did.
+    _library(database, subject, [800] * 9 + [6_000_000])
+
+    payload = build_obscurity_index(database, subject)
+
+    # The median stays where this person actually lives.
+    assert payload["index"]["median_rating_count"] == 800
+    # The mean is reported beside it precisely so the skew is visible: it lands
+    # 750x above the typical film and describes a taste nobody here has.
+    assert payload["index"]["mean_rating_count"] == 600_720
+
+
+def test_an_even_library_takes_the_midpoint_of_the_two_middle_films(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [100, 200, 300, 500])
+
+    assert build_obscurity_index(database, subject)["index"][
+        "median_rating_count"
+    ] == 250
+
+
+def test_a_fractional_median_is_reported_as_a_whole_audience(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    # A midpoint of 150.5 people is not a thing; it rounds away from zero.
+    _library(database, subject, [100, 201])
+
+    assert build_obscurity_index(database, subject)["index"][
+        "median_rating_count"
+    ] == 151
+
+
+# --- unknown is null, never zero --------------------------------------------
+
+
+def test_films_the_backfill_has_not_reached_are_excluded_not_counted_as_zero(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [1_000, 1_000, 1_000])
+    for index in range(7):
+        movie = _film(database, f"unsynced {index}", rating_count=None)
+        _rate(database, subject, movie, 3.5)
+
+    payload = build_obscurity_index(database, subject)
+
+    # Seven zeros would have pulled the median to 0 and called this the most
+    # obscure taste on the site.
+    assert payload["index"]["median_rating_count"] == 1_000
+    assert payload["coverage"] == {"rated_films": 10, "films_with_rating_count": 3}
+    assert [entry["title"] for entry in payload["most_obscure"]] == [
+        "subject film 0",
+        "subject film 1",
+        "subject film 2",
+    ]
+
+
+def test_a_profile_with_no_synced_films_reports_nulls_and_empty_lists(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    for index in range(3):
+        movie = _film(database, f"unsynced {index}", rating_count=None)
+        _rate(database, subject, movie, 4.0)
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["index"] == {
+        "median_rating_count": None,
+        "mean_rating_count": None,
+        "percentile_vs_group": None,
+        "lean": None,
+    }
+    assert payload["coverage"] == {"rated_films": 3, "films_with_rating_count": 0}
+    assert payload["most_obscure"] == []
+    assert payload["most_mainstream"] == []
+    assert payload["crowd_position"] == []
+
+
+def test_a_zero_rating_count_is_treated_as_unsynced_not_as_an_empty_crowd(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [0, 5_000, 7_000])
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["coverage"]["films_with_rating_count"] == 2
+    assert payload["index"]["median_rating_count"] == 6_000
+    assert [entry["rating_count"] for entry in payload["most_obscure"]] == [5_000, 7_000]
+
+
+def test_unrated_and_removed_films_are_outside_the_measured_library(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [1_000, 1_000])
+    _rate(database, subject, _film(database, "Watched", rating_count=9), None)
+    _rate(
+        database,
+        subject,
+        _film(database, "Removed", rating_count=9),
+        5.0,
+        removed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["coverage"] == {"rated_films": 2, "films_with_rating_count": 2}
+    assert payload["index"]["median_rating_count"] == 1_000
+
+
+# --- placement against the group --------------------------------------------
+
+
+def test_the_percentile_measures_this_profile_against_every_other_profile(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [500, 500, 500])
+    for index, audience in enumerate((1_000, 2_000, 3_000)):
+        _library(database, _profile(database, f"other{index}"), [audience] * 3)
+
+    payload = build_obscurity_index(database, subject)
+
+    # Every one of the three others watches bigger films.
+    assert payload["index"]["percentile_vs_group"] == 100.0
+    assert payload["index"]["lean"] == "obscure"
+
+
+def test_the_most_mainstream_profile_sits_at_the_bottom_of_the_percentile(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [4_000_000] * 3)
+    for index, audience in enumerate((900, 1_000, 1_100)):
+        _library(database, _profile(database, f"other{index}"), [audience] * 3)
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["index"]["percentile_vs_group"] == 0.0
+    assert payload["index"]["lean"] == "mainstream"
+
+
+def test_a_profile_is_never_part_of_the_group_it_is_placed_against(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [500] * 3)
+    _library(database, _profile(database, "other"), [5_000] * 3)
+
+    payload = build_obscurity_index(database, subject)
+
+    # With one other profile, all of which is more mainstream, the subject is
+    # at 100. Folding the subject into its own comparison group would halve
+    # that to 50 and report a profile as average against itself.
+    assert payload["index"]["percentile_vs_group"] == 100.0
+
+
+def test_a_profile_level_with_its_whole_group_lands_in_the_middle(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [2_000] * 3)
+    for index in range(4):
+        _library(database, _profile(database, f"other{index}"), [2_000] * 3)
+
+    payload = build_obscurity_index(database, subject)
+
+    # Ties count at their midpoint: level with everybody is the middle of the
+    # pack, not the obscure end of it and not the mainstream end.
+    assert payload["index"]["percentile_vs_group"] == 50.0
+    assert payload["index"]["lean"] == "balanced"
+
+
+def test_a_profile_with_no_group_gets_a_median_but_no_lean(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [700] * 3)
+
+    payload = build_obscurity_index(database, subject)
+
+    # 700 is small, but "mainstream" only means anything relative to somebody.
+    assert payload["index"]["median_rating_count"] == 700
+    assert payload["index"]["percentile_vs_group"] is None
+    assert payload["index"]["lean"] is None
+
+
+def test_only_active_completed_profiles_form_the_comparison_group(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [500] * 3)
+    _library(
+        database,
+        _profile(database, "pending", scraping_status="pending"),
+        [5_000_000] * 3,
+    )
+    _library(
+        database,
+        _profile(database, "disabled", is_active=False),
+        [5_000_000] * 3,
+    )
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["index"]["percentile_vs_group"] is None
+    assert payload["index"]["lean"] is None
+
+
+def test_a_group_member_with_no_synced_films_contributes_no_median(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [500] * 3)
+    unsynced = _profile(database, "unsynced")
+    for index in range(3):
+        _rate(database, unsynced, _film(database, f"blank {index}"), 4.0)
+
+    assert (
+        build_obscurity_index(database, subject)["index"]["percentile_vs_group"] is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("subject_median", "others", "expected"),
+    [
+        (100.0, [], None),
+        (None, [1.0, 2.0], None),
+        (100.0, [200.0, 300.0], 100.0),
+        (100.0, [50.0, 60.0], 0.0),
+        (100.0, [50.0, 200.0], 50.0),
+        (100.0, [100.0, 100.0], 50.0),
+        (100.0, [100.0, 500.0], 75.0),
+    ],
+)
+def test_percentile_arithmetic(subject_median, others, expected) -> None:
+    assert _percentile_vs_group(subject_median, others) == expected
+
+
+# --- the two ends of the ordering -------------------------------------------
+
+
+def test_the_two_lists_are_the_two_ends_of_one_ordering(database: Session) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [10, 20, 30, 400_000, 500_000])
+
+    payload = build_obscurity_index(database, subject, limit=2)
+
+    assert [entry["rating_count"] for entry in payload["most_obscure"]] == [10, 20]
+    assert [entry["rating_count"] for entry in payload["most_mainstream"]] == [
+        500_000,
+        400_000,
+    ]
+
+
+def test_a_library_smaller_than_twice_the_limit_still_fills_both_lists(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [10, 20, 30])
+
+    payload = build_obscurity_index(database, subject, limit=10)
+
+    # Both ends describe the same three films; neither list is truncated by the
+    # other having consumed them.
+    assert len(payload["most_obscure"]) == 3
+    assert len(payload["most_mainstream"]) == 3
+
+
+def test_film_entries_carry_their_identity_and_the_profile_rating(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    movie = _film(database, "Rare One", rating_count=205, year=1974)
+    _rate(database, subject, movie, 4.5)
+
+    entry = build_obscurity_index(database, subject)["most_obscure"][0]
+
+    assert entry == {
+        "title": "Rare One",
+        "year": 1974,
+        "poster_url": None,
+        "letterboxd_url": f"https://letterboxd.com/film/{movie.id}/",
+        "rating_count": 205,
+        "profile_rating": 4.5,
+    }
+
+
+# --- crowd position ---------------------------------------------------------
+
+
+_CROWD = {
+    "0.5": 10,
+    "1.0": 10,
+    "1.5": 10,
+    "2.0": 10,
+    "2.5": 10,
+    "3.0": 10,
+    "3.5": 10,
+    "4.0": 10,
+    "4.5": 10,
+    "5.0": 10,
+}
+
+
+def test_crowd_position_is_empty_while_distributions_are_unpopulated(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [1_000, 2_000, 3_000])
+
+    payload = build_obscurity_index(database, subject)
+
+    # Empty list, not null: the endpoint is useful before the re-backfill.
+    assert payload["crowd_position"] == []
+    assert payload["index"]["median_rating_count"] == 2_000
+
+
+def test_the_share_is_the_fraction_of_the_crowd_at_or_below_this_rating(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    movie = _film(
+        database,
+        "Flat Crowd",
+        rating_count=100,
+        crowd_average=2.75,
+        distribution=_CROWD,
+    )
+    _rate(database, subject, movie, 3.0)
+
+    entry = build_obscurity_index(database, subject)["crowd_position"][0]
+
+    # Six of the ten equal buckets sit at or below three stars.
+    assert entry["share_at_or_below"] == 0.6
+    assert entry["profile_rating"] == 3.0
+    assert entry["crowd_average"] == 2.75
+
+
+def test_the_most_contrarian_film_comes_first(database: Session) -> None:
+    subject = _profile(database, "subject")
+    crowd_loved_it = {"0.5": 0, "5.0": 100}
+    crowd_hated_it = {"0.5": 100, "5.0": 0}
+    _rate(
+        database,
+        subject,
+        _film(database, "Agreed", rating_count=100, distribution=crowd_loved_it),
+        5.0,
+    )
+    _rate(
+        database,
+        subject,
+        _film(database, "Alone", rating_count=100, distribution=crowd_loved_it),
+        0.5,
+    )
+    _rate(
+        database,
+        subject,
+        _film(database, "Piled On", rating_count=100, distribution=crowd_hated_it),
+        0.5,
+    )
+
+    titles = [
+        entry["title"]
+        for entry in build_obscurity_index(database, subject)["crowd_position"]
+    ]
+
+    # "Alone" rated a beloved film half a star: almost none of the crowd is at
+    # or below it. "Agreed" and "Piled On" both sit at the top of their crowd.
+    assert titles[0] == "Alone"
+    assert set(titles[1:]) == {"Agreed", "Piled On"}
+
+
+def test_ties_on_share_break_towards_the_larger_crowd(database: Session) -> None:
+    subject = _profile(database, "subject")
+    for title, audience in (("Small", 500), ("Huge", 4_000_000), ("Middling", 9_000)):
+        _rate(
+            database,
+            subject,
+            _film(database, title, rating_count=audience, distribution=_CROWD),
+            3.0,
+        )
+
+    titles = [
+        entry["title"]
+        for entry in build_obscurity_index(database, subject)["crowd_position"]
+    ]
+
+    assert titles == ["Huge", "Middling", "Small"]
+
+
+def test_a_film_with_an_all_zero_distribution_has_no_position(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    _rate(
+        database,
+        subject,
+        _film(database, "Zeroed", rating_count=100, distribution={"0.5": 0, "5.0": 0}),
+        4.0,
+    )
+
+    # Dividing by an empty crowd would be a fabricated share, not a zero one.
+    assert build_obscurity_index(database, subject)["crowd_position"] == []
+
+
+def test_crowd_position_needs_no_rating_count(database: Session) -> None:
+    subject = _profile(database, "subject")
+    _rate(
+        database,
+        subject,
+        _film(database, "Shape Only", rating_count=None, distribution=_CROWD),
+        5.0,
+    )
+
+    payload = build_obscurity_index(database, subject)
+
+    assert payload["coverage"]["films_with_rating_count"] == 0
+    assert payload["index"]["median_rating_count"] is None
+    assert payload["crowd_position"][0]["share_at_or_below"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("distribution", "rating", "expected"),
+    [
+        ({"0.5": 1, "5.0": 3}, 0.5, 0.25),
+        ({"0.5": 1, "5.0": 3}, 5.0, 1.0),
+        ({"3.5": 4}, 3.5, 1.0),  # the rating's own bucket counts as "at or below"
+        ({"3.5": 4}, 3.0, 0.0),
+        (None, 4.0, None),
+        ({}, 4.0, None),
+        ("not a mapping", 4.0, None),
+        ({"junk": 5, "4.0": 5}, 4.0, 1.0),  # unplaceable keys are dropped
+    ],
+)
+def test_share_arithmetic(distribution, rating, expected) -> None:
+    assert _share_at_or_below(distribution, rating) == expected
+
+
+# --- limits -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, DEFAULT_LIMIT),
+        (0, 1),
+        (-5, 1),
+        (3, 3),
+        (MAX_LIMIT + 100, MAX_LIMIT),
+        ("nonsense", DEFAULT_LIMIT),
+    ],
+)
+def test_limit_is_clamped(value, expected) -> None:
+    assert _clamp_limit(value) == expected
+
+
+# --- route ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(database: Session):
+    """Mount the router standalone; registering it in main.py is not our file."""
+
+    app = FastAPI()
+    app.include_router(obscurity_router)
+    app.dependency_overrides[get_db] = lambda: database
+    yield app
+
+
+def _tracked_user(database: Session, profile: Optional[Profile]) -> ClerkUser:
+    app_user = AppUser(clerk_user_id="user_one", primary_profile_required=False)
+    database.add(app_user)
+    database.flush()
+    if profile is not None:
+        database.add(
+            UserTrackedProfile(
+                user_id=app_user.id,
+                profile_id=profile.id,
+                source="direct",
+            )
+        )
+    database.commit()
+    return ClerkUser(
+        user_id="user_one",
+        session_id="session",
+        is_admin=False,
+        letterboxd_username=None,
+    )
+
+
+def test_route_serves_the_frozen_contract(database: Session, client) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [500, 900], distribution=_CROWD)
+    _library(database, _profile(database, "other"), [90_000] * 3)
+    user = _tracked_user(database, subject)
+    client.dependency_overrides[get_current_user] = lambda: user
+
+    response = TestClient(client).get("/api/profiles/subject/obscurity?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {
+        "username",
+        "coverage",
+        "index",
+        "most_obscure",
+        "most_mainstream",
+        "crowd_position",
+    }
+    assert payload["username"] == "subject"
+    assert set(payload["coverage"]) == {"rated_films", "films_with_rating_count"}
+    assert set(payload["index"]) == {
+        "median_rating_count",
+        "mean_rating_count",
+        "percentile_vs_group",
+        "lean",
+    }
+    for key in ("most_obscure", "most_mainstream"):
+        assert set(payload[key][0]) == {
+            "title",
+            "year",
+            "poster_url",
+            "letterboxd_url",
+            "rating_count",
+            "profile_rating",
+        }
+    assert set(payload["crowd_position"][0]) == {
+        "title",
+        "year",
+        "poster_url",
+        "letterboxd_url",
+        "profile_rating",
+        "share_at_or_below",
+        "crowd_average",
+    }
+    assert payload["index"]["lean"] == "obscure"
+
+
+def test_route_honours_the_limit_query_parameter(database: Session, client) -> None:
+    subject = _profile(database, "subject")
+    _library(database, subject, [10, 20, 30, 40])
+    user = _tracked_user(database, subject)
+    client.dependency_overrides[get_current_user] = lambda: user
+    http = TestClient(client)
+
+    assert len(http.get("/api/profiles/subject/obscurity?limit=2").json()["most_obscure"]) == 2
+    assert http.get("/api/profiles/subject/obscurity?limit=0").status_code == 422
+    assert (
+        http.get(f"/api/profiles/subject/obscurity?limit={MAX_LIMIT + 1}").status_code
+        == 422
+    )
+
+
+def test_route_refuses_an_untracked_profile(database: Session, client) -> None:
+    _profile(database, "subject")
+    user = _tracked_user(database, None)
+    client.dependency_overrides[get_current_user] = lambda: user
+
+    response = TestClient(client).get("/api/profiles/subject/obscurity")
+
+    assert response.status_code == 403
+
+
+def test_route_is_404_for_a_profile_that_does_not_exist(
+    database: Session, client
+) -> None:
+    user = _tracked_user(database, None)
+    client.dependency_overrides[get_current_user] = lambda: user
+
+    response = TestClient(client).get("/api/profiles/nobody/obscurity")
+
+    assert response.status_code == 404
+
+
+def test_route_requires_an_authenticated_user() -> None:
+    route = next(
+        route
+        for route in obscurity_router.routes
+        if route.path == "/api/profiles/{username}/obscurity"
+    )
+    assert "get_current_user" in {
+        dependency.call.__name__ for dependency in route.dependant.dependencies
+    }

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1,7 +1,7 @@
 """Profile stats: honest arithmetic over whatever enrichment we actually hold."""
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, timezone
 from itertools import count
 from typing import Any, Optional
 
@@ -21,12 +21,14 @@ from database.models import (
     Profile,
     ProfileAccessRequest,
     ProfileFilm,
+    Review,
     UserTrackedProfile,
     WatchEvent,
 )
 from services.profile_stats import (
     build_profile_stats,
     longest_streak_weeks,
+    median_length_chars,
     multi_film_days,
 )
 
@@ -42,6 +44,7 @@ TABLES = (
     ProfileFilm.__table__,
     WatchEvent.__table__,
     MovieEnrichment.__table__,
+    Review.__table__,
     AppUser.__table__,
     UserTrackedProfile.__table__,
     ProfileAccessRequest.__table__,
@@ -95,6 +98,9 @@ def _film(
     year: Optional[int] = 2000,
     rating: Optional[float] = None,
     rewatch_count: int = 0,
+    watch_count: Optional[int] = None,
+    poster_url: Optional[str] = None,
+    letterboxd_url: Optional[str] = None,
     enrich: bool = True,
     runtime: Optional[int] = 100,
     genres: Optional[list[str]] = None,
@@ -112,6 +118,8 @@ def _film(
         title=title,
         normalized_title=title.casefold(),
         release_year=year,
+        poster_url=poster_url,
+        letterboxd_url=letterboxd_url,
     )
     database.add(movie)
     database.add(
@@ -120,7 +128,9 @@ def _film(
             movie_id=movie_id,
             rating=rating,
             tags=[],
-            watch_count=max(1, rewatch_count + 1),
+            watch_count=(
+                watch_count if watch_count is not None else max(1, rewatch_count + 1)
+            ),
             rewatch_count=rewatch_count,
         )
     )
@@ -160,6 +170,37 @@ def _watch(database: Session, profile: Profile, movie: Movie, watched: date) -> 
         )
     )
     database.commit()
+
+
+def _review(
+    database: Session,
+    profile: Profile,
+    *,
+    movie: Optional[Movie] = None,
+    title: str = "Unmatched Film",
+    year: Optional[int] = None,
+    text: Optional[str] = "A fine watch.",
+    spoilers: bool = False,
+    likes: int = 0,
+    published: Optional[date] = None,
+    removed: bool = False,
+) -> Review:
+    review = Review(
+        profile_id=profile.id,
+        movie_id=movie.id if movie is not None else None,
+        movie_title=movie.title if movie is not None else title,
+        movie_year=movie.release_year if movie is not None else year,
+        review_text=text,
+        contains_spoilers=spoilers,
+        likes_count=likes,
+        comments_count=0,
+        published_date=published,
+        tags=[],
+        removed_at=datetime(2026, 6, 1, tzinfo=timezone.utc) if removed else None,
+    )
+    database.add(review)
+    database.commit()
+    return review
 
 
 # --- streak and multi-film-day arithmetic -----------------------------------
@@ -418,6 +459,8 @@ def test_a_profile_with_no_enrichment_returns_nulls_not_zeros(database: Session)
         "enrichment_ratio": 0.0,
         "dated_events": 1,
         "rated_films": 1,
+        "reviews_total": 0,
+        "reviews_matched_to_films": 0,
     }
     totals = stats["totals"]
     assert totals["films"] == 1
@@ -572,6 +615,400 @@ def test_letterboxd_reported_snapshot_is_returned_verbatim(database: Session) ->
     }
 
 
+# --- rewatches --------------------------------------------------------------
+
+
+def test_the_rewatch_block_counts_returns_and_averages_both_sides(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Returned To", rating=5.0, rewatch_count=2)
+    _film(database, profile, title="Revisited", rating=4.5, rewatch_count=1)
+    _film(database, profile, title="Seen Once", rating=3.0)
+    _film(database, profile, title="Also Once", rating=4.0)
+    _film(database, profile, title="Once, Unrated")
+
+    rewatches = build_profile_stats(database, profile)["rewatches"]
+
+    assert rewatches["total_rewatches"] == 3
+    assert rewatches["films_rewatched"] == 2
+    # Two of five films, never rounded up to "most of the library".
+    assert rewatches["rewatch_rate"] == 0.4
+    assert rewatches["average_rating_rewatched"] == 4.75
+    # The unrated film sits in neither average; 3.0 and 4.0 make 3.5.
+    assert rewatches["average_rating_once"] == 3.5
+
+
+def test_most_rewatched_ranks_by_watch_count_and_omits_films_seen_once(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(
+        database,
+        profile,
+        title="Comfort Film",
+        year=1994,
+        rating=4.5,
+        rewatch_count=1,
+        watch_count=5,
+        poster_url="https://image.example/comfort.jpg",
+        letterboxd_url="https://letterboxd.com/film/comfort/",
+    )
+    _film(database, profile, title="Second Favourite", rewatch_count=3, watch_count=4)
+    _film(database, profile, title="Seen Once", watch_count=1)
+
+    most_rewatched = build_profile_stats(database, profile)["rewatches"]["most_rewatched"]
+
+    assert [entry["title"] for entry in most_rewatched] == [
+        "Comfort Film",
+        "Second Favourite",
+    ]
+    assert most_rewatched[0] == {
+        "title": "Comfort Film",
+        "year": 1994,
+        "poster_url": "https://image.example/comfort.jpg",
+        "letterboxd_url": "https://letterboxd.com/film/comfort/",
+        "watch_count": 5,
+        "rating": 4.5,
+    }
+
+
+def test_equal_watch_counts_fall_back_to_the_deeper_rewatch(database: Session) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Shallow", rewatch_count=1, watch_count=4)
+    _film(database, profile, title="Deep", rewatch_count=3, watch_count=4)
+
+    most_rewatched = build_profile_stats(database, profile)["rewatches"]["most_rewatched"]
+
+    assert [entry["title"] for entry in most_rewatched] == ["Deep", "Shallow"]
+
+
+def test_a_rewatch_whose_first_viewing_was_never_logged_still_counts(
+    database: Session,
+) -> None:
+    # Letterboxd lets a diary entry be marked "rewatch" without the original
+    # watch ever being logged, so watch_count can be 1 alongside a rewatch.
+    # The count is reported as held, not nudged up to the viewing nobody logged.
+    profile = _profile(database)
+    _film(database, profile, title="Rewatch Only", rating=4.0, rewatch_count=1, watch_count=1)
+    _film(database, profile, title="Seen Once", rating=2.0, watch_count=1)
+
+    rewatches = build_profile_stats(database, profile)["rewatches"]
+
+    assert rewatches["films_rewatched"] == 1
+    assert rewatches["most_rewatched"] == [
+        {
+            "title": "Rewatch Only",
+            "year": 2000,
+            "poster_url": None,
+            "letterboxd_url": None,
+            "watch_count": 1,
+            "rating": 4.0,
+        }
+    ]
+    assert rewatches["average_rating_rewatched"] == 4.0
+    assert rewatches["average_rating_once"] == 2.0
+
+
+def test_most_rewatched_is_capped_at_ten_films(database: Session) -> None:
+    profile = _profile(database)
+    for index in range(14):
+        _film(
+            database,
+            profile,
+            title=f"Rewatch {index:02d}",
+            rewatch_count=1,
+            watch_count=index + 2,
+        )
+
+    most_rewatched = build_profile_stats(database, profile)["rewatches"]["most_rewatched"]
+
+    assert len(most_rewatched) == 10
+    assert most_rewatched[0]["title"] == "Rewatch 13"
+    assert most_rewatched[-1]["title"] == "Rewatch 04"
+
+
+def test_a_profile_that_never_rewatches_reports_zero_and_nulls_not_absence(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Only Watch", rating=4.0)
+
+    rewatches = build_profile_stats(database, profile)["rewatches"]
+
+    assert rewatches["total_rewatches"] == 0
+    assert rewatches["films_rewatched"] == 0
+    assert rewatches["rewatch_rate"] == 0.0
+    assert rewatches["most_rewatched"] == []
+    # Nothing was rewatched, so there is no rewatched average to report -- but
+    # the one-time average is perfectly knowable.
+    assert rewatches["average_rating_rewatched"] is None
+    assert rewatches["average_rating_once"] == 4.0
+
+
+def test_an_empty_library_has_no_rewatch_rate_rather_than_a_rate_of_zero(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+
+    rewatches = build_profile_stats(database, profile)["rewatches"]
+
+    assert rewatches["total_rewatches"] == 0
+    assert rewatches["films_rewatched"] == 0
+    assert rewatches["rewatch_rate"] is None
+    assert rewatches["most_rewatched"] == []
+    assert rewatches["average_rating_rewatched"] is None
+    assert rewatches["average_rating_once"] is None
+
+
+def test_the_rewatch_totals_agree_with_the_existing_totals_block(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Twice", rewatch_count=1)
+    _film(database, profile, title="Thrice", rewatch_count=2)
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["rewatches"]["total_rewatches"] == stats["totals"]["rewatches"] == 3
+
+
+# --- reviews ----------------------------------------------------------------
+
+
+def test_median_length_is_the_middle_review_and_unknown_without_reviews() -> None:
+    assert median_length_chars([]) is None
+    assert median_length_chars([42]) == 42
+    assert median_length_chars([30, 10, 20]) == 20
+    # No single middle review: the two middle lengths average out, floored,
+    # because a review is never half a character long.
+    assert median_length_chars([10, 20, 30, 41]) == 25
+
+
+def test_the_review_block_counts_text_spoilers_and_median_length(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Reviewed", rating=4.0)
+    _review(database, profile, movie=movie, text="x" * 100)
+    _review(database, profile, movie=movie, text="y" * 300, spoilers=True)
+    _review(database, profile, movie=movie, text="z" * 500)
+    # A rating logged with no prose is still a review row, but not writing.
+    _review(database, profile, movie=movie, text="   ")
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["total_reviews"] == 4
+    assert reviews["with_text"] == 3
+    assert reviews["spoiler_reviews"] == 1
+    assert reviews["median_length_chars"] == 300
+
+
+def test_the_longest_review_names_its_film(database: Session) -> None:
+    profile = _profile(database)
+    short = _film(database, profile, title="Short Take", year=2011)
+    essay = _film(database, profile, title="The Essay", year=1999)
+    _review(database, profile, movie=short, text="Fun.")
+    _review(database, profile, movie=essay, text="w" * 4000)
+
+    longest = build_profile_stats(database, profile)["reviews"]["longest"]
+
+    assert longest == {"title": "The Essay", "year": 1999, "length_chars": 4000}
+
+
+def test_review_length_ignores_surrounding_whitespace(database: Session) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Padded")
+    _review(database, profile, movie=movie, text="\n\n  four  \n\n")
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["longest"]["length_chars"] == 4
+    assert reviews["median_length_chars"] == 4
+
+
+def test_most_liked_is_capped_at_five_and_skips_reviews_nobody_liked(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Popular", year=2004)
+    for likes in range(8):
+        _review(
+            database,
+            profile,
+            movie=movie,
+            likes=likes,
+            published=date(2026, 1, 1 + likes),
+        )
+
+    most_liked = build_profile_stats(database, profile)["reviews"]["most_liked"]
+
+    assert [entry["likes_count"] for entry in most_liked] == [7, 6, 5, 4, 3]
+    assert most_liked[0] == {
+        "title": "Popular",
+        "year": 2004,
+        "likes_count": 7,
+        "published_date": "2026-01-08",
+    }
+
+
+def test_a_profile_whose_reviews_were_never_liked_gets_an_empty_shortlist(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Quiet")
+    _review(database, profile, movie=movie, likes=0)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["total_reviews"] == 1
+    assert reviews["most_liked"] == []
+
+
+def test_reviews_by_year_is_ascending_and_leaves_out_undated_reviews(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Dated")
+    for published in (
+        date(2024, 5, 1),
+        date(2022, 2, 2),
+        date(2024, 8, 9),
+        date(2023, 1, 1),
+        date(2024, 12, 25),
+    ):
+        _review(database, profile, movie=movie, published=published)
+    # No publication date: this review belongs to no year and is not guessed
+    # into one, though it still counts in the total.
+    _review(database, profile, movie=movie, published=None)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["reviews_by_year"] == [
+        {"year": 2022, "count": 1},
+        {"year": 2023, "count": 1},
+        {"year": 2024, "count": 3},
+    ]
+    assert reviews["total_reviews"] == 6
+
+
+def test_reviewed_and_unreviewed_averages_split_the_same_library(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    moved = _film(database, profile, title="Moved Me", rating=5.0)
+    also_moved = _film(database, profile, title="Also Moved Me", rating=4.5)
+    _film(database, profile, title="Just Watched", rating=3.0)
+    _film(database, profile, title="Also Just Watched", rating=2.0)
+    _film(database, profile, title="Unrated")
+    _review(database, profile, movie=moved)
+    _review(database, profile, movie=also_moved)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["average_rating_reviewed"] == 4.75
+    assert reviews["average_rating_unreviewed"] == 2.5
+
+
+def test_two_reviews_of_one_film_move_that_film_across_the_split_once(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    twice_reviewed = _film(database, profile, title="Written Up Twice", rating=5.0)
+    _film(database, profile, title="Never Written Up", rating=3.0)
+    _review(database, profile, movie=twice_reviewed, text="First pass.")
+    _review(database, profile, movie=twice_reviewed, text="Second pass.")
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["total_reviews"] == 2
+    # One film either side, however many times it was written about.
+    assert reviews["average_rating_reviewed"] == 5.0
+    assert reviews["average_rating_unreviewed"] == 3.0
+
+
+def test_a_review_that_matched_no_film_counts_but_moves_no_rating(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="In The Library", rating=4.0)
+    _review(database, profile, movie=None, title="Never Matched", year=1975)
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["reviews"]["total_reviews"] == 1
+    assert stats["reviews"]["longest"]["title"] == "Never Matched"
+    # It resolved to no film, so it cannot place one on the reviewed side.
+    assert stats["reviews"]["average_rating_reviewed"] is None
+    assert stats["reviews"]["average_rating_unreviewed"] == 4.0
+    # ...and the coverage block says so rather than leaving the gap silent.
+    assert stats["coverage"]["reviews_total"] == 1
+    assert stats["coverage"]["reviews_matched_to_films"] == 0
+
+
+def test_a_review_prefers_the_canonical_film_title_over_its_own_copy(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Renamed Since", year=2018)
+    review = _review(database, profile, movie=movie)
+    review.movie_title = "Stale Scraped Title"
+    review.movie_year = 1900
+    database.commit()
+
+    longest = build_profile_stats(database, profile)["reviews"]["longest"]
+
+    assert longest["title"] == "Renamed Since"
+    assert longest["year"] == 2018
+
+
+def test_removed_reviews_are_not_counted(database: Session) -> None:
+    profile = _profile(database)
+    movie = _film(database, profile, title="Deleted Take", rating=4.0)
+    _review(database, profile, movie=movie, text="Kept.", likes=3)
+    _review(database, profile, movie=movie, text="Deleted." * 50, likes=99, removed=True)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["total_reviews"] == 1
+    assert reviews["longest"]["length_chars"] == len("Kept.")
+    assert [entry["likes_count"] for entry in reviews["most_liked"]] == [3]
+
+
+def test_another_profiles_reviews_never_leak_in(database: Session) -> None:
+    profile = _profile(database)
+    other = _profile(database, username="stranger")
+    movie = _film(database, profile, title="Shared Film", rating=4.0)
+    _review(database, other, movie=movie, text="Not theirs.", likes=50)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews["total_reviews"] == 0
+    assert reviews["most_liked"] == []
+    assert reviews["average_rating_reviewed"] is None
+    assert reviews["average_rating_unreviewed"] == 4.0
+
+
+def test_a_profile_with_no_reviews_returns_the_block_with_nulls_not_absence(
+    database: Session,
+) -> None:
+    profile = _profile(database)
+
+    reviews = build_profile_stats(database, profile)["reviews"]
+
+    assert reviews == {
+        "total_reviews": 0,
+        "with_text": 0,
+        "spoiler_reviews": 0,
+        "median_length_chars": None,
+        "longest": None,
+        "most_liked": [],
+        "reviews_by_year": [],
+        "average_rating_reviewed": None,
+        "average_rating_unreviewed": None,
+    }
+
+
 # --- route ------------------------------------------------------------------
 
 
@@ -607,7 +1044,15 @@ def _tracked_user(database: Session, profile: Optional[Profile]) -> ClerkUser:
 
 def test_route_serves_the_payload_for_a_tracked_profile(database: Session, client) -> None:
     profile = _profile(database)
-    _film(database, profile, title="Tracked Film", rating=4.0, runtime=120)
+    movie = _film(
+        database,
+        profile,
+        title="Tracked Film",
+        rating=4.0,
+        runtime=120,
+        rewatch_count=1,
+    )
+    _review(database, profile, movie=movie, text="Worth returning to.", likes=2)
     user = _tracked_user(database, profile)
     backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
 
@@ -629,8 +1074,50 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "languages",
         "decades",
         "highest_rated",
+        "rewatches",
+        "reviews",
         "letterboxd_reported",
     }
+    assert set(payload["rewatches"]) == {
+        "total_rewatches",
+        "films_rewatched",
+        "rewatch_rate",
+        "most_rewatched",
+        "average_rating_rewatched",
+        "average_rating_once",
+    }
+    assert set(payload["reviews"]) == {
+        "total_reviews",
+        "with_text",
+        "spoiler_reviews",
+        "median_length_chars",
+        "longest",
+        "most_liked",
+        "reviews_by_year",
+        "average_rating_reviewed",
+        "average_rating_unreviewed",
+    }
+    assert payload["rewatches"]["most_rewatched"][0]["title"] == "Tracked Film"
+    assert payload["reviews"]["total_reviews"] == 1
+
+
+def test_the_route_serves_both_blocks_for_a_profile_with_neither(
+    database: Session, client
+) -> None:
+    profile = _profile(database)
+    _film(database, profile, title="Watched Once, Never Written Up", rating=3.5)
+    user = _tracked_user(database, profile)
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+
+    response = client(user).get(f"/api/profiles/{profile.username}/stats")
+
+    payload = response.json()
+    # Present and empty, so a client can render "none yet" rather than having
+    # to tell a missing block from a failed one.
+    assert payload["rewatches"]["most_rewatched"] == []
+    assert payload["rewatches"]["average_rating_rewatched"] is None
+    assert payload["reviews"]["total_reviews"] == 0
+    assert payload["reviews"]["longest"] is None
 
 
 def test_route_refuses_an_untracked_profile(database: Session, client) -> None:

--- a/backend/tests/test_route_access_matrix.py
+++ b/backend/tests/test_route_access_matrix.py
@@ -53,6 +53,8 @@ def test_data_bearing_reads_require_a_clerk_user():
         "/api/follow-graph/mutuals",
         "/api/follow-graph/suggestions",
         "/api/profiles/{username}/archive",
+        "/api/profiles/{username}/watchlist-insights",
+        "/api/profiles/{username}/obscurity",
     }
     for path in protected_reads:
         assert "get_current_user" in _dependency_names(_route("GET", path)), path

--- a/backend/tests/test_watchlist_insights.py
+++ b/backend/tests/test_watchlist_insights.py
@@ -1,0 +1,833 @@
+"""Watchlist insights: a dead list ranked by the circle that already watched."""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from itertools import count
+from typing import Any, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import BigInteger, Integer, create_engine, event
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from api.routes.watchlist_insights import router as watchlist_insights_router
+from auth import ClerkUser, get_current_user
+from database.connection import get_db
+from database.models import (
+    AppUser,
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileAccessRequest,
+    ProfileFilm,
+    UserTrackedProfile,
+    WatchlistItem,
+)
+from services.watchlist_insights import (
+    MAX_LIMIT,
+    MAX_RATERS_LISTED,
+    MAX_SECONDARY_ENTRIES,
+    _clamp_limit,
+    build_watchlist_insights,
+    median_days_waiting,
+)
+
+
+@compiles(BigInteger, "sqlite")
+def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
+    return Integer().compile(dialect=_compiler.dialect)
+
+
+TABLES = (
+    Profile.__table__,
+    Movie.__table__,
+    ProfileFilm.__table__,
+    MovieEnrichment.__table__,
+    WatchlistItem.__table__,
+    AppUser.__table__,
+    UserTrackedProfile.__table__,
+    ProfileAccessRequest.__table__,
+)
+
+TODAY = date(2026, 8, 1)
+
+
+@pytest.fixture()
+def database() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    for table in TABLES:
+        table.create(engine, checkfirst=True)
+    db = sessionmaker(bind=engine, expire_on_commit=False)()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+_MOVIE_IDS = count(1)
+
+
+def _profile(
+    database: Session,
+    username: str,
+    *,
+    is_active: bool = True,
+    scraping_status: str = "completed",
+) -> Profile:
+    profile = Profile(
+        username=username,
+        scraping_status=scraping_status,
+        is_active=is_active,
+    )
+    database.add(profile)
+    database.commit()
+    return profile
+
+
+def _film(
+    database: Session,
+    title: str,
+    *,
+    year: Optional[int] = 2000,
+    letterboxd_average: Optional[float] = None,
+    genres: Optional[list[str]] = None,
+) -> Movie:
+    movie_id = next(_MOVIE_IDS)
+    movie = Movie(
+        id=movie_id,
+        canonical_key=f"letterboxd:{title}-{movie_id}",
+        title=title,
+        normalized_title=title.casefold(),
+        release_year=year,
+        letterboxd_url=f"https://letterboxd.com/film/{movie_id}/",
+        letterboxd_average_rating=letterboxd_average,
+    )
+    database.add(movie)
+    if genres is not None:
+        database.add(
+            MovieEnrichment(
+                movie_id=movie_id,
+                genres=[{"name": name} for name in genres],
+                keywords=[],
+                credits={},
+                production_countries=[],
+                raw_payload={},
+            )
+        )
+    database.commit()
+    return movie
+
+
+def _watchlist(
+    database: Session,
+    profile: Profile,
+    movie: Movie,
+    *,
+    added: Optional[date] = date(2026, 7, 2),
+    removed: bool = False,
+) -> WatchlistItem:
+    item = WatchlistItem(
+        profile_id=profile.id,
+        movie_id=movie.id,
+        added_date=added,
+        removed_at=datetime(2026, 7, 20, tzinfo=timezone.utc) if removed else None,
+    )
+    database.add(item)
+    database.commit()
+    return item
+
+
+def _watched(
+    database: Session,
+    profile: Profile,
+    movie: Movie,
+    *,
+    rating: Optional[float] = None,
+    liked: bool = False,
+    removed: bool = False,
+) -> None:
+    database.add(
+        ProfileFilm(
+            profile_id=profile.id,
+            movie_id=movie.id,
+            rating=rating,
+            is_liked=liked,
+            tags=[],
+            watch_count=1,
+            rewatch_count=0,
+            removed_at=datetime(2026, 7, 20, tzinfo=timezone.utc) if removed else None,
+        )
+    )
+    database.commit()
+
+
+def _circle(database: Session, size: int = 3) -> list[Profile]:
+    return [_profile(database, f"other{index}") for index in range(size)]
+
+
+def _queued(
+    database: Session,
+    subject: Profile,
+    circle: list[Profile],
+    title: str,
+    *,
+    other_ratings: list[Optional[float]],
+    likes: Optional[list[bool]] = None,
+    added: Optional[date] = date(2026, 7, 2),
+    **film_kwargs: Any,
+) -> Movie:
+    """One film on the subject's watchlist that ``circle`` has already seen."""
+
+    movie = _film(database, title, **film_kwargs)
+    _watchlist(database, subject, movie, added=added)
+    flags = likes or [False] * len(other_ratings)
+    for profile, rating, liked in zip(circle, other_ratings, flags):
+        _watched(database, profile, movie, rating=rating, liked=liked)
+    return movie
+
+
+def _insights(database: Session, profile: Profile, **kwargs: Any) -> dict:
+    return build_watchlist_insights(database, profile, today=TODAY, **kwargs)
+
+
+# --- only unwatched films are recommended -----------------------------------
+
+
+def test_a_watchlist_film_the_profile_already_watched_is_not_a_candidate(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    stale = _queued(database, subject, circle, "Already Seen", other_ratings=[4.5, 4.5])
+    _queued(database, subject, circle, "Still Waiting", other_ratings=[4.0, 4.0])
+    # The member watched it after adding it; the watchlist row was never cleaned up.
+    _watched(database, subject, stale, rating=5.0)
+
+    payload = _insights(database, subject)
+
+    assert [entry["title"] for entry in payload["recommendations"]] == ["Still Waiting"]
+    assert [entry["title"] for entry in payload["longest_waiting"]] == ["Still Waiting"]
+    # The stale row is out of the denominator too, not merely out of the list.
+    assert payload["coverage"]["watchlist_films"] == 1
+
+
+def test_a_library_row_that_was_later_removed_still_means_watched(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    dropped = _queued(database, subject, circle, "Dropped Later", other_ratings=[4.5])
+    _watched(database, subject, dropped, rating=4.0, removed=True)
+
+    payload = _insights(database, subject)
+
+    assert payload["coverage"]["watchlist_films"] == 0
+    assert payload["recommendations"] == []
+
+
+def test_a_removed_watchlist_row_is_not_a_candidate(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    taken_off = _film(database, "Taken Off")
+    _watchlist(database, subject, taken_off, removed=True)
+    _watched(database, circle[0], taken_off, rating=5.0)
+    _queued(database, subject, circle, "Kept", other_ratings=[3.0])
+
+    payload = _insights(database, subject)
+
+    assert payload["coverage"]["watchlist_films"] == 1
+    assert [entry["title"] for entry in payload["recommendations"]] == ["Kept"]
+
+
+# --- the group is other people ----------------------------------------------
+
+
+def test_the_group_average_is_taken_over_other_members_only(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Group Verdict", other_ratings=[5.0, 4.0, 3.0])
+
+    payload = _insights(database, subject)
+    recommendation = payload["recommendations"][0]
+
+    assert recommendation["group_average"] == 4.0
+    assert recommendation["group_raters"] == 3
+    assert [rater["username"] for rater in recommendation["raters"]] == [
+        "other0",
+        "other1",
+        "other2",
+    ]
+
+
+def test_inactive_and_unfinished_profiles_are_not_part_of_the_group(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    trusted = _profile(database, "trusted")
+    inactive = _profile(database, "inactive", is_active=False)
+    pending = _profile(database, "pending", scraping_status="in_progress")
+    movie = _film(database, "Mixed Sources")
+    _watchlist(database, subject, movie)
+    _watched(database, trusted, movie, rating=3.0)
+    _watched(database, inactive, movie, rating=5.0, liked=True)
+    _watched(database, pending, movie, rating=5.0, liked=True)
+
+    payload = _insights(database, subject)
+    recommendation = payload["recommendations"][0]
+
+    assert recommendation["group_average"] == 3.0
+    assert recommendation["group_raters"] == 1
+    assert recommendation["liked_by"] == 0
+
+
+def test_a_film_no_other_member_rated_is_never_recommended(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    # Seen by somebody, but nobody put a number on it.
+    _queued(database, subject, circle, "Unrated By All", other_ratings=[None])
+    _queued(database, subject, circle, "Rated Once", other_ratings=[2.5])
+
+    payload = _insights(database, subject)
+
+    assert [entry["title"] for entry in payload["recommendations"]] == ["Rated Once"]
+    # It is still a real watchlist film: counted, and still shown as waiting.
+    assert payload["coverage"]["watchlist_films"] == 2
+    assert payload["coverage"]["rated_by_group"] == 1
+    assert {entry["title"] for entry in payload["longest_waiting"]} == {
+        "Unrated By All",
+        "Rated Once",
+    }
+
+
+def test_one_other_rater_is_enough_to_rank_on(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Lone Verdict", other_ratings=[4.5])
+
+    payload = _insights(database, subject)
+
+    assert payload["recommendations"][0]["group_raters"] == 1
+    assert payload["recommendations"][0]["group_average"] == 4.5
+
+
+# --- ranking -----------------------------------------------------------------
+
+
+def test_recommendations_rank_by_group_average_then_by_how_many_are_behind_it(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Thin Four Five", other_ratings=[4.5])
+    _queued(database, subject, circle, "Backed Four Five", other_ratings=[4.5, 4.5, 4.5])
+    _queued(database, subject, circle, "Merely Good", other_ratings=[3.5, 3.5])
+
+    payload = _insights(database, subject)
+
+    assert [entry["title"] for entry in payload["recommendations"]] == [
+        "Backed Four Five",
+        "Thin Four Five",
+        "Merely Good",
+    ]
+
+
+def test_the_limit_trims_the_queue_without_reshuffling_it(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for index, rating in enumerate([5.0, 4.5, 4.0, 3.5, 3.0]):
+        _queued(database, subject, circle, f"Film {index}", other_ratings=[rating])
+
+    payload = _insights(database, subject, limit=2)
+
+    assert [entry["title"] for entry in payload["recommendations"]] == ["Film 0", "Film 1"]
+    # Trimming the queue never trims the honesty about how big it was.
+    assert payload["coverage"]["rated_by_group"] == 5
+
+
+def test_limits_are_clamped_into_range() -> None:
+    assert _clamp_limit(0) == 1
+    assert _clamp_limit(MAX_LIMIT + 40) == MAX_LIMIT
+    assert _clamp_limit("nonsense") == 20
+    assert _clamp_limit(None) == 20
+
+
+# --- raters and likes --------------------------------------------------------
+
+
+def test_raters_are_capped_and_ordered_by_rating(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=8)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Crowded",
+        other_ratings=[1.0, 5.0, 2.0, 4.5, 3.0, 4.0, 2.5, 3.5],
+    )
+
+    recommendation = _insights(database, subject)["recommendations"][0]
+
+    assert recommendation["group_raters"] == 8
+    assert len(recommendation["raters"]) == MAX_RATERS_LISTED
+    ratings = [rater["rating"] for rater in recommendation["raters"]]
+    assert ratings == sorted(ratings, reverse=True)
+    assert ratings == [5.0, 4.5, 4.0, 3.5, 3.0, 2.5]
+
+
+def test_a_like_without_a_rating_counts_as_a_like_and_not_as_a_rater(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Liked Quietly",
+        other_ratings=[4.0, None, 4.0],
+        likes=[True, True, False],
+    )
+
+    recommendation = _insights(database, subject)["recommendations"][0]
+
+    assert recommendation["group_raters"] == 2
+    assert recommendation["liked_by"] == 2
+
+
+# --- the Letterboxd crowd average is optional -------------------------------
+
+
+def test_the_letterboxd_average_is_null_until_the_backfill_reaches_the_film(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Backfilled",
+        other_ratings=[4.0],
+        letterboxd_average=3.87,
+    )
+    _queued(database, subject, circle, "Pending", other_ratings=[4.0])
+    # A stored zero is the absence of a crowd rating, not a crowd score of zero.
+    _queued(database, subject, circle, "Zeroed", other_ratings=[4.0], letterboxd_average=0.0)
+
+    payload = _insights(database, subject)
+    averages = {
+        entry["title"]: entry["letterboxd_average"] for entry in payload["recommendations"]
+    }
+
+    assert averages == {"Backfilled": 3.87, "Pending": None, "Zeroed": None}
+    assert payload["coverage"]["with_letterboxd_average"] == 1
+
+
+# --- waiting time ------------------------------------------------------------
+
+
+def test_days_waiting_counts_from_the_added_date(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Old Queue Entry",
+        other_ratings=[4.0],
+        added=date(2024, 8, 1),
+    )
+
+    recommendation = _insights(database, subject)["recommendations"][0]
+
+    assert recommendation["added_date"] == "2024-08-01"
+    assert recommendation["days_waiting"] == 730
+
+
+def test_an_undated_row_has_an_unknown_wait_and_stays_out_of_the_totals(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Undated", other_ratings=[4.5], added=None)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Dated",
+        other_ratings=[4.0],
+        added=date(2026, 7, 22),
+    )
+
+    payload = _insights(database, subject)
+    recommendation = next(
+        entry for entry in payload["recommendations"] if entry["title"] == "Undated"
+    )
+
+    assert recommendation["added_date"] is None
+    assert recommendation["days_waiting"] is None
+    # Undated rows are absent from the wait statistics, never folded in as zero.
+    assert [entry["title"] for entry in payload["longest_waiting"]] == ["Dated"]
+    assert payload["totals"] == {"median_days_waiting": 10, "oldest_days_waiting": 10}
+
+
+def test_wait_totals_are_unknown_when_nothing_carries_a_date(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Undated", other_ratings=[4.5], added=None)
+
+    payload = _insights(database, subject)
+
+    assert payload["longest_waiting"] == []
+    assert payload["totals"] == {
+        "median_days_waiting": None,
+        "oldest_days_waiting": None,
+    }
+
+
+def test_longest_waiting_is_ordered_by_wait_and_capped(database: Session) -> None:
+    subject = _profile(database, "subject")
+    for index in range(MAX_SECONDARY_ENTRIES + 4):
+        movie = _film(database, f"Queued {index:02d}")
+        _watchlist(database, subject, movie, added=date(2026, 1, 1 + index))
+
+    payload = _insights(database, subject)
+
+    assert len(payload["longest_waiting"]) == MAX_SECONDARY_ENTRIES
+    assert payload["longest_waiting"][0]["title"] == "Queued 00"
+    waits = [entry["days_waiting"] for entry in payload["longest_waiting"]]
+    assert waits == sorted(waits, reverse=True)
+
+
+def test_a_future_added_date_is_zero_days_waiting_not_a_negative_one(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Clock Skew",
+        other_ratings=[4.0],
+        added=date(2026, 9, 1),
+    )
+
+    assert _insights(database, subject)["recommendations"][0]["days_waiting"] == 0
+
+
+def test_the_median_wait_is_the_middle_of_the_dated_rows() -> None:
+    assert median_days_waiting([]) is None
+    assert median_days_waiting([5]) == 5
+    assert median_days_waiting([1, 10, 100]) == 10
+    # Half-day medians round up rather than to the nearest even day.
+    assert median_days_waiting([10, 11]) == 11
+    assert median_days_waiting([2, 3]) == 3
+
+
+# --- genre skew --------------------------------------------------------------
+
+
+def test_genre_skew_counts_the_unwatched_pile_not_the_recommended_slice(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for index in range(3):
+        _queued(
+            database,
+            subject,
+            circle,
+            f"Horror {index}",
+            other_ratings=[None],
+            genres=["Horror"],
+        )
+    _queued(database, subject, circle, "Rated Drama", other_ratings=[4.0], genres=["Drama"])
+    _queued(database, subject, circle, "Unenriched", other_ratings=[4.0])
+
+    payload = _insights(database, subject)
+
+    assert payload["genre_skew"] == [
+        {"label": "Horror", "count": 3},
+        {"label": "Drama", "count": 1},
+    ]
+    # Films enrichment never reached simply contribute no genre.
+    assert payload["coverage"]["watchlist_films"] == 5
+
+
+def test_a_watched_film_does_not_skew_the_genres(database: Session) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    seen = _queued(database, subject, circle, "Seen Horror", other_ratings=[4.0], genres=["Horror"])
+    _watched(database, subject, seen)
+    _queued(database, subject, circle, "Queued Drama", other_ratings=[4.0], genres=["Drama"])
+
+    payload = _insights(database, subject)
+
+    assert payload["genre_skew"] == [{"label": "Drama", "count": 1}]
+
+
+# --- empty and degenerate profiles ------------------------------------------
+
+
+def test_an_empty_watchlist_returns_a_complete_payload(database: Session) -> None:
+    subject = _profile(database, "subject")
+
+    payload = _insights(database, subject)
+
+    assert payload == {
+        "username": "subject",
+        "coverage": {
+            "watchlist_films": 0,
+            "rated_by_group": 0,
+            "with_letterboxd_average": 0,
+        },
+        "recommendations": [],
+        "longest_waiting": [],
+        "genre_skew": [],
+        "totals": {"median_days_waiting": None, "oldest_days_waiting": None},
+    }
+
+
+def test_another_profiles_watchlist_never_leaks_into_this_one(database: Session) -> None:
+    subject = _profile(database, "subject")
+    neighbour = _profile(database, "neighbour")
+    circle = _circle(database)
+    theirs = _film(database, "Their Queue")
+    _watchlist(database, neighbour, theirs)
+    _watched(database, circle[0], theirs, rating=5.0)
+    _queued(database, subject, circle, "My Queue", other_ratings=[3.0])
+
+    payload = _insights(database, subject)
+
+    assert [entry["title"] for entry in payload["recommendations"]] == ["My Queue"]
+    assert payload["coverage"]["watchlist_films"] == 1
+
+
+# --- bulk loading ------------------------------------------------------------
+
+
+def test_the_payload_costs_the_same_number_of_queries_at_any_size(
+    database: Session,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(database, subject, circle, "Only Film", other_ratings=[4.0, 3.5], genres=["Drama"])
+
+    statements: list[str] = []
+
+    @event.listens_for(database.get_bind(), "before_cursor_execute")
+    def _record(_conn, _cursor, statement, *_args):  # noqa: ANN001
+        statements.append(statement)
+
+    _insights(database, subject)
+    small = len(statements)
+    statements.clear()
+
+    for index in range(40):
+        _queued(
+            database,
+            subject,
+            circle,
+            f"Bulk {index:02d}",
+            other_ratings=[4.0, 3.0, 2.0],
+            genres=["Drama", "Thriller"],
+        )
+    statements.clear()
+    _insights(database, subject)
+    large = len(statements)
+
+    assert small == large, statements
+
+
+# --- route -------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app(database: Session) -> FastAPI:
+    """The router as the orchestrator will mount it, on its own app.
+
+    ``backend/main.py`` wires routers in a later phase, so this exercises the
+    router itself -- its path, its query validation and its auth dependency --
+    without depending on that registration having happened yet.
+    """
+
+    application = FastAPI()
+    application.include_router(watchlist_insights_router)
+    application.dependency_overrides[get_db] = lambda: database
+    return application
+
+
+def _tracked_user(database: Session, profile: Optional[Profile]) -> ClerkUser:
+    app_user = AppUser(clerk_user_id="user_one", primary_profile_required=False)
+    database.add(app_user)
+    database.flush()
+    if profile is not None:
+        database.add(
+            UserTrackedProfile(
+                user_id=app_user.id,
+                profile_id=profile.id,
+                source="direct",
+            )
+        )
+    database.commit()
+    return ClerkUser(
+        user_id="user_one",
+        session_id="session",
+        is_admin=False,
+        letterboxd_username=None,
+    )
+
+
+def test_route_serves_the_payload_for_a_tracked_profile(
+    database: Session,
+    app: FastAPI,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    _queued(
+        database,
+        subject,
+        circle,
+        "Tracked Film",
+        other_ratings=[4.5, 4.0],
+        likes=[True, False],
+        letterboxd_average=4.1,
+        genres=["Drama"],
+    )
+    user = _tracked_user(database, subject)
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    response = TestClient(app).get("/api/profiles/subject/watchlist-insights")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload) == {
+        "username",
+        "coverage",
+        "recommendations",
+        "longest_waiting",
+        "genre_skew",
+        "totals",
+    }
+    assert set(payload["coverage"]) == {
+        "watchlist_films",
+        "rated_by_group",
+        "with_letterboxd_average",
+    }
+    assert set(payload["recommendations"][0]) == {
+        "title",
+        "year",
+        "poster_url",
+        "letterboxd_url",
+        "group_average",
+        "group_raters",
+        "liked_by",
+        "letterboxd_average",
+        "added_date",
+        "days_waiting",
+        "raters",
+    }
+    assert set(payload["recommendations"][0]["raters"][0]) == {"username", "rating"}
+    assert set(payload["longest_waiting"][0]) == {
+        "title",
+        "year",
+        "poster_url",
+        "letterboxd_url",
+        "added_date",
+        "days_waiting",
+    }
+    assert set(payload["genre_skew"][0]) == {"label", "count"}
+    assert set(payload["totals"]) == {"median_days_waiting", "oldest_days_waiting"}
+    assert payload["recommendations"][0]["group_average"] == 4.25
+    assert payload["recommendations"][0]["liked_by"] == 1
+    assert payload["recommendations"][0]["letterboxd_url"].startswith("https://letterboxd.com/")
+
+
+def test_route_honours_the_limit_query_parameter(
+    database: Session,
+    app: FastAPI,
+) -> None:
+    subject = _profile(database, "subject")
+    circle = _circle(database)
+    for index in range(4):
+        _queued(database, subject, circle, f"Film {index}", other_ratings=[4.0])
+    user = _tracked_user(database, subject)
+    app.dependency_overrides[get_current_user] = lambda: user
+    client = TestClient(app)
+
+    response = client.get("/api/profiles/subject/watchlist-insights?limit=2")
+    rejected = client.get(f"/api/profiles/subject/watchlist-insights?limit={MAX_LIMIT + 1}")
+
+    assert response.status_code == 200
+    assert len(response.json()["recommendations"]) == 2
+    assert rejected.status_code == 422
+
+
+def test_route_refuses_an_untracked_profile(database: Session, app: FastAPI) -> None:
+    _profile(database, "subject")
+    user = _tracked_user(database, None)
+    app.dependency_overrides[get_current_user] = lambda: user
+
+    response = TestClient(app).get("/api/profiles/subject/watchlist-insights")
+
+    assert response.status_code == 403
+
+
+def test_route_requires_an_authenticated_user() -> None:
+    route = next(
+        route
+        for route in watchlist_insights_router.routes
+        if route.path == "/api/profiles/{username}/watchlist-insights"
+    )
+
+    assert "get_current_user" in {
+        dependency.call.__name__ for dependency in route.dependant.dependencies
+    }
+
+
+def test_a_lone_five_star_does_not_outrank_a_corroborated_favourite(
+    database: Session,
+) -> None:
+    """Ranking must weigh how many people vouched for a film.
+
+    Sorting on the raw group average put a single 5.0 above a five-person
+    4.6, which is the opposite of a useful recommendation: across the real
+    tracked set most of what surfaced that way rested on one rater.
+    """
+    subject = _profile(database, "viewer")
+    circle = _circle(database, size=5)
+    # The circle needs a normal rating history, or the baseline the ranking
+    # shrinks toward is just the mean of these two films and cannot separate
+    # them. Real circles average around 3.5.
+    for index in range(6):
+        background = _film(database, f"Background {index}")
+        for profile in circle:
+            _watched(database, profile, background, rating=3.5)
+    _queued(database, subject, circle, "Lone Favourite", other_ratings=[5.0])
+    _queued(
+        database,
+        subject,
+        circle,
+        "Crowd Favourite",
+        other_ratings=[4.5, 4.5, 4.5, 5.0, 4.5],
+    )
+
+    result = _insights(database, subject)
+    titles = [entry["title"] for entry in result["recommendations"]]
+    assert titles.index("Crowd Favourite") < titles.index("Lone Favourite")
+
+    # The raw figures stay honest, so the panel can still show both.
+    rows = {entry["title"]: entry for entry in result["recommendations"]}
+    assert rows["Lone Favourite"]["group_average"] == 5.0
+    assert rows["Lone Favourite"]["group_raters"] == 1
+    assert rows["Crowd Favourite"]["group_raters"] == 5

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -93,25 +93,66 @@ const signalEvent = {
   day_gap: 0,
 };
 
+// The pair's social link as the event feeds annotate it: bravo already followed
+// alpha when these entries landed, which is what a follow marker may say and
+// the ceiling of what it may claim.
+const followRelationship = {
+  a: 'alpha',
+  b: 'bravo',
+  a_follows_b: false,
+  b_follows_a: true,
+  mutual: false,
+  known: true,
+  observed_by: ['alpha', 'bravo'],
+  earlier_watcher: 'alpha',
+  later_watcher: 'bravo',
+  follows_earlier_watcher: true,
+};
+
+// A gap event, so the follow marker has something to attach to. The same-day
+// event above deliberately carries no annotation: with no later watcher there
+// is nothing to say.
+const gapSignalEvent = {
+  title: 'Echoed Fixture Film',
+  year: 2022,
+  start_date: '2026-07-26',
+  end_date: '2026-07-27',
+  profile_count: 2,
+  pair_count: 1,
+  profiles: ['alpha', 'bravo'],
+  participants: [
+    { username: 'alpha', rating: 4, watched_date: '2026-07-26', is_rewatch: false },
+    { username: 'bravo', rating: 3.5, watched_date: '2026-07-27', is_rewatch: false },
+  ],
+  average_rating: 3.75,
+  max_rating_gap: 0.5,
+  rewatch_count: 0,
+  day_gap: 1,
+  follow_relationship: followRelationship,
+  follow_relationships: [followRelationship],
+  follows_earlier_watcher: true,
+  follow_backed: true,
+};
+
 const groupSignals = {
   summary: {
     profiles_analyzed: profiles.length,
     profiles_with_diary_dates: profiles.length,
     shared_titles: 42,
     same_day_events: 1,
-    one_day_gap_events: 0,
+    one_day_gap_events: 1,
     same_day_pair_hits: 1,
-    one_day_gap_pair_hits: 0,
+    one_day_gap_pair_hits: 1,
     gap_days: 1,
-    gap_events: 1,
-    gap_pair_hits: 1,
+    gap_events: 2,
+    gap_pair_hits: 2,
     most_shared_title: sharedMovie,
     strongest_alignment_pair: pair,
     most_divisive_title: sharedMovie,
   },
   same_day_events: [signalEvent],
-  one_day_gap_events: [],
-  gap_events: [signalEvent],
+  one_day_gap_events: [gapSignalEvent],
+  gap_events: [signalEvent, gapSignalEvent],
   most_shared_titles: [sharedMovie],
   consensus_hits: [sharedMovie],
   divisive_titles: [sharedMovie],
@@ -255,6 +296,9 @@ export const profileStats = {
     enrichment_ratio: 0.85,
     dated_events: 2_000,
     rated_films: 900,
+    // Deliberately unequal, so the panel's "matched to a film" qualifier renders.
+    reviews_total: 42,
+    reviews_matched_to_films: 39,
   },
   totals: {
     films: 1_200,
@@ -305,9 +349,198 @@ export const profileStats = {
     decade: { label: '1970s', count: 90, average_rating: 4 },
     director: { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
   },
+  // Folded into the same panel. One rewatched film is unrated and one review
+  // has no publication date, so both omission branches render.
+  rewatches: {
+    total_rewatches: 64,
+    films_rewatched: 41,
+    rewatch_rate: 0.0341,
+    most_rewatched: [
+      {
+        title: 'Rewatched Fixture Film',
+        year: 2001,
+        poster_url: null,
+        letterboxd_url: 'https://letterboxd.com/film/rewatched-fixture-film/',
+        watch_count: 5,
+        rating: 4.5,
+      },
+      {
+        title: 'Unrated Rewatch',
+        year: null,
+        poster_url: null,
+        letterboxd_url: null,
+        watch_count: 3,
+        rating: null,
+      },
+    ],
+    average_rating_rewatched: 4.12,
+    average_rating_once: 3.65,
+  },
+  reviews: {
+    total_reviews: 42,
+    with_text: 38,
+    spoiler_reviews: 6,
+    median_length_chars: 640,
+    longest: { title: 'Longest Fixture Review', year: 2015, length_chars: 4_210 },
+    most_liked: [
+      {
+        title: 'Most Liked Fixture Review',
+        year: 2018,
+        likes_count: 96,
+        published_date: '2026-03-14',
+      },
+      { title: 'Undated Fixture Review', year: null, likes_count: 12, published_date: null },
+    ],
+    reviews_by_year: [
+      { year: 2024, count: 12 },
+      { year: 2025, count: 18 },
+      { year: 2026, count: 9 },
+    ],
+    average_rating_reviewed: 4.02,
+    average_rating_unreviewed: 3.61,
+  },
   // Deliberately overlaps our figures: `directors` agrees, `hours` and
   // `longest_streak` do not, so both comparison branches render.
   letterboxd_reported: { hours: 2_130, directors: 640, longest_streak: 19 },
+};
+
+// The unwatched watchlist ranked by the circle. One recommendation has no
+// Letterboxd average and one waiting row has no added date, so both null
+// branches render as omissions rather than zeros.
+export const watchlistInsights = {
+  username: 'alpha',
+  coverage: {
+    watchlist_films: 310,
+    rated_by_group: 74,
+    with_letterboxd_average: 268,
+  },
+  recommendations: [
+    {
+      title: 'Queued Fixture Film',
+      year: 2016,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/queued-fixture-film/',
+      group_average: 4.42,
+      group_raters: 4,
+      liked_by: 3,
+      letterboxd_average: 4.11,
+      added_date: '2024-02-11',
+      days_waiting: 871,
+      raters: [
+        { username: 'bravo', rating: 4.5 },
+        { username: 'charlie', rating: 4.5 },
+        { username: 'delta', rating: 4.5 },
+        { username: 'echo', rating: 4 },
+      ],
+    },
+    {
+      title: 'Undated Queue Entry',
+      year: null,
+      poster_url: null,
+      letterboxd_url: null,
+      group_average: 4.25,
+      group_raters: 2,
+      liked_by: 0,
+      letterboxd_average: null,
+      added_date: null,
+      days_waiting: null,
+      raters: [
+        { username: 'bravo', rating: 4.5 },
+        { username: 'foxtrot', rating: 4 },
+      ],
+    },
+  ],
+  longest_waiting: [
+    {
+      title: 'Oldest Fixture Wait',
+      year: 2009,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/oldest-fixture-wait/',
+      added_date: '2019-05-02',
+      days_waiting: 2_646,
+    },
+    {
+      title: 'Undated Fixture Wait',
+      year: 2011,
+      poster_url: null,
+      letterboxd_url: null,
+      added_date: null,
+      days_waiting: null,
+    },
+  ],
+  genre_skew: [
+    { label: 'Drama', count: 96 },
+    { label: 'Documentary', count: 41 },
+    { label: 'Horror', count: 22 },
+  ],
+  totals: {
+    median_days_waiting: 412,
+    oldest_days_waiting: 2_646,
+  },
+};
+
+// Audience size across the rated library. `crowd_position` is populated here,
+// but the panel omits that section entirely when the backfill has not run.
+export const obscurity = {
+  username: 'alpha',
+  coverage: {
+    rated_films: 900,
+    films_with_rating_count: 742,
+  },
+  index: {
+    median_rating_count: 12_480,
+    mean_rating_count: 240_115,
+    percentile_vs_group: 78.5,
+    lean: 'obscure',
+  },
+  most_obscure: [
+    {
+      title: 'Obscure Fixture Film',
+      year: 1978,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/obscure-fixture-film/',
+      rating_count: 205,
+      profile_rating: 4,
+    },
+    {
+      title: 'Second Obscure Fixture',
+      year: 1985,
+      poster_url: null,
+      letterboxd_url: null,
+      rating_count: 613,
+      profile_rating: 3.5,
+    },
+  ],
+  most_mainstream: [
+    {
+      title: 'Mainstream Fixture Film',
+      year: 2014,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/mainstream-fixture-film/',
+      rating_count: 6_110_855,
+      profile_rating: 4.5,
+    },
+  ],
+  crowd_position: [
+    {
+      title: 'Contrarian Fixture Film',
+      year: 2019,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/contrarian-fixture-film/',
+      profile_rating: 2,
+      share_at_or_below: 0.0412,
+      crowd_average: 4.03,
+    },
+    {
+      title: 'Unaveraged Crowd Fixture',
+      year: 2020,
+      poster_url: null,
+      letterboxd_url: null,
+      profile_rating: 5,
+      share_at_or_below: 0.9821,
+      crowd_average: null,
+    },
+  ],
 };
 
 // Ratings against the rest of the tracked circle. Deliberately mixed: one
@@ -695,15 +928,70 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
       gap_days: Number(url.searchParams.get('gap_days') ?? 1),
       coverage: readyCoverage,
       summary: {
-        echoes: 0,
-        movies: 0,
+        echoes: 1,
+        movies: 1,
         same_day: 0,
-        within_gap: 0,
-        first_known_plus_rewatch: 0,
+        within_gap: 1,
+        first_known_plus_rewatch: 1,
         rewatch_plus_rewatch: 0,
         date_coverage_ratio: 1,
       },
-      echoes: [],
+      follow_graph: {
+        gap_events: 1,
+        follow_backed_gap_events: 1,
+        coincidental_gap_events: 0,
+        undetermined_gap_events: 0,
+        same_day_events: 0,
+        profiles_with_social_sync: ['alpha', 'bravo'],
+        social_sync_coverage_ratio: 1,
+        warnings: [
+          'A follow edge is an observed social link, not evidence that one member\'s watch caused another\'s.',
+        ],
+      },
+      echoes: [
+        {
+          echo_id: 'echo0000fixture1',
+          movie: {
+            movie_id: 4_242,
+            tmdb_id: null,
+            letterboxd_slug: 'echoed-fixture-film',
+            letterboxd_url: 'https://letterboxd.com/film/echoed-fixture-film/',
+            title: 'Echoed Fixture Film',
+            year: 2022,
+            poster_url: null,
+          },
+          pattern: 'first_known_plus_rewatch',
+          timing: 'within_gap',
+          start_date: '2026-07-26',
+          end_date: '2026-07-27',
+          day_gap: 1,
+          participants: [
+            {
+              username: 'alpha',
+              rating: 4,
+              watched_date: '2026-07-26',
+              is_rewatch: true,
+              liked: true,
+              watch_kind: 'rewatch',
+              classification_basis: 'letterboxd_rewatch_flag',
+              timing_role: 'leader',
+            },
+            {
+              username: 'bravo',
+              rating: 3.5,
+              watched_date: '2026-07-27',
+              is_rewatch: false,
+              liked: false,
+              watch_kind: 'first_known_watch',
+              classification_basis: 'earliest_observed_unmarked_event',
+              timing_role: 'follower',
+            },
+          ],
+          follow_relationship: followRelationship,
+          follows_earlier_watcher: true,
+          follow_backed: true,
+        },
+      ],
     });
   }
   if (path === '/api/data-coverage') return json(route, dataCoverage);
@@ -774,6 +1062,22 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         ...ratingComparison,
         username: decodeURIComponent(comparisonMatch[1]),
       });
+    }
+  }
+  {
+    // The unwatched watchlist ranked by the circle, and how mainstream the
+    // rated library is. Both are Analysis panels, so an unmocked request would
+    // 404 into the smoke suite's console-error assertion.
+    const watchlistMatch = path.match(/^\/api\/profiles\/([^/]+)\/watchlist-insights$/);
+    if (watchlistMatch) {
+      return json(route, {
+        ...watchlistInsights,
+        username: decodeURIComponent(watchlistMatch[1]),
+      });
+    }
+    const obscurityMatch = path.match(/^\/api\/profiles\/([^/]+)\/obscurity$/);
+    if (obscurityMatch) {
+      return json(route, { ...obscurity, username: decodeURIComponent(obscurityMatch[1]) });
     }
   }
   {

--- a/frontend/src/components/SpySignalsResults.tsx
+++ b/frontend/src/components/SpySignalsResults.tsx
@@ -19,6 +19,7 @@ import type {
   GroupSignalPair,
   GroupSignals,
 } from '../services/api';
+import { FollowsEarlierWatcherMarker } from './insights/InsightUI';
 import type { SignalGapDays } from './SpySignalsControls';
 
 interface SpySignalsResultsProps {
@@ -57,6 +58,20 @@ function getWindowDays(event: GroupSignalEvent): number {
   const start = Date.UTC(startParts[0], startParts[1] - 1, startParts[2]);
   const end = Date.UTC(endParts[0], endParts[1] - 1, endParts[2]);
   return Math.max(0, Math.round((end - start) / 86_400_000));
+}
+
+/**
+ * Whether this match carries the one social reading the data supports: the
+ * later watcher already followed the earlier one.
+ *
+ * Same-day matches are excluded because there is no later watcher to speak of,
+ * and an unobservable follow (no authoritative social import either way) stays
+ * off rather than reading as an absence. A true here is a social link that
+ * existed, never a claim that one watch produced the other.
+ */
+function followsEarlierWatcher(event: GroupSignalEvent, windowDays: number): boolean {
+  if (windowDays <= 0) return false;
+  return event.follows_earlier_watcher === true || event.follow_backed === true;
 }
 
 function eventKey(event: GroupSignalEvent): string {
@@ -136,6 +151,8 @@ function SignalStrength({ event }: { event: GroupSignalEvent }) {
 
 const SignalEventCard: React.FC<{ event: GroupSignalEvent; index: number }> = ({ event, index }) => {
   const windowDays = getWindowDays(event);
+  const followMarked = followsEarlierWatcher(event, windowDays);
+  const relationship = event.follow_relationship ?? null;
   return (
     <motion.article
       className="relative overflow-hidden rounded-xl border border-white/10 bg-white/[0.035] transition-colors hover:border-cinema-400/25 hover:bg-white/[0.055]"
@@ -176,7 +193,15 @@ const SignalEventCard: React.FC<{ event: GroupSignalEvent; index: number }> = ({
                   {event.profile_count} profiles · {event.pair_count} pair {event.pair_count === 1 ? 'match' : 'matches'}
                 </p>
               </div>
-              <SignalStrength event={event} />
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                {followMarked ? (
+                  <FollowsEarlierWatcherMarker
+                    earlierWatcher={relationship?.earlier_watcher}
+                    laterWatcher={relationship?.later_watcher}
+                  />
+                ) : null}
+                <SignalStrength event={event} />
+              </div>
             </div>
 
             <div className="mt-3 flex flex-wrap gap-2">
@@ -345,6 +370,9 @@ const SpySignalsResults: React.FC<SpySignalsResultsProps> = ({
 
   const strongestPair = summary.strongest_alignment_pair ?? groupSignals.aligned_pairs[0] ?? null;
   const mostDivisive = summary.most_divisive_title ?? groupSignals.divisive_titles[0] ?? null;
+  const followMarkedEvents = events.filter(
+    (event) => followsEarlierWatcher(event, getWindowDays(event)),
+  ).length;
 
   return (
     <div className="space-y-6">
@@ -401,6 +429,9 @@ const SpySignalsResults: React.FC<SpySignalsResultsProps> = ({
 
           <p className="mb-4 rounded-lg border border-white/10 bg-white/[0.025] px-3 py-2 text-xs leading-5 text-white/45">
             Coverage note: profiles with an authoritative diary use occurrence-level watch history; other profiles fall back to one stored date per title.
+            {followMarkedEvents > 0
+              ? ` A follow marker appears on ${followMarkedEvents} of these matches, meaning the later watcher already followed the earlier one — an observed social link, not evidence that one watch caused another. A match without the marker either had no follow between its watchers or no authoritative social import to read one from.`
+              : ''}
           </p>
 
           {events.length > 0 ? (

--- a/frontend/src/components/insights/InsightUI.tsx
+++ b/frontend/src/components/insights/InsightUI.tsx
@@ -2,9 +2,124 @@
 
 import React from 'react';
 import Link from 'next/link';
-import { AlertTriangle, CheckCircle2, CircleSlash, Film, Info, Loader2 } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, CircleSlash, Film, Info, Loader2, UserCheck } from 'lucide-react';
 
 import type { FeatureCoverage, MovieSummary, ProfileInfo } from '../../services/api';
+
+/** A film as the flat panel endpoints ship it, before it reaches a poster. */
+type FilmShell = {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+};
+
+export function formatInsightCount(value: number): string {
+  return value.toLocaleString();
+}
+
+/**
+ * Big audience numbers, shortened. A film with six million ratings and one
+ * with two hundred sit in the same column, and the exact figure is kept in the
+ * caller's `title` where it still matters.
+ */
+export function formatCompactCount(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+export function filmLabel(film: { title: string; year: number | null }): string {
+  return film.year ? `${film.title} (${film.year})` : film.title;
+}
+
+/**
+ * The panel endpoints return flat film shells rather than the full
+ * `MovieSummary` the shared poster expects; only the artwork is read from it.
+ */
+export function toMovieSummary(film: FilmShell): MovieSummary {
+  return {
+    movie_id: null,
+    tmdb_id: null,
+    letterboxd_slug: null,
+    letterboxd_url: film.letterboxd_url,
+    title: film.title,
+    year: film.year,
+    poster_url: film.poster_url,
+  };
+}
+
+export function FilmTitle({ film }: {
+  film: { title: string; year: number | null; letterboxd_url: string | null };
+}) {
+  const label = filmLabel(film);
+  return (
+    <p className="truncate text-sm font-medium text-white/85" title={label}>
+      {film.letterboxd_url ? (
+        <a
+          href={film.letterboxd_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-cinema-200 hover:underline"
+        >
+          {label}
+        </a>
+      ) : (
+        label
+      )}
+    </p>
+  );
+}
+
+/** A titled list inside a panel, so every panel's lists read the same way. */
+export function ListSection({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
+      {subtitle ? <p className="mt-0.5 text-[11px] text-white/30">{subtitle}</p> : null}
+      <ul className="mt-2 space-y-1.5">{children}</ul>
+    </div>
+  );
+}
+
+/**
+ * The marker for a gap co-watch where the later watcher already followed the
+ * earlier one.
+ *
+ * The wording is the ceiling the data supports and must not be raised: a follow
+ * edge is an observed social link, never evidence that one member's watch
+ * caused another's. Nothing here says "influenced", "picked up from", or
+ * "because of".
+ */
+export function FollowsEarlierWatcherMarker({
+  earlierWatcher,
+  laterWatcher,
+}: {
+  earlierWatcher?: string | null;
+  laterWatcher?: string | null;
+}) {
+  const who = earlierWatcher && laterWatcher
+    ? `@${laterWatcher} watched after @${earlierWatcher}, whom they already follow. `
+    : '';
+  return (
+    <span
+      title={`${who}A follow is an observed social link, not evidence that one member's watch caused another's.`}
+      className="inline-flex items-center gap-1.5 rounded-full border border-cinema-400/30 bg-cinema-500/10 px-2.5 py-1 text-[11px] font-semibold text-cinema-200"
+    >
+      <UserCheck className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      Watched after someone they follow
+    </span>
+  );
+}
 
 export function formatCalendarDate(value: string | null | undefined): string {
   if (!value) return 'Date unavailable';

--- a/frontend/src/components/insights/ObscurityPanel.tsx
+++ b/frontend/src/components/insights/ObscurityPanel.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { Telescope } from 'lucide-react';
+
+import { obscurityApi } from '../../services/api';
+import type { ObscurityCrowdPosition, ObscurityFilm, ObscurityLean } from '../../services/api';
+import {
+  FilmTitle,
+  ListSection,
+  MoviePoster,
+  formatCompactCount,
+  formatInsightCount,
+  toMovieSummary,
+} from './InsightUI';
+
+/**
+ * How the lean reads on screen. "Obscure" and "mainstream" are descriptions of
+ * audience size, not of quality, so neither gets the good/bad colouring the
+ * rating panels use for above/below.
+ */
+const LEAN_STYLES: Record<'obscure' | 'balanced' | 'mainstream', { panel: string; text: string }> = {
+  obscure: { panel: 'border-cinema-400/25 bg-cinema-500/[0.08]', text: 'text-cinema-200' },
+  balanced: { panel: 'border-white/10 bg-white/5', text: 'text-white/80' },
+  mainstream: { panel: 'border-sky-400/25 bg-sky-500/[0.08]', text: 'text-sky-200' },
+};
+
+const LEAN_HEADLINES: Record<'obscure' | 'balanced' | 'mainstream', string> = {
+  obscure: 'Watches smaller films than most of the circle',
+  balanced: 'Watches films about as widely seen as the circle does',
+  mainstream: 'Watches bigger films than most of the circle',
+};
+
+function leanStyle(lean: ObscurityLean | null) {
+  return LEAN_STYLES[lean ?? 'balanced'];
+}
+
+function ratingsNote(count: number): string {
+  return `${formatInsightCount(count)} ${count === 1 ? 'rating' : 'ratings'}`;
+}
+
+/** One film, sized by the crowd that rated it. */
+function AudienceRow({ film }: { film: ObscurityFilm }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
+      <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+          {`They rated it ${film.profile_rating.toFixed(1)}`}
+        </p>
+      </div>
+      {film.rating_count !== null ? (
+        <span
+          className="shrink-0 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-center text-white/70"
+          title={`${ratingsNote(film.rating_count)} on Letterboxd`}
+        >
+          <span className="block text-xs font-semibold tabular-nums">
+            {formatCompactCount(film.rating_count)}
+          </span>
+          <span className="block text-[9px] font-semibold uppercase tracking-wide text-white/35">
+            ratings
+          </span>
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * Where one rating fell inside the crowd's own histogram. `share_at_or_below`
+ * is stated as exactly what it is — the slice of the crowd sitting at or below
+ * this rating — rather than translated into a verdict about the member.
+ */
+function CrowdPositionRow({ film }: { film: ObscurityCrowdPosition }) {
+  const share = Math.max(0, Math.min(1, film.share_at_or_below));
+  const percent = Math.round(share * 100);
+  const references = [
+    `They rated it ${film.profile_rating.toFixed(1)}`,
+    film.crowd_average !== null ? `crowd average ${film.crowd_average.toFixed(2)}` : null,
+  ].filter((note): note is string => note !== null);
+
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
+      <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+          {references.join(' · ')}
+        </p>
+      </div>
+      <span
+        className="shrink-0 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-center text-white/70"
+        title={`${percent}% of the crowd rated this film at or below ${film.profile_rating.toFixed(1)}`}
+      >
+        <span className="block text-xs font-semibold tabular-nums">{percent}%</span>
+        <span className="block text-[9px] font-semibold uppercase tracking-wide text-white/35">
+          at or below
+        </span>
+      </span>
+    </li>
+  );
+}
+
+/**
+ * How mainstream a profile's taste is, measured in audience size.
+ *
+ * The headline is the median rather than the mean on purpose: audience sizes
+ * run from a few hundred to several million, and one blockbuster would drag a
+ * mean into a taste nobody has. The mean sits beside it so the skew stays
+ * visible, and the lean is only ever relative to the other tracked profiles —
+ * with nobody to compare against there is a median and no lean.
+ *
+ * The endpoint is optional from the page's point of view: any failure, and the
+ * panel simply is not there.
+ */
+const ObscurityPanel: React.FC<{ username: string; delay?: number }> = ({
+  username,
+  delay = 0,
+}) => {
+  const obscurityQuery = useQuery({
+    queryKey: ['obscurity', username],
+    queryFn: () => obscurityApi.getObscurity(username),
+    enabled: Boolean(username),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const data = obscurityQuery.data;
+
+  // No hooks below this line: the panel disappears entirely when the endpoint
+  // is unavailable or has nothing to measure.
+  if (obscurityQuery.isError || !data) return null;
+
+  const coverage = data.coverage;
+  const index = data.index;
+  const mostObscure = data.most_obscure ?? [];
+  const mostMainstream = data.most_mainstream ?? [];
+  const crowdPosition = data.crowd_position ?? [];
+  const median = index?.median_rating_count ?? null;
+  if (median === null && mostObscure.length === 0 && mostMainstream.length === 0) return null;
+
+  const mean = index?.mean_rating_count ?? null;
+  const percentile = index?.percentile_vs_group ?? null;
+  const lean = index?.lean ?? null;
+  const style = leanStyle(lean);
+
+  const headline = median === null
+    ? 'No audience size is known for these films yet'
+    : `${formatInsightCount(median)} ratings behind the typical film they rated`;
+  const headlineDetail = median === null
+    ? 'Letterboxd’s crowd counts have not reached this profile’s films, so there is no median to report.'
+    : mean !== null && mean > median
+      ? `A median, not a mean: audience sizes are heavily right-skewed. The mean of ${formatInsightCount(mean)} sits above it, which is a handful of very large audiences showing up.`
+      : 'A median rather than a mean, because audience sizes are heavily right-skewed.';
+
+  const leanLabel = lean === null ? null : LEAN_HEADLINES[lean];
+
+  // One qualification for the whole panel rather than a caveat on every row.
+  const coverageNote = `The median reads ${formatInsightCount(coverage.films_with_rating_count)} of ${formatInsightCount(coverage.rated_films)} rated films — the rest have no Letterboxd audience size synced yet and are left out rather than counted as an audience of zero.`;
+  const percentileNote = percentile === null
+    ? 'There is no other tracked profile to place this median against, so no lean is claimed.'
+    : null;
+
+  return (
+    <motion.section
+      className="analysis-panel"
+      aria-labelledby="obscurity-title"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <div className="flex items-center gap-2">
+        <Telescope className="h-5 w-5 text-cinema-400" aria-hidden="true" />
+        <h2 id="obscurity-title" className="text-xl font-semibold text-white">
+          Obscurity index
+        </h2>
+      </div>
+      <p className="mt-1 text-sm text-white/60">
+        How big a crowd @{username} tends to watch with — Letterboxd publishes a film’s
+        rating count and never adds it up across a member’s history.
+      </p>
+
+      <div
+        className={`mt-5 flex flex-col gap-4 rounded-2xl border px-4 py-4 sm:flex-row sm:items-center sm:justify-between ${style.panel}`}
+      >
+        <div className="flex min-w-0 items-start gap-3">
+          <Telescope className={`mt-0.5 h-6 w-6 shrink-0 ${style.text}`} aria-hidden="true" />
+          <div className="min-w-0">
+            <p className={`text-lg font-semibold ${style.text}`}>{headline}</p>
+            {leanLabel ? (
+              <p className="mt-0.5 text-sm font-medium text-white/70">{leanLabel}</p>
+            ) : null}
+            <p className="mt-1 text-xs leading-5 text-white/45">{headlineDetail}</p>
+          </div>
+        </div>
+        {percentile !== null ? (
+          <div className="shrink-0 sm:text-right">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+              Obscurity percentile
+            </p>
+            <p className="mt-0.5 text-lg font-bold tabular-nums text-white">
+              {percentile.toFixed(0)}
+            </p>
+            <p className="text-[11px] text-white/40">
+              100 = every other tracked profile watches bigger films
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      {mostObscure.length > 0 || mostMainstream.length > 0 ? (
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          {mostObscure.length > 0 ? (
+            <ListSection title="Most obscure" subtitle="Smallest audiences they have rated">
+              {mostObscure.map((film, index_) => (
+                <AudienceRow key={`${film.title}-${film.year ?? 'na'}-${index_}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
+          {mostMainstream.length > 0 ? (
+            <ListSection title="Most mainstream" subtitle="Biggest audiences they have rated">
+              {mostMainstream.map((film, index_) => (
+                <AudienceRow key={`${film.title}-${film.year ?? 'na'}-${index_}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
+        </div>
+      ) : null}
+
+      {crowdPosition.length > 0 ? (
+        <div className="mt-6">
+          <ListSection
+            title="Furthest from the crowd"
+            subtitle="Where their rating fell inside Letterboxd’s own histogram for the film"
+          >
+            {crowdPosition.map((film, index_) => (
+              <CrowdPositionRow key={`${film.title}-${film.year ?? 'na'}-${index_}`} film={film} />
+            ))}
+          </ListSection>
+        </div>
+      ) : null}
+
+      <p className="mt-5 text-[11px] leading-5 text-white/30">
+        {[coverageNote, percentileNote]
+          .filter((note): note is string => note !== null)
+          .join(' ')}
+      </p>
+    </motion.section>
+  );
+};
+
+export default ObscurityPanel;

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -9,8 +9,12 @@ import { profileStatsApi } from '../../services/api';
 import type {
   ProfileStatsBucket,
   ProfileStatsCountryBucket,
+  ProfileStatsCoverage,
   ProfileStatsPerson,
+  ProfileStatsReviews,
+  ProfileStatsRewatches,
 } from '../../services/api';
+import { FilmTitle, MoviePoster, formatCalendarDate, toMovieSummary } from './InsightUI';
 
 /** Below this, the metadata gap is worth saying once at the panel level. */
 const ENRICHMENT_CAVEAT_THRESHOLD = 0.95;
@@ -207,6 +211,207 @@ function BreakdownBars({
   );
 }
 
+/** A sub-heading inside the panel, so the folded sections keep its chrome. */
+function SubSection({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
+      {subtitle ? <p className="mt-0.5 text-[11px] leading-4 text-white/30">{subtitle}</p> : null}
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The two averages a rewatch or review split produces, phrased as what they
+ * are. Both sides are self-selected sets of films from the same library, so the
+ * gap describes which films get revisited or written about — never what
+ * revisiting or writing does to a rating.
+ */
+function PairedAverages({
+  leftLabel,
+  leftValue,
+  rightLabel,
+  rightValue,
+  caveat,
+}: {
+  leftLabel: string;
+  leftValue: number | null;
+  rightLabel: string;
+  rightValue: number | null;
+  caveat: string;
+}) {
+  if (leftValue === null && rightValue === null) return null;
+  const parts = [
+    leftValue === null ? null : `${leftLabel} ${leftValue.toFixed(2)}`,
+    rightValue === null ? null : `${rightLabel} ${rightValue.toFixed(2)}`,
+  ].filter((part): part is string => part !== null);
+
+  return (
+    <p className="mt-2 text-[11px] leading-4 text-white/40">
+      {parts.join(' · ')}
+      <span className="text-white/25">{` — ${caveat}`}</span>
+    </p>
+  );
+}
+
+/**
+ * What this member returns to. Films seen once are not listed: a film with no
+ * rewatch is not a quiet entry at the bottom of a rewatch list.
+ */
+function RewatchSection({ rewatches }: { rewatches: ProfileStatsRewatches }) {
+  const films = rewatches.most_rewatched ?? [];
+  if (rewatches.total_rewatches === 0 && films.length === 0) return null;
+
+  const subtitle = [
+    `${formatCount(rewatches.total_rewatches)} logged across ${formatCount(rewatches.films_rewatched)} films`,
+    rewatches.rewatch_rate === null
+      ? null
+      : `${formatRatio(rewatches.rewatch_rate)} of the library revisited`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(' · ');
+
+  return (
+    <SubSection title="Rewatches" subtitle={subtitle}>
+      {films.length > 0 ? (
+        <ul className="mt-2 space-y-1.5">
+          {films.map((film, index) => (
+            <li
+              key={`${film.title}-${film.year ?? 'na'}-${index}`}
+              className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2"
+            >
+              <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+              <div className="min-w-0 flex-1">
+                <FilmTitle film={film} />
+                <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+                  {film.rating === null ? 'Unrated' : `Rated ${film.rating.toFixed(1)}`}
+                </p>
+              </div>
+              <span
+                className="shrink-0 rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs font-semibold tabular-nums text-white/70"
+                title={`${formatCount(film.watch_count)} logged ${film.watch_count === 1 ? 'watch' : 'watches'}`}
+              >
+                {`×${formatCount(film.watch_count)}`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <PairedAverages
+        leftLabel="Revisited films average"
+        leftValue={rewatches.average_rating_rewatched}
+        rightLabel="seen once"
+        rightValue={rewatches.average_rating_once}
+        caveat="two self-selected sets, not a before-and-after"
+      />
+    </SubSection>
+  );
+}
+
+/** Writing habits, and how this member rates the films they write about. */
+function ReviewSection({
+  reviews,
+  coverage,
+}: {
+  reviews: ProfileStatsReviews;
+  coverage: ProfileStatsCoverage;
+}) {
+  const liked = reviews.most_liked ?? [];
+  const byYear = reviews.reviews_by_year ?? [];
+  if (reviews.total_reviews === 0) return null;
+
+  const subtitle = [
+    `${formatCount(reviews.total_reviews)} published`,
+    reviews.with_text > 0 ? `${formatCount(reviews.with_text)} with prose` : null,
+    reviews.spoiler_reviews > 0 ? `${formatCount(reviews.spoiler_reviews)} flagged for spoilers` : null,
+    reviews.median_length_chars === null
+      ? null
+      : `${formatCount(reviews.median_length_chars)} characters median`,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(' · ');
+
+  return (
+    <SubSection title="Reviews" subtitle={subtitle}>
+      {reviews.longest ? (
+        <p className="mt-2 text-[11px] leading-4 text-white/40">
+          {`Longest: ${reviews.longest.title}${reviews.longest.year ? ` (${reviews.longest.year})` : ''}, ${formatCount(reviews.longest.length_chars)} characters`}
+        </p>
+      ) : null}
+
+      {liked.length > 0 ? (
+        <p className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-white/35">
+          Most liked
+        </p>
+      ) : null}
+      {liked.length > 0 ? (
+        <ol className="mt-2 space-y-1.5">
+          {liked.map((review, index) => (
+            <li
+              key={`${review.title}-${review.published_date ?? index}`}
+              className="flex items-center gap-2 text-sm"
+            >
+              <span className="min-w-0 flex-1 truncate text-white/80" title={review.title}>
+                {review.title}
+                {review.year ? <span className="text-white/35">{` (${review.year})`}</span> : null}
+              </span>
+              {review.published_date ? (
+                <span className="shrink-0 text-[11px] text-white/30">
+                  {formatCalendarDate(review.published_date)}
+                </span>
+              ) : null}
+              <span
+                className="w-10 shrink-0 text-right text-xs tabular-nums text-white/45"
+                title={`${formatCount(review.likes_count)} likes`}
+              >
+                {`♥ ${formatCount(review.likes_count)}`}
+              </span>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      {byYear.length > 0 ? (
+        <div className="mt-4">
+          <BreakdownBars
+            title="Reviews by year"
+            subtitle="Undated reviews belong to no year and are left out"
+            rows={byYear.map((entry) => ({
+              id: String(entry.year),
+              label: String(entry.year),
+              title: String(entry.year),
+              count: entry.count,
+              averageRating: null,
+            }))}
+          />
+        </div>
+      ) : null}
+
+      <PairedAverages
+        leftLabel="Reviewed films average"
+        leftValue={reviews.average_rating_reviewed}
+        rightLabel="unreviewed"
+        rightValue={reviews.average_rating_unreviewed}
+        caveat="two self-selected sets, not a before-and-after"
+      />
+      {coverage.reviews_total > coverage.reviews_matched_to_films ? (
+        <p className="mt-1 text-[11px] leading-4 text-white/25">
+          {`${formatCount(coverage.reviews_matched_to_films)} of ${formatCount(coverage.reviews_total)} reviews matched a film in the library; the rest count only in the totals above.`}
+        </p>
+      ) : null}
+    </SubSection>
+  );
+}
+
 /**
  * The numbers Letterboxd puts behind its Patron-only stats page, computed for
  * every tracked member from their synced history. The endpoint is optional
@@ -336,6 +541,16 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
     (item): item is { label: string; name: string; count: number; average: number } => item !== null,
   );
 
+  // Rewatching and reviewing are part of the same "about this profile" story,
+  // so they fold in here rather than arriving as panels of their own. A profile
+  // with neither gets no divider and no empty shell.
+  const rewatches = stats.rewatches;
+  const reviews = stats.reviews;
+  const hasRewatchSection = Boolean(
+    rewatches && (rewatches.total_rewatches > 0 || (rewatches.most_rewatched?.length ?? 0) > 0),
+  );
+  const hasReviewSection = Boolean(reviews && reviews.total_reviews > 0);
+
   // One caveat for the whole panel rather than a footnote on every row.
   const enrichmentCaveat = coverage.films_total > 0
     && coverage.enrichment_ratio < ENRICHMENT_CAVEAT_THRESHOLD
@@ -448,6 +663,15 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
               </p>
             </div>
           ))}
+        </div>
+      ) : null}
+
+      {hasRewatchSection || hasReviewSection ? (
+        <div className="mt-6 grid gap-6 border-t border-white/10 pt-5 lg:grid-cols-2">
+          {hasRewatchSection && rewatches ? <RewatchSection rewatches={rewatches} /> : null}
+          {hasReviewSection && reviews ? (
+            <ReviewSection reviews={reviews} coverage={coverage} />
+          ) : null}
         </div>
       ) : null}
 

--- a/frontend/src/components/insights/RatingComparisonPanel.tsx
+++ b/frontend/src/components/insights/RatingComparisonPanel.tsx
@@ -7,12 +7,11 @@ import { Minus, Scale, TrendingDown, TrendingUp } from 'lucide-react';
 
 import { ratingComparisonApi } from '../../services/api';
 import type {
-  MovieSummary,
   RatingComparisonDivisiveFilm,
   RatingComparisonFilm,
   RatingComparisonLean,
 } from '../../services/api';
-import { MoviePoster } from './InsightUI';
+import { FilmTitle, ListSection, MoviePoster, toMovieSummary } from './InsightUI';
 
 /** The band the API documents for calling a profile generous or harsh. */
 const LEAN_BAND = 0.15;
@@ -72,53 +71,8 @@ function leanFromDelta(value: number | null): RatingComparisonLean {
   return 'aligned';
 }
 
-function filmLabel(film: { title: string; year: number | null }): string {
-  return film.year ? `${film.title} (${film.year})` : film.title;
-}
-
-/**
- * The comparison endpoints return flat film shells rather than the full
- * `MovieSummary` the shared poster expects; only the artwork is read from it.
- */
-function toMovieSummary(film: {
-  title: string;
-  year: number | null;
-  poster_url: string | null;
-  letterboxd_url: string | null;
-}): MovieSummary {
-  return {
-    movie_id: null,
-    tmdb_id: null,
-    letterboxd_slug: null,
-    letterboxd_url: film.letterboxd_url,
-    title: film.title,
-    year: film.year,
-    poster_url: film.poster_url,
-  };
-}
-
 function raterNote(count: number): string {
   return `${formatCount(count)} ${count === 1 ? 'rater' : 'raters'}`;
-}
-
-function FilmTitle({ film }: { film: { title: string; year: number | null; letterboxd_url: string | null } }) {
-  const label = filmLabel(film);
-  return (
-    <p className="truncate text-sm font-medium text-white/85" title={label}>
-      {film.letterboxd_url ? (
-        <a
-          href={film.letterboxd_url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-cinema-200 hover:underline"
-        >
-          {label}
-        </a>
-      ) : (
-        label
-      )}
-    </p>
-  );
 }
 
 /**
@@ -210,24 +164,6 @@ function DivisiveRow({ film, username }: { film: RatingComparisonDivisiveFilm; u
         </span>
       </span>
     </li>
-  );
-}
-
-function ListSection({
-  title,
-  subtitle,
-  children,
-}: {
-  title: string;
-  subtitle: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div>
-      <p className="text-xs font-semibold uppercase tracking-wide text-white/45">{title}</p>
-      <p className="mt-0.5 text-[11px] text-white/30">{subtitle}</p>
-      <ul className="mt-2 space-y-1.5">{children}</ul>
-    </div>
   );
 }
 

--- a/frontend/src/components/insights/RewatchEchoesPanel.tsx
+++ b/frontend/src/components/insights/RewatchEchoesPanel.tsx
@@ -4,11 +4,29 @@ import React, { useState } from 'react';
 import { ArrowRight, History, RefreshCw, Repeat2 } from 'lucide-react';
 
 import type { RewatchEcho, RewatchEchoesResponse } from '../../services/api';
-import { CoverageBanner, FeatureState, formatCalendarDate, MoviePoster, ProfileAvatar } from './InsightUI';
+import {
+  CoverageBanner,
+  FeatureState,
+  FollowsEarlierWatcherMarker,
+  formatCalendarDate,
+  MoviePoster,
+  ProfileAvatar,
+} from './InsightUI';
 
 function echoLabel(echo: RewatchEcho): string {
   if (echo.pattern === 'rewatch_plus_rewatch') return 'Both revisited it';
   return 'First watch met a rewatch';
+}
+
+/**
+ * Whether this echo carries the one social reading the data supports: the later
+ * watcher already followed the earlier one. Same-day echoes have no later
+ * watcher, and an unobservable follow stays off rather than reading as an
+ * absence.
+ */
+function followsEarlierWatcher(echo: RewatchEcho): boolean {
+  if (echo.day_gap <= 0) return false;
+  return echo.follows_earlier_watcher === true || echo.follow_backed === true;
 }
 
 function echoExplanation(echo: RewatchEcho): string {
@@ -50,6 +68,14 @@ function EchoRow({ echo }: { echo: RewatchEcho }) {
           {echo.day_gap === 0 ? 'Same day' : `${echo.day_gap} day${echo.day_gap === 1 ? '' : 's'} apart`}
         </p>
         <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-white/40">{echoExplanation(echo)}</p>
+        {followsEarlierWatcher(echo) ? (
+          <p className="mt-1.5 flex lg:justify-end">
+            <FollowsEarlierWatcherMarker
+              earlierWatcher={echo.follow_relationship?.earlier_watcher}
+              laterWatcher={echo.follow_relationship?.later_watcher}
+            />
+          </p>
+        ) : null}
       </div>
     </article>
   );
@@ -90,6 +116,19 @@ export default function RewatchEchoesPanel({
   const echoes = data.echoes ?? [];
   const visibleEchoes = expanded ? echoes : echoes.slice(0, 6);
 
+  // Said once for the panel rather than beside every marker.
+  const followGraph = data.follow_graph;
+  const followNote = followGraph && followGraph.follow_backed_gap_events > 0
+    ? [
+        `A follow marker appears on ${followGraph.follow_backed_gap_events} of the ${followGraph.gap_events} echoes with a day between them: the later watcher already followed the earlier one. That is an observed social link, not evidence that one watch caused another.`,
+        followGraph.undetermined_gap_events > 0
+          ? `${followGraph.undetermined_gap_events} stay undetermined because no authoritative following import covers them.`
+          : null,
+      ]
+        .filter((part): part is string => part !== null)
+        .join(' ')
+    : null;
+
   return (
     <section className="space-y-4" aria-labelledby="rewatch-echoes-title">
       <CoverageBanner coverage={data.coverage} />
@@ -114,6 +153,12 @@ export default function RewatchEchoesPanel({
             </div>
           </div>
         </header>
+
+        {followNote ? (
+          <p className="border-b border-white/10 px-4 py-2.5 text-[11px] leading-5 text-white/40">
+            {followNote}
+          </p>
+        ) : null}
 
         {data.coverage.status === 'blocked' ? (
           <FeatureState title="Rewatch history is unavailable" message={data.coverage.blockers[0] ?? 'Occurrence-level rewatch data is required for this view.'} />

--- a/frontend/src/components/insights/WatchlistPanel.tsx
+++ b/frontend/src/components/insights/WatchlistPanel.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { useQuery } from '@tanstack/react-query';
+import { Bookmark } from 'lucide-react';
+
+import { watchlistInsightsApi } from '../../services/api';
+import type {
+  WatchlistGenreCount,
+  WatchlistRecommendation,
+  WatchlistWaitingFilm,
+} from '../../services/api';
+import {
+  FilmTitle,
+  ListSection,
+  MoviePoster,
+  ProfileAvatar,
+  formatCalendarDate,
+  formatInsightCount,
+  toMovieSummary,
+} from './InsightUI';
+
+/** How much of the ranked queue to show before the reader asks for the rest. */
+const QUEUE_PREVIEW = 8;
+
+function formatDays(days: number): string {
+  return `${formatInsightCount(days)} ${days === 1 ? 'day' : 'days'}`;
+}
+
+/**
+ * A wait is unknown, never zero: Letterboxd only publishes an added date on
+ * some watchlist surfaces, so a film without one is left unqualified rather
+ * than described as freshly added.
+ */
+function waitNote(film: { added_date: string | null; days_waiting: number | null }): string {
+  if (film.days_waiting === null) return 'Added date unknown';
+  return `Waiting ${formatDays(film.days_waiting)}`;
+}
+
+function waitTitle(film: { added_date: string | null }): string | undefined {
+  return film.added_date ? `Added ${formatCalendarDate(film.added_date)}` : undefined;
+}
+
+/** One member behind the circle's verdict on a queued film. */
+function RaterChip({ username, rating }: { username: string; rating: number }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-md border border-white/10 bg-white/5 py-0.5 pl-0.5 pr-1.5"
+      title={`@${username} rated it ${rating.toFixed(1)}`}
+    >
+      <ProfileAvatar username={username} size="sm" />
+      <span className="max-w-24 truncate text-white/60">{username}</span>
+      <span className="font-semibold tabular-nums text-white/80">{rating.toFixed(1)}</span>
+    </span>
+  );
+}
+
+function QueueRow({ film, rank }: { film: WatchlistRecommendation; rank: number }) {
+  const references = [
+    `${formatInsightCount(film.group_raters)} ${film.group_raters === 1 ? 'rater' : 'raters'}`,
+    film.liked_by > 0 ? `${formatInsightCount(film.liked_by)} liked` : null,
+    film.letterboxd_average !== null ? `Letterboxd ${film.letterboxd_average.toFixed(2)}` : null,
+  ].filter((note): note is string => note !== null);
+
+  return (
+    <li className="flex items-start gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2.5">
+      <span className="w-4 shrink-0 pt-1 text-right text-[11px] tabular-nums text-white/25">
+        {rank}
+      </span>
+      <MoviePoster movie={toMovieSummary(film)} className="h-16 w-11" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 tabular-nums text-white/40">
+          {references.join(' · ')}
+        </p>
+        {film.raters.length > 0 ? (
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5 text-[11px] leading-4">
+            {film.raters.map((rater) => (
+              <RaterChip key={rater.username} username={rater.username} rating={rater.rating} />
+            ))}
+          </div>
+        ) : null}
+        <p className="mt-1.5 text-[11px] leading-4 text-white/30" title={waitTitle(film)}>
+          {waitNote(film)}
+        </p>
+      </div>
+      {film.group_average !== null ? (
+        <span
+          className="shrink-0 rounded-lg border border-cinema-400/25 bg-cinema-500/10 px-2 py-1 text-center text-cinema-300"
+          title="Average over the other tracked profiles who have seen it"
+        >
+          <span className="block text-sm font-semibold tabular-nums">
+            {film.group_average.toFixed(2)}
+          </span>
+          <span className="block text-[9px] font-semibold uppercase tracking-wide text-cinema-300/70">
+            circle
+          </span>
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+function WaitingRow({ film }: { film: WatchlistWaitingFilm }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-white/5 bg-black/20 px-3 py-2">
+      <MoviePoster movie={toMovieSummary(film)} className="h-12 w-8" />
+      <div className="min-w-0 flex-1">
+        <FilmTitle film={film} />
+        <p className="mt-0.5 text-[11px] leading-4 text-white/40" title={waitTitle(film)}>
+          {film.added_date ? `Added ${formatCalendarDate(film.added_date)}` : 'Added date unknown'}
+        </p>
+      </div>
+      {film.days_waiting !== null ? (
+        <span className="shrink-0 text-right text-xs font-semibold tabular-nums text-white/55">
+          {formatDays(film.days_waiting)}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+function GenreSkewBars({ genres }: { genres: WatchlistGenreCount[] }) {
+  const largest = genres.reduce((max, genre) => Math.max(max, genre.count), 0);
+
+  return (
+    <ul className="mt-2 space-y-1.5">
+      {genres.map((genre) => (
+        <li key={genre.label} className="flex items-center gap-2 text-sm">
+          <span className="min-w-0 flex-1 truncate text-white/80" title={genre.label}>
+            {genre.label}
+          </span>
+          <span className="h-1.5 w-14 shrink-0 overflow-hidden rounded-full bg-white/10">
+            <span
+              className="block h-full rounded-full bg-cinema-500"
+              style={{ width: `${largest > 0 ? Math.max(4, Math.round((genre.count / largest) * 100)) : 4}%` }}
+            />
+          </span>
+          <span className="w-8 shrink-0 text-right text-xs tabular-nums text-white/45">
+            {formatInsightCount(genre.count)}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * A watchlist ranked by the circle that already saw the films.
+ *
+ * Letterboxd keeps a watchlist as an undifferentiated bag and can only annotate
+ * it with its own site-wide average; every tracked profile's rating is already
+ * held here, so each unwatched film carries what this member's own people made
+ * of it. Only films with no watch record for this profile are recommended, and
+ * the average behind each one excludes the member being served.
+ *
+ * The endpoint is optional from the page's point of view: any failure, and the
+ * panel simply is not there, the same way the stats and comparison panels bow
+ * out.
+ */
+const WatchlistPanel: React.FC<{ username: string; delay?: number }> = ({
+  username,
+  delay = 0,
+}) => {
+  const [expanded, setExpanded] = React.useState(false);
+  const watchlistQuery = useQuery({
+    queryKey: ['watchlist-insights', username],
+    queryFn: () => watchlistInsightsApi.getInsights(username),
+    enabled: Boolean(username),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const data = watchlistQuery.data;
+
+  // No hooks below this line: the panel disappears entirely when the endpoint
+  // is unavailable or has nothing worth queueing.
+  if (watchlistQuery.isError || !data) return null;
+
+  const coverage = data.coverage;
+  const recommendations = data.recommendations ?? [];
+  const longestWaiting = data.longest_waiting ?? [];
+  const genreSkew = data.genre_skew ?? [];
+  if (recommendations.length === 0 && longestWaiting.length === 0 && genreSkew.length === 0) {
+    return null;
+  }
+
+  const medianWait = data.totals?.median_days_waiting ?? null;
+  const oldestWait = data.totals?.oldest_days_waiting ?? null;
+  const visibleQueue = expanded ? recommendations : recommendations.slice(0, QUEUE_PREVIEW);
+
+  const headlineStats: Array<{ key: string; label: string; value: string; hint?: string }> = [
+    {
+      key: 'unwatched',
+      label: 'Unwatched',
+      value: formatInsightCount(coverage.watchlist_films),
+      hint: 'still on the watchlist',
+    },
+    medianWait !== null
+      ? { key: 'median', label: 'Median wait', value: formatDays(medianWait) }
+      : null,
+    oldestWait !== null
+      ? { key: 'oldest', label: 'Longest wait', value: formatDays(oldestWait) }
+      : null,
+  ].filter((stat): stat is { key: string; label: string; value: string; hint?: string } => (
+    stat !== null
+  ));
+
+  // One qualification for the whole panel rather than a caveat on every row.
+  const coverageNote = `${formatInsightCount(coverage.rated_by_group)} of ${formatInsightCount(coverage.watchlist_films)} unwatched films have a rating from another tracked profile, and only those can be ranked; ${formatInsightCount(coverage.with_letterboxd_average)} carry Letterboxd’s own average.`;
+  const waitNoteForPanel = medianWait === null
+    ? 'No row on this watchlist carried an added date, so the wait is unknown rather than zero.'
+    : 'Rows with no added date are left out of the wait figures rather than counted as newly added.';
+
+  return (
+    <motion.section
+      className="analysis-panel"
+      aria-labelledby="watchlist-queue-title"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay }}
+    >
+      <div className="flex items-center gap-2">
+        <Bookmark className="h-5 w-5 text-cinema-400" aria-hidden="true" />
+        <h2 id="watchlist-queue-title" className="text-xl font-semibold text-white">
+          Watchlist queue
+        </h2>
+      </div>
+      <p className="mt-1 text-sm text-white/60">
+        What @{username} has queued but not seen, ranked by what the profiles tracked
+        alongside them scored it — the number Letterboxd cannot show.
+      </p>
+
+      <dl className="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3">
+        {headlineStats.map((stat) => (
+          <div
+            key={stat.key}
+            className="rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-center"
+          >
+            <dt className="text-[10px] font-semibold uppercase tracking-wide text-white/45">
+              {stat.label}
+            </dt>
+            <dd className="mt-1 text-lg font-bold text-white">{stat.value}</dd>
+            {stat.hint ? (
+              <p className="mt-0.5 text-[10px] leading-4 text-white/35">{stat.hint}</p>
+            ) : null}
+          </div>
+        ))}
+      </dl>
+
+      {recommendations.length > 0 ? (
+        <div className="mt-6">
+          <ListSection
+            title="Watch next"
+            subtitle="Highest circle average first, then the number of members behind it"
+          >
+            {visibleQueue.map((film, index) => (
+              <QueueRow
+                key={`${film.title}-${film.year ?? 'na'}-${index}`}
+                film={film}
+                rank={index + 1}
+              />
+            ))}
+          </ListSection>
+          {recommendations.length > QUEUE_PREVIEW ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((value) => !value)}
+              className="btn-ghost mt-3 border-white/10 px-4 py-2 text-xs"
+            >
+              {expanded
+                ? 'Show fewer'
+                : `Show all ${formatInsightCount(recommendations.length)} ranked films`}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {longestWaiting.length > 0 || genreSkew.length > 0 ? (
+        <div className="mt-6 grid gap-6 lg:grid-cols-2">
+          {longestWaiting.length > 0 ? (
+            <ListSection title="Longest waiting" subtitle="On the list the longest, rated or not">
+              {longestWaiting.map((film, index) => (
+                <WaitingRow key={`${film.title}-${film.year ?? 'na'}-${index}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
+          {genreSkew.length > 0 ? (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-white/45">
+                Piling up
+              </p>
+              <p className="mt-0.5 text-[11px] text-white/30">
+                Genres across the whole unwatched list, not just the ranked slice
+              </p>
+              <GenreSkewBars genres={genreSkew} />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <p className="mt-5 text-[11px] leading-5 text-white/30">
+        {`${coverageNote} ${waitNoteForPanel}`}
+      </p>
+    </motion.section>
+  );
+};
+
+export default WatchlistPanel;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -407,6 +407,44 @@ export interface GroupSignalParticipant {
   is_rewatch: boolean;
 }
 
+/**
+ * The observed social link between two members of a co-watch, as annotated on
+ * the event itself. Every direction is three-valued: `null` means no
+ * authoritative following/followers import covers it, which is not the same as
+ * an observed absence.
+ *
+ * `follows_earlier_watcher` is the strongest reading available — the later
+ * watcher already followed the earlier one when these diary entries landed. It
+ * is never evidence that one watch caused the other, and any copy built on it
+ * must stay at "watched after someone they follow".
+ */
+export interface CoWatchFollowRelationship {
+  a: string;
+  b: string;
+  a_follows_b: boolean | null;
+  b_follows_a: boolean | null;
+  mutual: boolean | null;
+  /** Whether either direction was observable at all. */
+  known: boolean;
+  /** Whose own social import the reading is sourced from. */
+  observed_by: string[];
+  earlier_watcher: string | null;
+  later_watcher: string | null;
+  follows_earlier_watcher: boolean | null;
+}
+
+/** How much of a co-watch feed could be read against the follow graph. */
+export interface CoWatchFollowGraphSummary {
+  gap_events: number;
+  follow_backed_gap_events: number;
+  coincidental_gap_events: number;
+  undetermined_gap_events: number;
+  same_day_events: number;
+  profiles_with_social_sync: string[];
+  social_sync_coverage_ratio: number | null;
+  warnings: string[];
+}
+
 export interface GroupSignalEvent {
   title: string;
   year: number | null;
@@ -420,6 +458,16 @@ export interface GroupSignalEvent {
   max_rating_gap: number | null;
   rewatch_count: number;
   day_gap?: number;
+  /**
+   * Follow annotations. Optional because only the event feeds built from the
+   * social-aware insights service carry them; a feed without them must render
+   * exactly as it did before rather than as an absence of follows.
+   */
+  follow_relationship?: CoWatchFollowRelationship | null;
+  follow_relationships?: CoWatchFollowRelationship[];
+  follows_earlier_watcher?: boolean | null;
+  /** True when any later watcher in the event already followed an earlier one. */
+  follow_backed?: boolean | null;
 }
 
 export interface GroupSignalPair {
@@ -502,6 +550,10 @@ export interface RewatchEcho {
   end_date: string;
   day_gap: number;
   participants: RewatchEchoParticipant[];
+  /** Social context for the echo; see `CoWatchFollowRelationship`. */
+  follow_relationship?: CoWatchFollowRelationship | null;
+  follows_earlier_watcher?: boolean | null;
+  follow_backed?: boolean | null;
 }
 
 export interface RewatchEchoesResponse {
@@ -517,6 +569,8 @@ export interface RewatchEchoesResponse {
     rewatch_plus_rewatch: number;
     date_coverage_ratio: number | null;
   };
+  /** Absent from responses produced before the echoes were read against follows. */
+  follow_graph?: CoWatchFollowGraphSummary;
   echoes: RewatchEcho[];
 }
 
@@ -1196,6 +1250,12 @@ export interface ProfileStatsCoverage {
   enrichment_ratio: number;
   dated_events: number;
   rated_films: number;
+  reviews_total: number;
+  /**
+   * Reviews that resolved to a film in the library. Only these can place a
+   * rating on either side of the reviewed/unreviewed split.
+   */
+  reviews_matched_to_films: number;
 }
 
 export interface ProfileStatsTotals {
@@ -1242,6 +1302,71 @@ export interface ProfileStatsHighestRated {
   director: { name: string; count: number; average_rating: number } | null;
 }
 
+export interface ProfileStatsRewatchedFilm {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  /**
+   * Watches as the diary holds them. A count of 1 beside a rewatch is real:
+   * Letterboxd allows a rewatch flag when the original viewing was never
+   * logged, and that missing viewing is not invented here.
+   */
+  watch_count: number;
+  rating: number | null;
+}
+
+/**
+ * What a profile returns to. `average_rating_rewatched` and
+ * `average_rating_once` are two averages over two self-selected halves of the
+ * same library — never a before-and-after of what rewatching does to a rating.
+ */
+export interface ProfileStatsRewatches {
+  total_rewatches: number;
+  films_rewatched: number;
+  /** 0..1. Null for an empty library, which has no rate rather than a rate of zero. */
+  rewatch_rate: number | null;
+  most_rewatched: ProfileStatsRewatchedFilm[];
+  average_rating_rewatched: number | null;
+  average_rating_once: number | null;
+}
+
+export interface ProfileStatsLongestReview {
+  title: string;
+  year: number | null;
+  length_chars: number;
+}
+
+export interface ProfileStatsLikedReview {
+  title: string;
+  year: number | null;
+  likes_count: number;
+  published_date: string | null;
+}
+
+/** Reviews published in a given calendar year; undated reviews belong to none. */
+export interface ProfileStatsReviewYear {
+  year: number;
+  count: number;
+}
+
+/**
+ * Writing habits. As with rewatches, the two averages describe which films get
+ * written about, not what writing does to a rating.
+ */
+export interface ProfileStatsReviews {
+  total_reviews: number;
+  /** Reviews carrying prose; a rating logged bare has no length, not a length of 0. */
+  with_text: number;
+  spoiler_reviews: number;
+  median_length_chars: number | null;
+  longest: ProfileStatsLongestReview | null;
+  most_liked: ProfileStatsLikedReview[];
+  reviews_by_year: ProfileStatsReviewYear[];
+  average_rating_reviewed: number | null;
+  average_rating_unreviewed: number | null;
+}
+
 export interface ProfileStatsResponse {
   username: string;
   coverage: ProfileStatsCoverage;
@@ -1255,6 +1380,13 @@ export interface ProfileStatsResponse {
   /** Ascending by decade, labelled like "1990s". */
   decades: ProfileStatsBucket[];
   highest_rated: ProfileStatsHighestRated;
+  /**
+   * Always present, even for a profile with neither: counts fall to zero and
+   * every average, median and headline film falls to null, so the client can
+   * say "none yet" instead of guessing whether the block failed to compute.
+   */
+  rewatches: ProfileStatsRewatches;
+  reviews: ProfileStatsReviews;
   /**
    * Letterboxd's own stats-page figures, verbatim, for side-by-side
    * comparison. Null when that Patron-only page was never scraped, and the
@@ -1340,6 +1472,141 @@ export const ratingComparisonApi = {
   getComparison: async (username: string, limit = 10): Promise<RatingComparisonResponse> => {
     const response = await api.get(
       `/api/profiles/${encodeURIComponent(username)}/rating-comparison`,
+      { params: { limit } },
+    );
+    return response.data;
+  },
+};
+
+/**
+ * How much of the watchlist the queue below stands on. `watchlist_films` counts
+ * only *unwatched* rows and is the denominator for everything else here, so a
+ * client can say how much of the list the circle can actually speak to.
+ */
+export interface WatchlistInsightsCoverage {
+  watchlist_films: number;
+  /** Unwatched films at least one other tracked profile has rated. */
+  rated_by_group: number;
+  /** Unwatched films carrying Letterboxd's own crowd average. */
+  with_letterboxd_average: number;
+}
+
+export interface WatchlistRater {
+  username: string;
+  rating: number;
+}
+
+export interface WatchlistRecommendation {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  /** Averaged over *other* tracked profiles only — never this member's own rating. */
+  group_average: number | null;
+  group_raters: number;
+  liked_by: number;
+  letterboxd_average: number | null;
+  added_date: string | null;
+  /** Null when the import carried no added date: an unknown wait, not a zero-day one. */
+  days_waiting: number | null;
+  /** Up to a handful of the members behind the average, best rating first. */
+  raters: WatchlistRater[];
+}
+
+export interface WatchlistWaitingFilm {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  added_date: string | null;
+  days_waiting: number | null;
+}
+
+export interface WatchlistGenreCount {
+  label: string;
+  count: number;
+}
+
+export interface WatchlistInsightsResponse {
+  username: string;
+  coverage: WatchlistInsightsCoverage;
+  recommendations: WatchlistRecommendation[];
+  longest_waiting: WatchlistWaitingFilm[];
+  genre_skew: WatchlistGenreCount[];
+  totals: {
+    /** Both read dated rows only; null when nothing on the list carried a date. */
+    median_days_waiting: number | null;
+    oldest_days_waiting: number | null;
+  };
+}
+
+export const watchlistInsightsApi = {
+  getInsights: async (username: string, limit = 20): Promise<WatchlistInsightsResponse> => {
+    const response = await api.get(
+      `/api/profiles/${encodeURIComponent(username)}/watchlist-insights`,
+      { params: { limit } },
+    );
+    return response.data;
+  },
+};
+
+/**
+ * The rated films the obscurity index could be computed over. Films the
+ * crowd-rating backfill has not reached are excluded rather than counted as an
+ * audience of zero, so this pair is the caveat for the median.
+ */
+export interface ObscurityCoverage {
+  rated_films: number;
+  films_with_rating_count: number;
+}
+
+/** Which way this profile's audience sizes lean against the rest of the circle. */
+export type ObscurityLean = 'obscure' | 'balanced' | 'mainstream';
+
+export interface ObscurityIndex {
+  /** Audience size of the typical rated film. A median: audience sizes are wildly skewed. */
+  median_rating_count: number | null;
+  mean_rating_count: number | null;
+  /** 100 means every other tracked profile watches bigger films. Null with no one to compare to. */
+  percentile_vs_group: number | null;
+  /** Read straight off the percentile, so label and number can never disagree. */
+  lean: ObscurityLean | null;
+}
+
+export interface ObscurityFilm {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  rating_count: number | null;
+  profile_rating: number;
+}
+
+export interface ObscurityCrowdPosition {
+  title: string;
+  year: number | null;
+  poster_url: string | null;
+  letterboxd_url: string | null;
+  profile_rating: number;
+  /** 0..1 share of the crowd's own histogram sitting at or below this rating. */
+  share_at_or_below: number;
+  crowd_average: number | null;
+}
+
+export interface ObscurityResponse {
+  username: string;
+  coverage: ObscurityCoverage;
+  index: ObscurityIndex;
+  most_obscure: ObscurityFilm[];
+  most_mainstream: ObscurityFilm[];
+  /** Empty — never null — until the rating-distribution backfill has been run. */
+  crowd_position: ObscurityCrowdPosition[];
+}
+
+export const obscurityApi = {
+  getObscurity: async (username: string, limit = 10): Promise<ObscurityResponse> => {
+    const response = await api.get(
+      `/api/profiles/${encodeURIComponent(username)}/obscurity`,
       { params: { limit } },
     );
     return response.data;

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -17,8 +17,10 @@ import AdminScopeToggle from '../components/AdminScopeToggle';
 import ProfileHeader from '../components/ProfileHeader';
 import ProfilePicker from '../components/ProfilePicker';
 import ArchivePanel from '../components/insights/ArchivePanel';
+import ObscurityPanel from '../components/insights/ObscurityPanel';
 import ProfileStatsPanel from '../components/insights/ProfileStatsPanel';
 import RatingComparisonPanel from '../components/insights/RatingComparisonPanel';
+import WatchlistPanel from '../components/insights/WatchlistPanel';
 import TasteProfilePanel from '../components/insights/TasteProfilePanel';
 import TagsPanel, { TagChipList } from '../components/insights/TagsPanel';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
@@ -169,6 +171,10 @@ const Analysis: React.FC = () => {
           <ProfileStatsPanel username={analysis.username} delay={0.08} />
 
           <RatingComparisonPanel username={analysis.username} delay={0.1} />
+
+          <ObscurityPanel username={analysis.username} delay={0.12} />
+
+          <WatchlistPanel username={analysis.username} delay={0.14} />
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
             <StatsCard


### PR DESCRIPTION
Five datasets that were being collected and never read.

## Watchlist intelligence
**1,711 queued films, 648 already rated by someone in the circle** — previously zero insight. Now a queue ranked by what your circle actually thought.

Ranking uses a **confidence-weighted score**, not the raw average. A single 5.0 is weaker evidence than five people at 4.6, and sorting on the mean put the lone opinion on top — most of what surfaced that way rested on one rater. Each average is shrunk toward what a film typically scores from this circle (**3.48** across the tracked set).

That prior had to come from their whole rating history: a prior drawn from the watchlist candidates is inflated by the very films being ranked. A test caught this — the first version looked right on real data and was wrong in principle.

Real effect for whiteknight03x: *Incendies* (4.6 from **5**) now tops the queue instead of a lone 5.0.

## Obscurity index
Letterboxd rating counts span **205 → 6,110,855** — a 30,000× range that makes "how mainstream is this taste" computable, which Letterboxd never shows. Headline is the **median** audience size, so one blockbuster among hundreds of small films can't dominate.

## Rating distribution kept, not discarded
The histogram's ten buckets were parsed and thrown away. The markup carries each bucket twice — exact in a `title` attribute, abbreviated in the visible label. The exact figures win because abbreviations are lossy (**off by 80,202 on one film**), and their sum reconciles with the published total exactly.

## Spy signals can see the follow graph
`insights.py` had **zero** references to `profile_follow_edges`. A gap event now reports whether the later watcher follows the earlier one — stated as sequence, never influence.

## Rewatch and review patterns
322 rewatches and 2,261 review texts, previously unread. Includes whether someone rates films they return to higher than films they watched once.

## Verification
**544 backend tests** pass; `tsc` + `next build` green. All five verified against the real local database with real titles and numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)