### PR TITLE
Stop the sidebar and top bar fading in from invisible

### DIFF
--- a/frontend/e2e/network-back-navigation.spec.ts
+++ b/frontend/e2e/network-back-navigation.spec.ts
@@ -74,6 +74,34 @@ test('page content is actually painted, not just present in the DOM', async ({ p
   expect(await effectiveOpacity()).toBeGreaterThan(0.99);
 });
 
+test('navigation chrome is painted, not only the page content', async ({ page }) => {
+  // The first fix covered the shell and the view roots but left the sidebar and
+  // top bar fading in from `opacity: 0`. On production, with the tab
+  // backgrounded so no animation clock advances, the content was fully painted
+  // and the navigation was at 0 - invisible until the tab was focused.
+  await page.goto('/network');
+
+  const chromeOpacity = () =>
+    page.evaluate(() =>
+      ['nav', 'main > header'].map((selector) => {
+        const node = document.querySelector(selector);
+        if (!node) return { selector, opacity: null as number | null };
+        let element: HTMLElement | null = node as HTMLElement;
+        let product = 1;
+        while (element && element !== document.documentElement) {
+          product *= parseFloat(getComputedStyle(element).opacity);
+          element = element.parentElement;
+        }
+        return { selector, opacity: product };
+      }),
+    );
+
+  for (const entry of await chromeOpacity()) {
+    if (entry.opacity === null) continue;
+    expect(entry.opacity, `${entry.selector} must be painted`).toBeGreaterThan(0.99);
+  }
+});
+
 test('a failed follow-graph request explains itself instead of rendering nothing', async ({
   page,
 }) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -106,8 +106,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       {/* Sidebar Navigation */}
       <motion.nav 
         className="relative z-50 w-full flex-shrink-0 border-b border-white/10 bg-[#081321]/95 backdrop-blur-xl lg:sticky lg:top-0 lg:h-screen lg:w-72 lg:border-b-0 lg:border-r lg:bg-black/20"
-        initial={{ x: -100, opacity: 0 }}
-        animate={{ x: 0, opacity: 1 }}
+        initial={{ x: -100 }}
+        animate={{ x: 0 }}
         transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
       >
         <div className="flex h-full flex-col px-4 py-3 lg:p-6">
@@ -180,8 +180,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
             {/* System Status */}
             <motion.div
             className="mb-8 p-4 rounded-xl bg-white/5 border border-white/10 backdrop-blur-sm"
-            initial={{ y: 20, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
+            initial={{ y: 20 }}
+            animate={{ y: 0 }}
             transition={{ delay: 0.4 }}
           >
             <div className="flex items-center justify-between mb-2">
@@ -204,8 +204,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               return (
                 <motion.div
                   key={item.path}
-                  initial={{ x: -50, opacity: 0 }}
-                  animate={{ x: 0, opacity: 1 }}
+                  initial={{ x: -50 }}
+                  animate={{ x: 0 }}
                   transition={{ delay: 0.3 + (index * 0.1) }}
                 >
                   <Link href={item.path} onClick={() => setMobileNavOpen(false)}>
@@ -282,8 +282,8 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         {/* Top Header */}
         <motion.header 
           className="hidden border-b border-white/10 bg-black/10 px-6 py-3 backdrop-blur-md lg:block"
-          initial={{ y: -50, opacity: 0 }}
-          animate={{ y: 0, opacity: 1 }}
+          initial={{ y: -50 }}
+          animate={{ y: 0 }}
           transition={{ duration: 0.6, delay: 0.3 }}
         >
           <div className="flex min-h-11 items-center justify-between gap-4">


### PR DESCRIPTION
Verifying #77 on production found it **half applied**.

The shell and view roots no longer gate visibility on an animation completing — but the sidebar, top bar and two nav panels still entered from `opacity: 0`. Measured on the live site with the tab backgrounded:

```
page content:    opacity 1  ✅
semantic panel:  opacity 1  ✅
nav (sidebar):   opacity 0  ❌   inline: "opacity: 0; transform: translateX(-100px)"
```

The content was fully painted while the navigation was invisible until the tab was focused. Same defect class as #77, same rule — I'd only applied it to the shell and the view roots.

They keep their slide and no longer touch opacity, so a frozen animation clock costs a few pixels of offset rather than the navigation.

## What I deliberately did NOT change
Views still contain `initial={{ opacity: 0, y: 20 }}` on card entrances. Measured on production, **exactly one element under `main` was dim** — the top bar fixed here. Those card animations do not strand, so rewriting nine files on suspicion would be churn rather than a fix.

## Test
Asserts the chrome is painted, not only the content. Against the previous code it reports:
```
Error: nav must be painted
Received: 0
```

## Verification
579 backend tests, 48/48 Playwright, `tsc` + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)