### PR TITLE
Store an unfilled TMDB runtime as unknown rather than zero

### DIFF
--- a/backend/services/tmdb_enrichment.py
+++ b/backend/services/tmdb_enrichment.py
@@ -167,7 +167,12 @@ def build_enrichment_values(details: Mapping[str, Any]) -> Dict[str, Any]:
     return {
         "original_title": str(details.get("original_title") or "").strip() or None,
         "overview": str(details.get("overview") or "").strip() or None,
-        "runtime_minutes": _positive_int(details.get("runtime")),
+        # TMDB writes 0 for a runtime nobody has filled in, and `_positive_int`
+        # keeps zero because other callers (display_priority) legitimately use
+        # it. A film of zero minutes does not exist, so store the absence: 55
+        # rows arrived as 0 before this and had to be defended against on every
+        # read, once landing 27 films in a "Under 90 min" taste bucket.
+        "runtime_minutes": _positive_int(details.get("runtime")) or None,
         "original_language": str(details.get("original_language") or "").strip() or None,
         "release_date": _parse_iso_date(details.get("release_date")),
         "genres": _as_list(details.get("genres")),

--- a/backend/tests/test_tmdb_enrichment.py
+++ b/backend/tests/test_tmdb_enrichment.py
@@ -762,3 +762,27 @@ class TMDBEnrichmentMappingTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RuntimeAbsenceTests(unittest.TestCase):
+    """TMDB writes 0 for a runtime nobody has filled in.
+
+    Stored as 0 it reads as a known length everywhere downstream: 55 rows
+    arrived that way and once put 27 films in an "Under 90 min" taste bucket on
+    the strength of runtimes nobody had recorded.
+    """
+
+    def _runtime(self, value):
+        return build_enrichment_values({"runtime": value})["runtime_minutes"]
+
+    def test_a_zero_runtime_is_stored_as_unknown(self):
+        self.assertIsNone(self._runtime(0))
+
+    def test_a_missing_runtime_is_unknown(self):
+        self.assertIsNone(self._runtime(None))
+
+    def test_a_negative_runtime_is_unknown(self):
+        self.assertIsNone(self._runtime(-5))
+
+    def test_a_real_runtime_survives(self):
+        self.assertEqual(self._runtime(132), 132)


### PR DESCRIPTION
TMDB writes `0` for a runtime nobody has filled in. `_positive_int` keeps zero because its other callers (`display_priority`) legitimately use it — so **55 enrichment rows arrived carrying 0**, which reads as a *known* length everywhere downstream:

- 27 films landed in an "Under 90 min" taste bucket on runtimes nobody recorded
- The same 0 slipped through Watch Together's `max_runtime` filter, because `0 > 90` is false

Those read paths were fixed in #80 where they are read, but the value should never have been stored in the first place. A film of zero minutes does not exist.

Existing rows keep their `0` and stay covered by the read guards; only new writes change. The **747 films currently being enriched on production** will store the absence instead — which is why this is worth landing now rather than later.

587 backend tests, 4 new covering 0, null, negative and a real runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)