### PR TITLE
Never let an entrance animation own whether content is visible

### DIFF
--- a/frontend/e2e/network-back-navigation.spec.ts
+++ b/frontend/e2e/network-back-navigation.spec.ts
@@ -58,7 +58,12 @@ test('page content is actually painted, not just present in the DOM', async ({ p
     });
 
   await page.goto('/network');
-  await expect.poll(effectiveOpacity).toBeGreaterThan(0.99);
+  // Checked immediately, not polled. Polling waits for the entrance animation
+  // to finish, which is exactly the assumption that broke: an animation clock
+  // that never advances (a background tab freezes it at its first keyframe)
+  // leaves the page at whatever that keyframe says. No ancestor may start from
+  // transparent, so the content is already painted before anything animates.
+  expect(await effectiveOpacity()).toBeGreaterThan(0.99);
 
   await page.getByRole('button', { name: /^Centre the network on @/ }).first().click();
   await page.getByRole('button', { name: /deep dive analysis$/ }).first().click();
@@ -66,7 +71,7 @@ test('page content is actually painted, not just present in the DOM', async ({ p
   await page.goBack();
 
   await expect(page).toHaveURL(/\/network/);
-  await expect.poll(effectiveOpacity).toBeGreaterThan(0.99);
+  expect(await effectiveOpacity()).toBeGreaterThan(0.99);
 });
 
 test('a failed follow-graph request explains itself instead of rendering nothing', async ({

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -98,13 +98,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     : 'Account';
 
   return (
-    // Whether the app is visible at all must not depend on a JavaScript
-    // animation finishing. This wrapper used to fade the entire shell in, and
-    // an interrupted route change could strand it part-way -- three nested
-    // opacity animations multiply, so a stranded 0.16 here left the page at
-    // ~2% and read as blank. The entrance is CSS now: it cannot be interrupted
-    // into an invisible resting state.
-    <div className="min-h-screen flex flex-col lg:flex-row animate-fade-in">
+    // The shell has no entrance animation at all. It used to fade itself in,
+    // and because opacity multiplies down the tree that made the whole app's
+    // visibility depend on an animation finishing -- stranded, the page read as
+    // blank. Nothing decorative is worth that.
+    <div className="min-h-screen flex flex-col lg:flex-row">
       {/* Sidebar Navigation */}
       <motion.nav 
         className="relative z-50 w-full flex-shrink-0 border-b border-white/10 bg-[#081321]/95 backdrop-blur-xl lg:sticky lg:top-0 lg:h-screen lg:w-72 lg:border-b-0 lg:border-r lg:bg-black/20"
@@ -322,7 +320,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             opacity of 0. CSS replaces it, so a route change cannot leave
             content invisible. */}
         <div className="flex-1 p-4 sm:p-6">
-          <div key={pathname} className="animate-fade-up">
+          <div key={pathname} className="animate-rise-in">
             {children}
           </div>
         </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -85,6 +85,7 @@ module.exports = {
         '3xl': '40px',
       },
       animation: {
+        'rise-in': 'riseIn 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
         'fade-in': 'fadeIn 0.5s ease-in-out',
         'fade-up': 'fadeUp 0.5s ease-out',
         'slide-in': 'slideIn 0.3s ease-out',
@@ -95,6 +96,16 @@ module.exports = {
         'shimmer': 'shimmer 2s linear infinite',
       },
       keyframes: {
+        // Entrance for anything whose visibility matters. Every other keyframe
+        // here starts at `opacity: 0`, which makes the animation own whether
+        // the content can be seen -- and an animation clock that never advances
+        // (a background tab freezes it at 0%) then leaves the page blank. This
+        // one only moves, so a frozen clock costs a few pixels of offset
+        // instead of the entire page.
+        riseIn: {
+          '0%': { transform: 'translateY(12px)' },
+          '100%': { transform: 'translateY(0)' },
+        },
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },


### PR DESCRIPTION
Verifying #76 on the live site turned up the same defect in a new form.

The shell and page wrappers no longer used JavaScript, but their CSS entrances still began at `opacity: 0` — so the animation still decided whether anything could be seen. **A background tab freezes an animation clock at its first keyframe.** Measured on production:

```
visibility: "hidden"
playState:  "running"   currentTime: 0    ← clock never advances
computed opacity: 0     effective: 0.0000
```

The page was completely blank until the tab was focused.

The previous code had the same hole through throttled `requestAnimationFrame`, so this is not a regression — but it is not fixed either, and swapping one mechanism for another that fails identically is not a fix.

## The rule
Every keyframe in the config started from transparent, which made all of them unsafe for anything load-bearing:

| keyframe | starts at |
|---|---|
| `fadeIn` | `opacity: 0` |
| `fadeUp` | `opacity: 0` |
| `slideIn` | `opacity: 0` |
| `scaleIn` | `opacity: 0` |
| **`riseIn`** (new) | **transform only** |

`riseIn` only moves, so a frozen clock costs twelve pixels of offset rather than the entire page. The shell has **no** entrance at all — nothing decorative justifies gating the whole app behind an animation completing.

## The test
The regression test no longer polls. Polling waits for the animation to finish, which is precisely the assumption that fails — it would have passed against this bug. The assertion is immediate, so an ancestor that starts transparent is caught while it still is:

- opacity-based entrance → `Received: 0.283823` ❌
- transform-only entrance → `> 0.99` ✅

## Verification
`tsc`, `eslint`, `next build` clean. **46/46 Playwright pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)