### PR TITLE
Compute semantic neighbours instead of returning an empty list

### DIFF
--- a/backend/services/insights.py
+++ b/backend/services/insights.py
@@ -63,6 +63,43 @@ WATCH_TOGETHER_MODES = {
     "collective_blind_spots",
     "list_mission",
 }
+# Semantic neighbours: two people watching *different* films that are contextually
+# the same thing, close together in time. Only high-signal dimensions qualify --
+# "both watched a drama" is not a contextual match, it is a coincidence, and a
+# panel that says otherwise is noise. Ordered strongest first; the first
+# dimension that matches a pair of films wins, so the stated reason is the
+# strongest true one rather than the last one checked.
+SEMANTIC_NEIGHBOR_DIMENSIONS = (
+    ("director", "Both watched {article} {label} film"),
+    ("keyword", "Both explored {label}"),
+    ("actor", "Both watched {label}"),
+)
+SEMANTIC_NEIGHBOR_GAP_DAYS = 21
+# TMDB keywords mix themes with production trivia. "Both explored
+# duringcreditsstinger" is not an observation about anyone's taste, so the
+# non-thematic ones are dropped rather than shown as one.
+SEMANTIC_NEIGHBOR_KEYWORD_STOPLIST = {
+    "aftercreditsstinger",
+    "duringcreditsstinger",
+    "woman director",
+    "women directors",
+    "female director",
+    "based on novel or book",
+    "based on true story",
+    "based on comic",
+    "based on young adult novel",
+    "live action remake",
+    "remake",
+    "sequel",
+    "prequel",
+    "imax",
+    "3d",
+    "silent film",
+}
+# A trait shared by this many films across the group is a category, not a
+# connection, and pairing every film in it would be quadratic for no insight.
+SEMANTIC_NEIGHBOR_MAX_TRAIT_SIZE = 60
+
 SEASON_ORDER = ("winter", "spring", "summer", "autumn")
 SEASON_MONTHS = {
     "winter": (12, 1, 2),
@@ -2300,6 +2337,101 @@ class InsightsService:
             )
         return []
 
+    def _semantic_neighbors(
+        self,
+        profiles: Sequence[Profile],
+        states: Sequence[StateRow],
+        limit: int,
+    ) -> List[Dict[str, Any]]:
+        """Different films, watched by different people, that are the same thing.
+
+        The panel's promise is "contextual matches, not exact-title co-watches",
+        so a pair sharing a ``movie_id`` is excluded by construction: that is an
+        ordinary co-watch and every other surface already reports it.
+
+        Needs at least two profiles to be a match between anyone, and a date on
+        both sides to claim they happened close together.
+        """
+
+        if len(profiles) < 2:
+            return []
+
+        best: Dict[Tuple[int, int], Dict[str, Any]] = {}
+        for rank, (dimension, template) in enumerate(SEMANTIC_NEIGHBOR_DIMENSIONS):
+            buckets: Dict[str, Tuple[str, List[StateRow]]] = {}
+            for row in states:
+                if row.latest_watched_date is None:
+                    continue
+                for label in self._trait_values(row, dimension):
+                    key = label.casefold()
+                    if dimension == "keyword" and key in SEMANTIC_NEIGHBOR_KEYWORD_STOPLIST:
+                        continue
+                    if key not in buckets:
+                        buckets[key] = (label, [])
+                    buckets[key][1].append(row)
+
+            for label, rows in buckets.values():
+                if len(rows) > SEMANTIC_NEIGHBOR_MAX_TRAIT_SIZE:
+                    continue
+                for index, left in enumerate(rows):
+                    for right in rows[index + 1 :]:
+                        if left.profile_id == right.profile_id:
+                            continue
+                        if left.movie_id == right.movie_id:
+                            continue
+                        gap = abs(
+                            (left.latest_watched_date - right.latest_watched_date).days
+                        )
+                        if gap > SEMANTIC_NEIGHBOR_GAP_DAYS:
+                            continue
+                        pair = (min(left.movie_id, right.movie_id), max(left.movie_id, right.movie_id))
+                        existing = best.get(pair)
+                        # Strongest dimension wins; within one dimension the
+                        # closest pair in time is the better illustration.
+                        if existing is not None and (
+                            existing["_rank"] < rank
+                            or (existing["_rank"] == rank and existing["day_gap"] <= gap)
+                        ):
+                            continue
+                        later, earlier = (
+                            (left, right)
+                            if left.latest_watched_date >= right.latest_watched_date
+                            else (right, left)
+                        )
+                        best[pair] = {
+                            "movie": self._movie_summary(later.movie, later.enrichment),
+                            # "a Alex Garland film" is the sort of thing a reader
+                            # notices instead of the insight.
+                            "reason": template.format(
+                                label=label,
+                                article="an" if label[:1].lower() in "aeiou" else "a",
+                            ),
+                            # Ordered by who got there first, which is the only
+                            # claim the dates support.
+                            "watched_by": [earlier.username, later.username],
+                            "day_gap": gap,
+                            "_rank": rank,
+                        }
+
+        ordered = sorted(
+            best.values(),
+            key=lambda entry: (entry["_rank"], entry["day_gap"], entry["movie"]["title"]),
+        )
+        # One card per film. Two different pairs can share a displayed film --
+        # two Park Chan-wook matches both surface "Decision to Leave" -- and the
+        # panel renders posters, so that reads as the same entry twice. The
+        # first survivor is already the strongest by the sort above.
+        deduped: List[Dict[str, Any]] = []
+        seen_titles: set = set()
+        for entry in ordered:
+            identity = entry["movie"].get("movie_id") or entry["movie"].get("title")
+            if identity in seen_titles:
+                continue
+            seen_titles.add(identity)
+            entry.pop("_rank", None)
+            deduped.append(entry)
+        return deduped[:limit]
+
     @staticmethod
     def _alignment_sort_key(trait: Dict[str, Any], profile_count: int) -> Tuple:
         """Order a dimension by how much the profiles actually agree.
@@ -2474,7 +2606,7 @@ class InsightsService:
             "shared_signature": signature_candidates[:limit],
             "contrasts": [item[1] for item in contrast_candidates[:limit]],
             "dimensions": dimension_payloads,
-            "semantic_neighbors": [],
+            "semantic_neighbors": self._semantic_neighbors(profiles, states, limit),
         }
 
     @staticmethod

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -1508,3 +1508,185 @@ class FollowAwareSignalTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SemanticNeighborTests(unittest.TestCase):
+    """Different films that are contextually the same thing.
+
+    The panel promised "contextual matches, not exact-title co-watches" and the
+    backend returned a hard-coded empty list from the first commit onward, so the
+    section was always blank. These pin what it may and may not claim.
+    """
+
+    def setUp(self) -> None:
+        self.service = InsightsService(db=None)
+        self.profiles = [
+            Profile(id=1, username="ana", is_active=True, scraping_status="completed"),
+            Profile(id=2, username="ben", is_active=True, scraping_status="completed"),
+        ]
+
+    def _movie(self, movie_id: int, title: str) -> Movie:
+        return Movie(
+            id=movie_id,
+            canonical_key=f"letterboxd:{movie_id}",
+            title=title,
+            normalized_title=title.casefold(),
+            release_year=2024,
+            letterboxd_slug=f"film-{movie_id}",
+        )
+
+    def _state(
+        self,
+        profile_index: int,
+        movie_id: int,
+        title: str,
+        watched: date,
+        *,
+        director: str | None = None,
+        keywords: tuple[str, ...] = (),
+    ) -> StateRow:
+        profile = self.profiles[profile_index]
+        crew = [{"name": director, "job": "Director"}] if director else []
+        return StateRow(
+            profile_id=profile.id,
+            username=profile.username,
+            movie_id=movie_id,
+            rating=None,
+            liked=False,
+            tags=[],
+            first_watched_date=watched,
+            latest_watched_date=watched,
+            watch_count=1,
+            rewatch_count=0,
+            movie=self._movie(movie_id, title),
+            enrichment=MovieEnrichment(
+                movie_id=movie_id,
+                genres=[],
+                keywords=list(keywords),
+                credits={"crew": crew, "cast": []},
+                production_countries=[],
+            ),
+        )
+
+    def _neighbors(self, states, *, limit: int = 8, profiles=None):
+        return self.service._semantic_neighbors(
+            profiles if profiles is not None else self.profiles, states, limit
+        )
+
+    def test_two_different_films_by_one_director_are_a_neighbour(self) -> None:
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+            self._state(1, 11, "Decision to Leave", date(2026, 7, 3), director="Park Chan-wook"),
+        ])
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["movie"]["title"], "Decision to Leave")
+        self.assertEqual(result[0]["reason"], "Both watched a Park Chan-wook film")
+        self.assertEqual(result[0]["day_gap"], 2)
+
+    def test_the_same_film_is_a_co_watch_and_never_a_semantic_neighbour(self) -> None:
+        """The panel's whole promise is that these are NOT exact-title co-watches."""
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+            self._state(1, 10, "Oldboy", date(2026, 7, 2), director="Park Chan-wook"),
+        ])
+
+        self.assertEqual(result, [])
+
+    def test_one_person_watching_two_related_films_is_not_a_match_between_anyone(self) -> None:
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+            self._state(0, 11, "Thirst", date(2026, 7, 2), director="Park Chan-wook"),
+        ])
+
+        self.assertEqual(result, [])
+
+    def test_a_single_profile_can_have_no_neighbours(self) -> None:
+        result = self._neighbors(
+            [self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook")],
+            profiles=self.profiles[:1],
+        )
+
+        self.assertEqual(result, [])
+
+    def test_films_watched_further_apart_than_the_window_are_not_related_in_time(self) -> None:
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 6, 1), director="Park Chan-wook"),
+            self._state(1, 11, "Thirst", date(2026, 7, 15), director="Park Chan-wook"),
+        ])
+
+        self.assertEqual(result, [])
+
+    def test_a_film_without_a_watch_date_cannot_claim_closeness_in_time(self) -> None:
+        undated = self._state(1, 11, "Thirst", date(2026, 7, 2), director="Park Chan-wook")
+        undated = StateRow(**{**undated.__dict__, "latest_watched_date": None})
+
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+            undated,
+        ])
+
+        self.assertEqual(result, [])
+
+    def test_watched_by_names_the_earlier_watcher_first(self) -> None:
+        result = self._neighbors([
+            self._state(1, 11, "Thirst", date(2026, 7, 5), director="Park Chan-wook"),
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+        ])
+
+        self.assertEqual(result[0]["watched_by"], ["ana", "ben"])
+
+    def test_production_trivia_is_not_a_shared_theme(self) -> None:
+        """TMDB keywords mix themes with credits metadata.
+
+        "Both explored duringcreditsstinger" reached the real UI before this.
+        """
+        result = self._neighbors([
+            self._state(0, 10, "A", date(2026, 7, 1), keywords=("duringcreditsstinger", "woman director")),
+            self._state(1, 11, "B", date(2026, 7, 2), keywords=("duringcreditsstinger", "woman director")),
+        ])
+
+        self.assertEqual(result, [])
+
+    def test_one_card_per_film_even_when_several_pairs_point_at_it(self) -> None:
+        """Two Park Chan-wook pairs both surfaced "Decision to Leave" as duplicates."""
+        result = self._neighbors([
+            self._state(0, 10, "Oldboy", date(2026, 7, 1), director="Park Chan-wook"),
+            self._state(0, 12, "Thirst", date(2026, 7, 2), director="Park Chan-wook"),
+            self._state(1, 11, "Decision to Leave", date(2026, 7, 3), director="Park Chan-wook"),
+        ])
+
+        titles = [entry["movie"]["title"] for entry in result]
+        self.assertEqual(titles, sorted(set(titles)))
+        self.assertEqual(titles.count("Decision to Leave"), 1)
+
+    def test_a_director_match_outranks_a_shared_keyword(self) -> None:
+        result = self._neighbors([
+            self._state(0, 10, "A", date(2026, 7, 1), director="Agnes Varda", keywords=("grief",)),
+            self._state(1, 11, "B", date(2026, 7, 2), director="Agnes Varda", keywords=("grief",)),
+        ])
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("Agnes Varda", result[0]["reason"])
+
+    def test_a_vowel_initial_name_takes_the_right_article(self) -> None:
+        result = self._neighbors([
+            self._state(0, 10, "A", date(2026, 7, 1), director="Alex Garland"),
+            self._state(1, 11, "B", date(2026, 7, 2), director="Alex Garland"),
+        ])
+
+        self.assertEqual(result[0]["reason"], "Both watched an Alex Garland film")
+
+    def test_the_limit_trims_without_reordering(self) -> None:
+        states = [
+            self._state(0, 10, "A", date(2026, 7, 1), director="Wong Kar-Wai"),
+            self._state(1, 11, "B", date(2026, 7, 2), director="Wong Kar-Wai"),
+            self._state(0, 12, "C", date(2026, 7, 1), director="Michael Mann"),
+            self._state(1, 13, "D", date(2026, 7, 8), director="Michael Mann"),
+        ]
+
+        full = self._neighbors(states, limit=8)
+        trimmed = self._neighbors(states, limit=1)
+
+        self.assertEqual(len(trimmed), 1)
+        self.assertEqual(trimmed[0]["movie"]["title"], full[0]["movie"]["title"])

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -1078,8 +1078,35 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
           },
         ],
       },
+      // The real endpoint always returns this block, and the panel reads
+      // `summary.similarity_score` unguarded. Omitting it here threw
+      // "Cannot read properties of undefined" and took the whole tab down,
+      // which is why nothing under it was ever exercised.
+      summary: {
+        similarity_score: 72.5,
+        shared_rated_titles: 35,
+        metadata_coverage_ratio: 0.92,
+        tmdb_status: 'connected',
+      },
       shared_signature: [],
       contrasts: [],
+      // Carries entries on purpose. The backend returned a hard-coded empty
+      // list from the first commit, and because the fixture omitted the field
+      // too, nothing ever noticed the panel was permanently blank.
+      semantic_neighbors: [
+        {
+          movie: { movie_id: 501, title: 'Decision to Leave', release_year: 2022, poster_url: null },
+          reason: 'Both watched a Park Chan-wook film',
+          watched_by: [profiles[0].username, profiles[1].username],
+          day_gap: 2,
+        },
+        {
+          movie: { movie_id: 502, title: 'Fallen Angels', release_year: 1995, poster_url: null },
+          reason: 'Both watched a Wong Kar-Wai film',
+          watched_by: [profiles[1].username, profiles[0].username],
+          day_gap: 3,
+        },
+      ],
       coverage: { status: 'ready', score: 100, blockers: [], warnings: [] },
     });
   }

--- a/frontend/e2e/semantic-neighbors.spec.ts
+++ b/frontend/e2e/semantic-neighbors.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The Compare page's "Semantic neighbors" panel shipped with a heading, a
+ * promise ("contextual matches, not exact-title co-watches") and a backend that
+ * returned a hard-coded empty list, so it was blank for every user from the
+ * first commit onward. Assert it renders what it is given.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the semantic neighbors panel renders its entries', async ({ page }) => {
+  await page.goto('/compare?tab=taste');
+
+  const heading = page.getByRole('heading', { name: 'Semantic neighbors' });
+  await expect(heading).toBeVisible();
+
+  // The panel is a heading plus its cards; a heading alone is the bug.
+  const panel = page.locator('section').filter({ has: heading });
+  await expect(panel.getByText('Decision to Leave')).toBeVisible();
+  await expect(panel.getByText('Both watched a Park Chan-wook film')).toBeVisible();
+  await expect(panel.getByText('Fallen Angels')).toBeVisible();
+});


### PR DESCRIPTION
The Compare page's **"Semantic neighbors"** panel has been blank for every user since the first commit.

Not a data problem — `taste_dna` returned this literal, and it was the *only* reference to the field in the entire backend:

```python
"semantic_neighbors": [],
```

The heading, the explanatory copy and the card layout all shipped around a value nothing ever produced.

## What it computes now
The panel promises "contextual matches, not exact-title co-watches", so a pair sharing a `movie_id` is excluded by construction — that's an ordinary co-watch every other surface already reports. What's left is two people watching **different** films that are contextually the same thing, close in time.

Only high-signal dimensions qualify — "both watched a drama" is a coincidence, not a connection:

| dimension | used | reason shown |
|---|---|---|
| director | ✅ | "Both watched a Park Chan-wook film" |
| keyword | ✅ | "Both explored coming of age" |
| cast | ✅ | "Both watched Tilda Swinton" |
| genre / country | ❌ | too generic to be a match |

Real output for `whiteknight03x + er3nweeber`:
```
Mission: Impossible – Fallout   Both watched a Christopher McQuarrie film   0d
Monster                         Both watched a Hirokazu Kore-eda film       1d
Decision to Leave               Both watched a Park Chan-wook film          2d
Fallen Angels                   Both watched a Wong Kar-Wai film            3d
```

## Two faults found only against the real library
Checked against real data *before* writing tests, which is how these surfaced:

- **Duplicate cards** — two different Park Chan-wook pairs both surfaced "Decision to Leave", and the panel renders posters, so it read as the same card twice. Now one entry per film.
- **Production trivia as themes** — "Both explored duringcreditsstinger" and "woman director" are TMDB credits metadata, not taste. Stoplisted.

## The fixture hid it
The e2e fixture omitted the field, so the panel was as untestable as it was empty. Completing it exposed a second defect: no `summary` block either, the panel reads `summary.similarity_score` unguarded, and the resulting **TypeError took down the entire Taste DNA tab** — which is why nothing under it had ever been exercised.

## Verification
568 backend tests (12 new pinning co-watch exclusion, the time window, dedupe, the keyword stoplist and ordering). 47/47 Playwright. `tsc`, `eslint`, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)