### PR TITLE
Stop entrance animations from stranding pages invisible, and deliver the histogram

### DIFF
--- a/backend/api/routes/film_ratings.py
+++ b/backend/api/routes/film_ratings.py
@@ -35,7 +35,7 @@ from api.dependencies import get_active_upload_user
 from auth import ClerkUser
 from database.connection import get_db
 from database.models import Movie
-from services.letterboxd_ratings import resolve_slug
+from services.letterboxd_ratings import BUCKET_KEYS, resolve_slug
 
 
 LOGGER = logging.getLogger("spyboxd.film_ratings")
@@ -62,11 +62,38 @@ class FilmRatingEntry(BaseModel):
     slug: str = Field(..., max_length=250)
     average_rating: Optional[float] = None
     rating_count: Optional[int] = None
+    rating_distribution: Optional[Dict[str, int]] = None
     synced_at: Optional[datetime] = None
 
 
 class FilmRatingBatch(BaseModel):
     ratings: List[FilmRatingEntry] = Field(..., min_length=1, max_length=MAX_BATCH_SIZE)
+
+
+def _usable_distribution(
+    distribution: Optional[Dict[str, int]]
+) -> Optional[Dict[str, int]]:
+    """Return the histogram if it is safe to store, otherwise ``None``.
+
+    Every key has to be one of the ten half-star buckets the scraper emits, but
+    *all ten* are not required: Letterboxd omits a bucket nobody has voted in,
+    and films in the tracked library really do come back with nine or seven.
+    Demanding a full ten here would drop those on the floor.
+
+    Sizes are bounded like ``rating_count`` and may not be negative, since the
+    column feeds a crowd-position share whose denominator is their sum. Pydantic
+    has already made every value an ``int`` by the time this runs, so only the
+    range is left to check here.
+    """
+
+    if not distribution:
+        return None
+    for key, size in distribution.items():
+        if key not in BUCKET_KEYS:
+            return None
+        if not 0 <= size <= MAX_RATING_COUNT:
+            return None
+    return dict(distribution)
 
 
 def _as_utc(value: Optional[datetime]) -> Optional[datetime]:
@@ -117,18 +144,32 @@ def ingest_letterboxd_ratings(
     backfill applies in ``services.letterboxd_ratings``. A null ``rating_count``
     likewise leaves the stored count alone. ``synced_at`` records when the
     residential machine read the figure, falling back to the request time.
+
+    ``distributions_written`` and ``distributions_rejected`` are reported
+    alongside, and sit outside the ``received`` identity on purpose: the
+    histogram rides along with the average rather than replacing it, so a film
+    can be ``updated`` while carrying no usable histogram.
     """
 
     received = len(payload.ratings)
     request_time = datetime.now(timezone.utc)
 
-    # (slug, average, count, synced_at) for entries worth writing.
-    prepared: List[Tuple[str, float, Optional[int], datetime]] = []
+    # (slug, average, count, distribution, synced_at) for entries worth writing.
+    prepared: List[
+        Tuple[str, float, Optional[int], Optional[Dict[str, int]], datetime]
+    ] = []
     skipped = 0
+    distributions_rejected = 0
     for entry in payload.ratings:
         slug = resolve_slug(entry.slug, None)
         average = entry.average_rating
         count = entry.rating_count
+        distribution = _usable_distribution(entry.rating_distribution)
+        # A malformed histogram must not cost the film its average, which is the
+        # primary payload and validated separately. Drop the histogram, keep the
+        # average, and report the drop rather than swallowing it.
+        if entry.rating_distribution is not None and distribution is None:
+            distributions_rejected += 1
         usable = (
             slug is not None
             and average is not None
@@ -141,14 +182,21 @@ def ingest_letterboxd_ratings(
             skipped += 1
             continue
         prepared.append(
-            (slug.lower(), float(average), count, _as_utc(entry.synced_at) or request_time)
+            (
+                slug.lower(),
+                float(average),
+                count,
+                distribution,
+                _as_utc(entry.synced_at) or request_time,
+            )
         )
 
-    matches = _movies_by_slug(db, {slug for slug, _, _, _ in prepared})
+    matches = _movies_by_slug(db, {slug for slug, _, _, _, _ in prepared})
 
     updated = 0
     unmatched = 0
-    for slug, average, count, synced_at in prepared:
+    distributions_written = 0
+    for slug, average, count, distribution, synced_at in prepared:
         movies = matches.get(slug)
         if not movies:
             unmatched += 1
@@ -157,7 +205,13 @@ def ingest_letterboxd_ratings(
             movie.letterboxd_average_rating = average
             if count is not None:
                 movie.letterboxd_rating_count = count
+            # A null histogram is "this push carried none", not "the film has
+            # none", so it never clears one production already holds.
+            if distribution is not None:
+                movie.letterboxd_rating_distribution = distribution
             movie.letterboxd_rating_synced_at = synced_at
+        if distribution is not None:
+            distributions_written += 1
         updated += 1
 
     try:
@@ -173,4 +227,6 @@ def ingest_letterboxd_ratings(
         "updated": updated,
         "unmatched": unmatched,
         "skipped": skipped,
+        "distributions_written": distributions_written,
+        "distributions_rejected": distributions_rejected,
     }

--- a/backend/tests/test_film_ratings_push.py
+++ b/backend/tests/test_film_ratings_push.py
@@ -147,7 +147,7 @@ def test_matching_slug_writes_the_letterboxd_average(client, database):
     )
 
     assert response.status_code == 200
-    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0}
+    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0, "distributions_written": 0, "distributions_rejected": 0}
 
     stored = _reload(database, movie)
     assert stored.letterboxd_average_rating == pytest.approx(4.12)
@@ -169,7 +169,7 @@ def test_slug_matching_is_case_insensitive_in_both_directions(client, database):
         ],
     )
 
-    assert response.json() == {"received": 2, "updated": 2, "unmatched": 0, "skipped": 0}
+    assert response.json() == {"received": 2, "updated": 2, "unmatched": 0, "skipped": 0, "distributions_written": 0, "distributions_rejected": 0}
     assert _reload(database, stored_lower).letterboxd_average_rating == pytest.approx(4.12)
     assert _reload(database, stored_mixed).letterboxd_average_rating == pytest.approx(3.87)
 
@@ -186,7 +186,7 @@ def test_unknown_slugs_are_reported_not_fatal(client, database):
     )
 
     assert response.status_code == 200
-    assert response.json() == {"received": 2, "updated": 1, "unmatched": 1, "skipped": 0}
+    assert response.json() == {"received": 2, "updated": 1, "unmatched": 1, "skipped": 0, "distributions_written": 0, "distributions_rejected": 0}
     # The rest of the batch still landed.
     assert _reload(database, known).letterboxd_average_rating == pytest.approx(4.12)
 
@@ -204,7 +204,7 @@ def test_out_of_range_averages_are_skipped_before_the_check_constraint(client, d
     )
 
     assert response.status_code == 200
-    assert response.json() == {"received": 2, "updated": 0, "unmatched": 0, "skipped": 2}
+    assert response.json() == {"received": 2, "updated": 0, "unmatched": 0, "skipped": 2, "distributions_written": 0, "distributions_rejected": 0}
     assert _reload(database, high).letterboxd_average_rating == pytest.approx(3.0)
     assert _reload(database, low).letterboxd_average_rating == pytest.approx(3.0)
 
@@ -223,7 +223,7 @@ def test_non_finite_averages_are_skipped(client, database, literal):
     )
 
     assert response.status_code == 200
-    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1, "distributions_written": 0, "distributions_rejected": 0}
     assert _reload(database, movie).letterboxd_average_rating == pytest.approx(3.0)
 
 
@@ -239,7 +239,7 @@ def test_impossible_rating_counts_are_skipped(client, database, rating_count):
         ],
     )
 
-    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1, "distributions_written": 0, "distributions_rejected": 0}
     stored = _reload(database, movie)
     assert stored.letterboxd_average_rating == pytest.approx(3.0)
     assert stored.letterboxd_rating_count == 10
@@ -256,7 +256,7 @@ def test_null_average_never_clobbers_a_known_value(client, database):
 
     response = _post(client, [_entry("the-brutalist", average_rating=None, rating_count=999)])
 
-    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1}
+    assert response.json() == {"received": 1, "updated": 0, "unmatched": 0, "skipped": 1, "distributions_written": 0, "distributions_rejected": 0}
     stored = _reload(database, movie)
     assert stored.letterboxd_average_rating == pytest.approx(4.12)
     assert stored.letterboxd_rating_count == 250_000
@@ -270,7 +270,7 @@ def test_null_rating_count_keeps_the_stored_count(client, database):
 
     response = _post(client, [_entry("the-brutalist", average_rating=4.2, rating_count=None)])
 
-    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0}
+    assert response.json() == {"received": 1, "updated": 1, "unmatched": 0, "skipped": 0, "distributions_written": 0, "distributions_rejected": 0}
     stored = _reload(database, movie)
     assert stored.letterboxd_average_rating == pytest.approx(4.2)
     assert stored.letterboxd_rating_count == 250_000
@@ -302,7 +302,7 @@ def test_counts_always_account_for_every_submitted_entry(client, database):
     body = response.json()
     assert body["received"] == 4
     assert body["updated"] + body["unmatched"] + body["skipped"] == body["received"]
-    assert body == {"received": 4, "updated": 1, "unmatched": 1, "skipped": 2}
+    assert body == {"received": 4, "updated": 1, "unmatched": 1, "skipped": 2, "distributions_written": 0, "distributions_rejected": 0}
 
 
 def test_oversized_batch_is_rejected_outright(client, database):
@@ -382,3 +382,111 @@ def test_pusher_respects_the_limit_and_chunks_into_batches(database):
 
     assert len(entries) == 3
     assert [len(batch) for batch in batches] == [2, 1]
+
+
+# --- Rating distribution ----------------------------------------------------
+#
+# The histogram is the crowd-position feature's whole input. The migration and
+# the read path shipped before this transport existed, so production held the
+# column and no way to fill it; these pin the delivery.
+
+_HISTOGRAM = {
+    "0.5": 3, "1.0": 31, "1.5": 21, "2.0": 103, "2.5": 75,
+    "3.0": 114, "3.5": 22, "4.0": 16, "4.5": 2, "5.0": 2,
+}
+
+
+def test_a_histogram_reaches_the_column_the_read_path_expects(client, database):
+    movie = _film(database, "the-brutalist")
+
+    response = _post(client, [_entry("the-brutalist", rating_distribution=_HISTOGRAM)])
+
+    assert response.status_code == 200
+    assert response.json()["distributions_written"] == 1
+    assert _reload(database, movie).letterboxd_rating_distribution == _HISTOGRAM
+
+
+def test_a_partial_histogram_is_kept_because_letterboxd_omits_empty_buckets(
+    client, database
+):
+    """Films really do come back with fewer than ten buckets.
+
+    Letterboxd renders no row for a rating nobody has given, so demanding all
+    ten would silently drop real films rather than store what they have.
+    """
+    movie = _film(database, "obscure-short")
+    partial = {"2.0": 4, "3.0": 9, "3.5": 1}
+
+    response = _post(client, [_entry("obscure-short", rating_distribution=partial)])
+
+    assert response.json()["distributions_written"] == 1
+    assert _reload(database, movie).letterboxd_rating_distribution == partial
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        pytest.param({"6.0": 10}, id="bucket outside the half-star scale"),
+        pytest.param({"3": 10}, id="unpadded key the scraper never emits"),
+        pytest.param({"3.0": -1}, id="negative bucket size"),
+        pytest.param({"3.0": 10**13}, id="impossible bucket size"),
+        pytest.param({"": 5}, id="empty key"),
+    ],
+)
+def test_a_malformed_histogram_is_rejected_without_costing_the_film_its_average(
+    client, database, bad
+):
+    """The average is the primary payload and is validated separately.
+
+    A histogram this endpoint cannot trust must not take a good average down
+    with it, and must be reported rather than dropped in silence.
+    """
+    movie = _film(database, "the-brutalist")
+
+    response = _post(
+        client, [_entry("the-brutalist", average_rating=4.2, rating_distribution=bad)]
+    )
+
+    body = response.json()
+    assert body["updated"] == 1
+    assert body["distributions_written"] == 0
+    assert body["distributions_rejected"] == 1
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == 4.2
+    assert stored.letterboxd_rating_distribution is None
+
+
+def test_a_push_carrying_no_histogram_never_clears_one_already_stored(client, database):
+    """A null means "this push carried none", not "the film has none"."""
+    movie = _film(database, "the-brutalist")
+    _post(client, [_entry("the-brutalist", rating_distribution=_HISTOGRAM)])
+
+    response = _post(client, [_entry("the-brutalist", average_rating=4.4)])
+
+    body = response.json()
+    assert body["updated"] == 1
+    assert body["distributions_written"] == 0
+    assert body["distributions_rejected"] == 0
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == 4.4
+    assert stored.letterboxd_rating_distribution == _HISTOGRAM
+
+
+def test_the_pusher_sends_the_histogram_it_holds(database):
+    """collect_ratings must carry the column, or nothing reaches production."""
+    _film(database, "the-brutalist", average=4.1)
+    stored = database.query(Movie).filter(Movie.letterboxd_slug == "the-brutalist").one()
+    stored.letterboxd_rating_distribution = _HISTOGRAM
+    database.commit()
+
+    entries, _ = collect_ratings(database)
+
+    assert [entry["rating_distribution"] for entry in entries] == [_HISTOGRAM]
+
+
+def test_the_pusher_sends_null_for_a_film_with_no_histogram(database):
+    _film(database, "unscraped", average=3.3)
+
+    entries, _ = collect_ratings(database)
+
+    assert entries[0]["rating_distribution"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -15,6 +15,51 @@ const PROFILE_NAMES = [
 
 export const MISSING_POSTER_URL = 'https://assets.spyboxd.test/missing-poster.jpg';
 
+/**
+ * A follow graph with real edges, so the network view can be driven end to end.
+ *
+ * Deterministic rather than random: `alpha` is deliberately the busiest node so
+ * a test can assert an ordering, and every pair is spelled out so a changed
+ * rollup shows up as a diff rather than as arithmetic nobody re-checks.
+ */
+const FOLLOW_PAIRS: Array<[string, string, boolean, boolean]> = [
+  // [a, b, a_follows_b, b_follows_a]
+  ['alpha', 'bravo', true, true],
+  ['alpha', 'charlie', true, true],
+  ['alpha', 'delta', true, false],
+  ['alpha', 'echo', false, true],
+  ['bravo', 'charlie', true, true],
+  ['bravo', 'delta', true, false],
+  ['charlie', 'echo', false, true],
+  ['delta', 'echo', true, true],
+];
+
+export const followMutuals = {
+  profiles: ['alpha', 'bravo', 'charlie', 'delta', 'echo'],
+  pairs: FOLLOW_PAIRS.map(([a, b, aFollowsB, bFollowsA]) => ({
+    a,
+    b,
+    a_follows_b: aFollowsB,
+    b_follows_a: bFollowsA,
+    mutual: aFollowsB && bFollowsA,
+  })),
+  rollups: FOLLOW_PAIRS.reduce<
+    Record<string, { follows_in_group: number; followed_by_in_group: number }>
+  >((totals, [a, b, aFollowsB, bFollowsA]) => {
+    totals[a] ??= { follows_in_group: 0, followed_by_in_group: 0 };
+    totals[b] ??= { follows_in_group: 0, followed_by_in_group: 0 };
+    if (aFollowsB) {
+      totals[a].follows_in_group += 1;
+      totals[b].followed_by_in_group += 1;
+    }
+    if (bFollowsA) {
+      totals[b].follows_in_group += 1;
+      totals[a].followed_by_in_group += 1;
+    }
+    return totals;
+  }, {}),
+};
+
 export const profiles = PROFILE_NAMES.map((username, index) => ({
   username,
   display_name: username[0].toUpperCase() + username.slice(1),
@@ -1039,10 +1084,13 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     });
   }
 
-  // Social graph (contract-shaped empty states until fixtures grow edges).
+  // Social graph. The mutuals fixture carries real edges: an empty graph
+  // renders "no follow connections" and leaves every node, the ego view and the
+  // deep-dive hand-off untestable, which is how a blank-on-back regression
+  // reached production unnoticed.
   if (path === '/api/follow-graph/suggestions') return json(route, { suggestions: [] });
   if (path === '/api/follow-graph/mutuals') {
-    return json(route, { profiles: [], pairs: [], rollups: {} });
+    return json(route, followMutuals);
   }
   {
     // Patron-only stats, computed for everyone. Contract-shaped so the

--- a/frontend/e2e/network-back-navigation.spec.ts
+++ b/frontend/e2e/network-back-navigation.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Opening a profile's deep dive from the network graph and pressing Back has to
+ * return to a rendered graph. The report was that it came back blank.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('returning from a deep dive re-renders the network graph', async ({ page }) => {
+  await page.goto('/network');
+
+  const panel = page.getByTestId('follow-network');
+  await expect(panel).toBeVisible();
+
+  // Centre a tracked profile, then open its deep dive from the centre.
+  const centreNode = page.getByRole('button', { name: /^Centre the network on @/ }).first();
+  await expect(centreNode).toBeVisible();
+  await centreNode.click();
+
+  const openDeepDive = page.getByRole('button', { name: /deep dive analysis$/ }).first();
+  await expect(openDeepDive).toBeVisible();
+  await openDeepDive.click();
+  await expect(page).toHaveURL(/\/analysis\?profile=/);
+
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/network/);
+  await expect(page.getByRole('heading', { name: 'Network', level: 1 })).toBeVisible();
+  // The header alone is not enough — the graph panel itself must come back,
+  // with clickable nodes rather than an empty frame.
+  await expect(panel).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /^Centre the network on @/ }).first(),
+  ).toBeVisible();
+});
+
+test('page content is actually painted, not just present in the DOM', async ({ page }) => {
+  // Playwright's visibility check ignores opacity, so `toBeVisible` passed on a
+  // page users saw as blank. Three nested entrance animations each started at
+  // opacity 0 and multiply down the tree; when a route change stranded them
+  // part-way the product reached ~0.02. Assert the painted result.
+  const effectiveOpacity = () =>
+    page.evaluate(() => {
+      const heading = [...document.querySelectorAll('h1')].find(
+        (node) => node.textContent?.trim() === 'Network',
+      );
+      let element: HTMLElement | null = heading ?? null;
+      let product = 1;
+      while (element && element !== document.documentElement) {
+        product *= parseFloat(getComputedStyle(element).opacity);
+        element = element.parentElement;
+      }
+      return product;
+    });
+
+  await page.goto('/network');
+  await expect.poll(effectiveOpacity).toBeGreaterThan(0.99);
+
+  await page.getByRole('button', { name: /^Centre the network on @/ }).first().click();
+  await page.getByRole('button', { name: /deep dive analysis$/ }).first().click();
+  await expect(page).toHaveURL(/\/analysis\?profile=/);
+  await page.goBack();
+
+  await expect(page).toHaveURL(/\/network/);
+  await expect.poll(effectiveOpacity).toBeGreaterThan(0.99);
+});
+
+test('a failed follow-graph request explains itself instead of rendering nothing', async ({
+  page,
+}) => {
+  // The panel used to `return null` on error, so any failed request -- a token
+  // refresh landing mid-navigation, a dropped connection -- left the page blank
+  // with no way to recover, since the query does not retry.
+  await page.route('**/api/follow-graph/mutuals*', (route) =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: '{"detail":"boom"}' }),
+  );
+
+  await page.goto('/network');
+
+  await expect(page.getByRole('heading', { name: 'Network', level: 1 })).toBeVisible();
+  const panel = page.getByTestId('follow-network');
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText(/could not be loaded/i)).toBeVisible();
+  await expect(panel.getByRole('button', { name: /try again/i })).toBeVisible();
+});

--- a/frontend/src/components/FollowNetwork.tsx
+++ b/frontend/src/components/FollowNetwork.tsx
@@ -897,7 +897,37 @@ export default function FollowNetwork({
     );
   };
 
-  if (networkQuery.error) return null;
+  // Returning nothing here read as a blank page: leaving for a deep dive aborts
+  // the in-flight request, which lands the query in an error state that
+  // ``retry: false`` never leaves, so coming back rendered an empty panel with
+  // no way out. Say what happened and offer the way out instead.
+  if (networkQuery.error) {
+    return (
+      <motion.section
+        aria-label="Follow network"
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, delay: 0.1 }}
+        className="panel-insight p-5"
+        data-testid="follow-network"
+      >
+        <header className="flex items-center gap-2.5">
+          <Share2 className="h-4 w-4 text-cinema-300" aria-hidden="true" />
+          <h2 className="text-lg font-bold text-white">Network</h2>
+        </header>
+        <p className="mt-3 text-sm text-white/55">
+          The follow network could not be loaded.
+        </p>
+        <button
+          type="button"
+          onClick={() => networkQuery.refetch()}
+          className="mt-3 rounded-lg border border-white/15 bg-white/5 px-3 py-1.5 text-xs font-semibold text-white/80 transition hover:bg-white/10"
+        >
+          Try again
+        </button>
+      </motion.section>
+    );
+  }
 
   return (
     <motion.section

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -83,12 +83,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const pathname = usePathname();
   const { isSignedIn } = useAuth();
   const currentUserQuery = useCurrentUser(Boolean(isSignedIn));
-  const [isLoaded, setIsLoaded] = useState(false);
   const [currentTime, setCurrentTime] = useState<Date | null>(null);
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
+  // The clock is client-only so the server and client markup agree.
   useEffect(() => {
-    setIsLoaded(true);
     setCurrentTime(new Date());
   }, []);
 
@@ -99,12 +98,13 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     : 'Account';
 
   return (
-    <motion.div 
-      className="min-h-screen flex flex-col lg:flex-row"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: isLoaded ? 1 : 0 }}
-      transition={{ duration: 0.8, ease: "easeOut" }}
-    >
+    // Whether the app is visible at all must not depend on a JavaScript
+    // animation finishing. This wrapper used to fade the entire shell in, and
+    // an interrupted route change could strand it part-way -- three nested
+    // opacity animations multiply, so a stranded 0.16 here left the page at
+    // ~2% and read as blank. The entrance is CSS now: it cannot be interrupted
+    // into an invisible resting state.
+    <div className="min-h-screen flex flex-col lg:flex-row animate-fade-in">
       {/* Sidebar Navigation */}
       <motion.nav 
         className="relative z-50 w-full flex-shrink-0 border-b border-white/10 bg-[#081321]/95 backdrop-blur-xl lg:sticky lg:top-0 lg:h-screen lg:w-72 lg:border-b-0 lg:border-r lg:bg-black/20"
@@ -315,25 +315,19 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           </div>
         </motion.header>
 
-        {/* Page Content with Animation */}
+        {/* Page content. Keyed on the path so the entrance replays per route.
+            `AnimatePresence mode="wait"` used to hold the incoming page until
+            the outgoing one finished exiting, which is what stranded it on a
+            browser Back: the enter never ran and the page sat at its initial
+            opacity of 0. CSS replaces it, so a route change cannot leave
+            content invisible. */}
         <div className="flex-1 p-4 sm:p-6">
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={pathname}
-              initial={{ opacity: 0, y: 20, scale: 0.98 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: -20, scale: 1.02 }}
-              transition={{ 
-                duration: 0.4, 
-                ease: [0.25, 0.46, 0.45, 0.94] 
-              }}
-            >
-              {children}
-            </motion.div>
-          </AnimatePresence>
+          <div key={pathname} className="animate-fade-up">
+            {children}
+          </div>
         </div>
       </main>
-    </motion.div>
+    </div>
   );
 };
 

--- a/frontend/src/views/Analysis.tsx
+++ b/frontend/src/views/Analysis.tsx
@@ -104,8 +104,8 @@ const Analysis: React.FC = () => {
   return (
     <motion.div
       className="space-y-8"
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 20 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.6 }}
     >
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -225,8 +225,8 @@ export default function Compare() {
   return (
     <motion.div
       className="space-y-6"
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 12 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.4 }}
     >
       <header className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">

--- a/frontend/src/views/Dashboard.tsx
+++ b/frontend/src/views/Dashboard.tsx
@@ -105,8 +105,8 @@ const Dashboard: React.FC = () => {
     return (
       <motion.div
         className="space-y-8"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
+        initial={{ y: 20 }}
+        animate={{ y: 0 }}
         transition={{ duration: 0.6 }}
       >
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/frontend/src/views/Network.tsx
+++ b/frontend/src/views/Network.tsx
@@ -58,8 +58,8 @@ export default function Network() {
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 12 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.4 }}
       className="space-y-6"
     >

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -358,8 +358,8 @@ const ProfileManager: React.FC = () => {
   return (
     <motion.div
       className="space-y-8"
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 20 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.6 }}
     >
       <motion.div

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -48,8 +48,8 @@ export default function PublicDashboard() {
     <>
       <motion.section
         className="space-y-3 py-4"
-        initial={{ opacity: 0, y: 16 }}
-        animate={{ opacity: 1, y: 0 }}
+        initial={{ y: 16 }}
+        animate={{ y: 0 }}
       >
         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cinema-300">Public dashboard</p>
         <h1 className="max-w-4xl text-4xl font-bold leading-tight text-white text-glow sm:text-5xl">

--- a/frontend/src/views/SpySignals.tsx
+++ b/frontend/src/views/SpySignals.tsx
@@ -147,8 +147,8 @@ const SpySignals: React.FC = () => {
   return (
     <motion.div
       className="space-y-6"
-      initial={{ opacity: 0, y: 18 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 18 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.5 }}
     >
       <header className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/frontend/src/views/WatchTogether.tsx
+++ b/frontend/src/views/WatchTogether.tsx
@@ -210,8 +210,8 @@ export default function WatchTogether() {
   return (
     <motion.div
       className="space-y-6"
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: 12 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.4 }}
     >
       <header className="relative z-40 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">

--- a/scripts/push_letterboxd_ratings.py
+++ b/scripts/push_letterboxd_ratings.py
@@ -78,6 +78,7 @@ def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[D
             Movie.letterboxd_url,
             Movie.letterboxd_average_rating,
             Movie.letterboxd_rating_count,
+            Movie.letterboxd_rating_distribution,
             Movie.letterboxd_rating_synced_at,
         )
         .filter(Movie.letterboxd_average_rating.isnot(None))
@@ -88,7 +89,7 @@ def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[D
 
     entries: List[Dict[str, Any]] = []
     skipped_no_slug = 0
-    for slug, url, average, count, synced_at in query.all():
+    for slug, url, average, count, distribution, synced_at in query.all():
         resolved = resolve_slug(slug, url)
         if not resolved:
             skipped_no_slug += 1
@@ -98,6 +99,13 @@ def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[D
                 "slug": resolved,
                 "average_rating": float(average),
                 "rating_count": int(count) if count is not None else None,
+                # Sent only when this machine actually holds one; the receiver
+                # treats a null as "not carried" and keeps what it has.
+                "rating_distribution": (
+                    {key: int(size) for key, size in distribution.items()}
+                    if isinstance(distribution, dict) and distribution
+                    else None
+                ),
                 "synced_at": synced_at.isoformat() if synced_at is not None else None,
             }
         )


### PR DESCRIPTION
Two defects in what shipped last, both found from a real report.

## The network page came back blank

Opening a profile's deep dive and pressing Back left the page blank. The request was fine (`mutuals` → **200**) and the markup was all there. The page was painted at **1.8% opacity**.

Three entrance animations nest on every route:

| Layer | Source |
|---|---|
| App shell | `Layout.tsx` — `animate={{opacity: isLoaded ? 1 : 0}}` |
| Page transition | `Layout.tsx` — `AnimatePresence mode="wait"` keyed on pathname |
| View root | 8 views — `initial={{opacity: 0}}` |

Opacity multiplies down the tree, so all three had to finish. Measured on the live page they were stranded at **0.309, 0.371 and 0.161** and stayed there — **0.0185** together. `mode="wait"` holds the incoming page until the outgoing one has exited, which is how a browser Back leaves the enter animation unrun.

Whether the app is visible cannot depend on a JavaScript animation finishing. The two shell wrappers are CSS now — a CSS animation cannot be interrupted into an invisible resting state — and the eight view roots still slide but no longer animate opacity at all.

**Playwright agreed the page was visible throughout**, because its visibility check ignores opacity. The regression test multiplies computed opacity up the ancestor chain and asserts what actually reaches the screen.

The network route had **no end-to-end coverage of any kind**, and the mutuals fixture was an empty graph — so nodes, ego focus and the deep-dive hand-off were all untested. The fixture now carries real edges.

## The histogram could never have reached production

The column, the migration and the read path all shipped. But the pusher sends `(slug, average, count, synced_at)` and `FilmRatingEntry` had no field for a histogram — so the crowd-position panel would have sat empty forever.

Both ends carry it now. Buckets validate against the ten half-star keys **without requiring all ten**: Letterboxd omits a bucket nobody voted in, and real films in the library come back with nine or seven — demanding ten would have silently dropped them. A histogram that cannot be trusted is dropped and reported (`distributions_rejected`) rather than costing the film its average.

## Verification
554 backend tests; **46/46 Playwright pass** (the suite is green serially — the failures seen in parallel runs are the local dev server's lazy route compilation losing a race, not the tests). `tsc`, `eslint`, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)