### PR TITLE
Let a rating histogram travel without a weighted average

### DIFF
--- a/backend/api/routes/film_ratings.py
+++ b/backend/api/routes/film_ratings.py
@@ -155,8 +155,12 @@ def ingest_letterboxd_ratings(
     request_time = datetime.now(timezone.utc)
 
     # (slug, average, count, distribution, synced_at) for entries worth writing.
+    # The average is optional: Letterboxd publishes no weighted average below a
+    # rating threshold but still renders the histogram, and 75 films in the
+    # library are in exactly that state. Requiring one stranded their crowd
+    # position locally forever.
     prepared: List[
-        Tuple[str, float, Optional[int], Optional[Dict[str, int]], datetime]
+        Tuple[str, Optional[float], Optional[int], Optional[Dict[str, int]], datetime]
     ] = []
     skipped = 0
     distributions_rejected = 0
@@ -170,13 +174,19 @@ def ingest_letterboxd_ratings(
         # average, and report the drop rather than swallowing it.
         if entry.rating_distribution is not None and distribution is None:
             distributions_rejected += 1
+        # A value present but impossible means the entry is corrupt, and the
+        # whole thing is still skipped — the column CHECK constraints must never
+        # be what catches a bad payload. What has changed is only that an
+        # ABSENT average no longer disqualifies an entry: the histogram is
+        # writable on its own. Range tests are written this way round so NaN,
+        # which compares false against everything, fails them.
+        average_ok = average is None or MIN_AVERAGE_RATING <= average <= MAX_AVERAGE_RATING
+        count_ok = count is None or 0 <= count <= MAX_RATING_COUNT
         usable = (
             slug is not None
-            and average is not None
-            # Written as a range test so NaN — which compares false against
-            # everything — is skipped rather than stored.
-            and MIN_AVERAGE_RATING <= average <= MAX_AVERAGE_RATING
-            and (count is None or 0 <= count <= MAX_RATING_COUNT)
+            and average_ok
+            and count_ok
+            and (average is not None or distribution is not None)
         )
         if not usable:
             skipped += 1
@@ -184,7 +194,7 @@ def ingest_letterboxd_ratings(
         prepared.append(
             (
                 slug.lower(),
-                float(average),
+                None if average is None else float(average),
                 count,
                 distribution,
                 _as_utc(entry.synced_at) or request_time,
@@ -202,7 +212,11 @@ def ingest_letterboxd_ratings(
             unmatched += 1
             continue
         for movie in movies:
-            movie.letterboxd_average_rating = average
+            # Now that an entry may legitimately carry no average, assigning
+            # unconditionally would erase a stored one — the exact rule this
+            # endpoint has always promised not to break.
+            if average is not None:
+                movie.letterboxd_average_rating = average
             if count is not None:
                 movie.letterboxd_rating_count = count
             # A null histogram is "this push carried none", not "the film has

--- a/backend/tests/test_film_ratings_push.py
+++ b/backend/tests/test_film_ratings_push.py
@@ -547,3 +547,66 @@ def test_non_numeric_fields_in_the_response_are_not_summed(monkeypatch):
     assert totals["updated"] == 1
     assert "detail" not in totals
     assert "dry_run" not in totals
+
+
+def test_a_histogram_travels_without_an_average(client, database):
+    """Letterboxd publishes no weighted average below a rating threshold.
+
+    75 films in the library render ten buckets and no average. Requiring one at
+    both ends of this trip stranded their crowd position on the scraping
+    machine, where nothing reads it.
+    """
+    movie = _film(database, "obscure-classic")
+
+    response = _post(
+        client,
+        [{"slug": "obscure-classic", "average_rating": None, "rating_count": None,
+          "rating_distribution": _HISTOGRAM, "synced_at": None}],
+    )
+
+    body = response.json()
+    assert body["updated"] == 1
+    assert body["skipped"] == 0
+    assert body["distributions_written"] == 1
+    stored = _reload(database, movie)
+    assert stored.letterboxd_rating_distribution == _HISTOGRAM
+    assert stored.letterboxd_average_rating is None
+
+
+def test_an_entry_carrying_neither_average_nor_histogram_is_skipped(client, database):
+    _film(database, "nothing-to-say")
+
+    response = _post(client, [_entry("nothing-to-say", average_rating=None)])
+
+    assert response.json() == {
+        "received": 1, "updated": 0, "unmatched": 0, "skipped": 1,
+        "distributions_written": 0, "distributions_rejected": 0,
+    }
+
+
+def test_a_histogram_only_entry_never_erases_a_stored_average(client, database):
+    """An absent average is "not carried", which must not clear a known one."""
+    movie = _film(database, "known-average", average=4.2)
+
+    _post(
+        client,
+        [{"slug": "known-average", "average_rating": None, "rating_count": None,
+          "rating_distribution": _HISTOGRAM, "synced_at": None}],
+    )
+
+    stored = _reload(database, movie)
+    assert stored.letterboxd_average_rating == 4.2
+    assert stored.letterboxd_rating_distribution == _HISTOGRAM
+
+
+def test_the_pusher_sends_a_film_that_only_has_a_histogram(database):
+    _film(database, "histogram-only")
+    stored = database.query(Movie).filter(Movie.letterboxd_slug == "histogram-only").one()
+    stored.letterboxd_rating_distribution = _HISTOGRAM
+    database.commit()
+
+    entries, _ = collect_ratings(database)
+
+    assert [entry["slug"] for entry in entries] == ["histogram-only"]
+    assert entries[0]["average_rating"] is None
+    assert entries[0]["rating_distribution"] == _HISTOGRAM

--- a/scripts/push_letterboxd_ratings.py
+++ b/scripts/push_letterboxd_ratings.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 import requests
 from dotenv import load_dotenv
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 
@@ -81,7 +82,16 @@ def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[D
             Movie.letterboxd_rating_distribution,
             Movie.letterboxd_rating_synced_at,
         )
-        .filter(Movie.letterboxd_average_rating.isnot(None))
+        # A histogram alone is worth sending. Letterboxd publishes no weighted
+        # average below a rating threshold but still renders the ten buckets,
+        # and filtering on the average left those films' crowd position stuck
+        # on this machine.
+        .filter(
+            or_(
+                Movie.letterboxd_average_rating.isnot(None),
+                Movie.letterboxd_rating_distribution.isnot(None),
+            )
+        )
         .order_by(Movie.id)
     )
     if limit is not None:
@@ -97,7 +107,7 @@ def collect_ratings(db: Session, *, limit: Optional[int] = None) -> tuple[List[D
         entries.append(
             {
                 "slug": resolved,
-                "average_rating": float(average),
+                "average_rating": None if average is None else float(average),
                 "rating_count": int(count) if count is not None else None,
                 # Sent only when this machine actually holds one; the receiver
                 # treats a null as "not carried" and keeps what it has.


### PR DESCRIPTION
Letterboxd publishes no weighted average below a rating threshold but still renders the ten buckets. **75 films in the tracked library** are in exactly that state — real histograms with 25–153 ratings each.

Both ends of the delivery required an average:

```python
# pusher
.filter(Movie.letterboxd_average_rating.isnot(None))

# ingest
usable = slug is not None and average is not None and ...
```

So those films' crowd position stayed on the scraping machine, where nothing reads it. Same defect class as the histogram transport itself — data collected with no path to production.

## What changed
An entry qualifies when it carries **an average OR a histogram**.

## What deliberately did not change
Corrupt values still skip the whole entry — an average outside Letterboxd's 0–5 scale, or an impossible rating count. The column CHECK constraints must never be what catches a bad payload. My first attempt relaxed this too, and two existing tests caught it.

## The guard the change required
With the average optional, assigning it unconditionally would **erase a stored average** on any histogram-only push — breaking the "a null never overwrites" rule this endpoint has always kept. Now guarded, and tested.

## Verification
583 backend tests (4 new: histogram-only travels, neither-value is skipped, a histogram-only push preserves a known average, and the pusher selects such films). Dry run against production confirms the pusher now collects **5,246** films rather than 5,171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)