### PR TITLE
Call the profile follows panel what it is, and link to the actual graph

### DIFF
--- a/frontend/e2e/profiles-follow-list.spec.ts
+++ b/frontend/e2e/profiles-follow-list.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The My Profiles card offered a control labelled "Follow graph" that expanded
+ * a tabbed list of following/followers. No graph was ever drawn there; the
+ * graph lives on the Network page.
+ */
+// The control sits in the admin view of the profile card.
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+});
+
+test('the profiles card offers a follows list, not a graph', async ({ page }) => {
+  await page.goto('/profiles');
+
+  // The button's accessible name comes from its aria-label; the visible text is
+  // checked separately.
+  const toggle = page.getByRole('button', { name: /follows and is followed by/i }).first();
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toContainText('Following');
+  // The old label promised something this panel never rendered.
+  await expect(page.getByRole('button', { name: /follow graph for/i })).toHaveCount(0);
+});
+
+test('the follows panel links to the real graph, centred on that profile', async ({ page }) => {
+  await page.goto('/profiles');
+
+  await page.getByRole('button', { name: /follows and is followed by/i }).first().click();
+
+  const link = page.getByRole('link', { name: /in the network graph/i }).first();
+  await expect(link).toBeVisible();
+  const href = await link.getAttribute('href');
+  expect(href).toMatch(/^\/network\?focus=/);
+
+  await link.click();
+  await expect(page).toHaveURL(/\/network\?focus=/);
+});

--- a/frontend/src/components/FollowNetwork.tsx
+++ b/frontend/src/components/FollowNetwork.tsx
@@ -329,11 +329,16 @@ function NodeAvatar({
 export default function FollowNetwork({
   profiles,
   onFocusChange,
+  initialFocus,
 }: {
   profiles: ProfileInfo[];
   /** Notified with the centred username, or null in the full view, so a
    *  surrounding page can follow the selection instead of contradicting it. */
   onFocusChange?: (username: string | null) => void;
+  /** Username to centre on when the graph first has nodes, so another page can
+   *  link straight to one profile's corner of the network. Applied once; the
+   *  user is free to walk elsewhere afterwards. */
+  initialFocus?: string | null;
 }) {
   const reactId = useId();
   const router = useRouter();
@@ -465,6 +470,18 @@ export default function FollowNetwork({
       setFocusKey(null);
     }
   }, [focusKey, groupIndexByKey, groupNodes.length]);
+
+  // Honour a requested starting profile once the group has loaded, and only
+  // once: re-applying it would fight the user every time they walked to a
+  // neighbour. A name that is not in the group is ignored rather than clearing
+  // the view.
+  const appliedInitialFocus = useRef(false);
+  useEffect(() => {
+    if (appliedInitialFocus.current || !initialFocus || groupNodes.length === 0) return;
+    appliedInitialFocus.current = true;
+    const key = initialFocus.toLowerCase();
+    if (groupIndexByKey.has(key)) setFocusKey(key);
+  }, [initialFocus, groupIndexByKey, groupNodes.length]);
 
   const focusNode = useMemo(
     () => (focusKey ? groupNodes.find((node) => node.key === focusKey) ?? null : null),

--- a/frontend/src/components/ProfileFollowGraph.tsx
+++ b/frontend/src/components/ProfileFollowGraph.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import { ExternalLink, Waypoints } from 'lucide-react';
 
 import { followGraphApi, type FollowGraphEdge } from '../services/api';
 import { ProfileAvatar } from './insights/InsightUI';
@@ -63,7 +64,7 @@ export default function ProfileFollowGraph({ username }: { username: string }) {
 
   return (
     <div className="mt-3 rounded-xl border border-white/10 bg-black/20 p-3" data-testid={`follow-graph-${username}`}>
-      <div className="flex items-center gap-1 rounded-lg border border-white/10 bg-black/20 p-1" role="tablist" aria-label={`Follow graph for ${username}`}>
+      <div className="flex items-center gap-1 rounded-lg border border-white/10 bg-black/20 p-1" role="tablist" aria-label={`Who ${username} follows and is followed by`}>
         {(['following', 'followers'] as const).map((option) => {
           const count = option === 'following' ? data?.following_count : data?.followers_count;
           const selected = direction === option;
@@ -86,7 +87,7 @@ export default function ProfileFollowGraph({ username }: { username: string }) {
       </div>
 
       {graphQuery.isLoading ? (
-        <p className="mt-3 text-xs text-white/45">Loading follow graph…</p>
+        <p className="mt-3 text-xs text-white/45">Loading follows…</p>
       ) : graphQuery.error || edges.length === 0 ? (
         <p className="mt-3 rounded-lg border border-white/[0.06] bg-black/15 p-3 text-xs text-white/45">
           No social data synced yet.
@@ -105,6 +106,15 @@ export default function ProfileFollowGraph({ username }: { username: string }) {
           )}
         </>
       )}
+      {/* The actual graph is drawn on the Network page. Linking there is what
+          makes the promise good, rather than a list under a graph heading. */}
+      <Link
+        href={`/network?focus=${encodeURIComponent(username)}`}
+        className="mt-3 flex items-center justify-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.03] px-3 py-1.5 text-[11px] font-semibold text-white/55 transition-colors hover:bg-white/10 hover:text-white"
+      >
+        <Waypoints className="h-3 w-3" aria-hidden="true" />
+        See @{username} in the network graph
+      </Link>
     </div>
   );
 }

--- a/frontend/src/views/Network.tsx
+++ b/frontend/src/views/Network.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import { useQuery } from '@tanstack/react-query';
 import { Trophy, Waypoints } from 'lucide-react';
@@ -10,6 +11,11 @@ import { followGraphApi } from '../services/api';
 import { useScopedProfiles } from '../hooks/useScopedProfiles';
 
 export default function Network() {
+  // `?focus=` lets another page hand off to one profile's corner of the graph.
+  // My Profiles links here rather than claiming to draw a graph of its own.
+  const searchParams = useSearchParams();
+  const requestedFocus = searchParams.get('focus');
+
   // The graph reports which profile is centred so the ranking can follow the
   // selection instead of sitting underneath it contradicting the view.
   const [focusedUsername, setFocusedUsername] = useState<string | null>(null);
@@ -73,7 +79,11 @@ export default function Network() {
         </p>
       </header>
 
-      <FollowNetwork profiles={completedProfiles} onFocusChange={handleFocusChange} />
+      <FollowNetwork
+        profiles={completedProfiles}
+        onFocusChange={handleFocusChange}
+        initialFocus={requestedFocus}
+      />
 
       {ranking.length > 0 && (
         <section className="rounded-xl border border-white/10 bg-white/5 p-4">

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -1131,11 +1131,14 @@ const ProfileManager: React.FC = () => {
                       type="button"
                       onClick={() => setOpenFollowGraph((current) => (current === profile.username ? null : profile.username))}
                       aria-expanded={openFollowGraph === profile.username}
-                      aria-label={`${openFollowGraph === profile.username ? 'Hide' : 'Show'} follow graph for ${profile.username}`}
+                      aria-label={`${openFollowGraph === profile.username ? 'Hide' : 'Show'} who ${profile.username} follows and is followed by`}
                       className="mt-3 flex w-full items-center justify-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs font-semibold text-white/60 transition-colors hover:bg-white/10 hover:text-white"
                     >
                       <Users className="h-3.5 w-3.5" />
-                      Follow graph
+                      {/* This panel is a list of follows, not a drawing of one.
+                          The graph lives on the Network page, which the panel
+                          links to. */}
+                      Following &amp; followers
                       {openFollowGraph === profile.username
                         ? <ChevronUp className="h-3.5 w-3.5" />
                         : <ChevronDown className="h-3.5 w-3.5" />}


### PR DESCRIPTION
The My Profiles card offered a control labelled **"Follow graph"** that expanded a tabbed list of following/followers. No graph was drawn there, and none ever had been — `ProfileFollowGraph` renders a `<ul>` of rows. The graph lives on the Network page.

## Change
- The control now reads **"Following & followers"**, and the stale "follow graph" wording inside the panel (tablist label, loading text) goes with it.
- The panel links to **`/network?focus=<username>`**, so the graph the old label promised is one click away rather than absent.
- `Network` reads `?focus=`; `FollowNetwork` accepts `initialFocus` and applies it **once**, when the group has loaded, and only if the name is in the group. It sets a starting point rather than pinning the view, so walking to a neighbour still works and a stale username is ignored rather than clearing the graph.

## Tests
Two new e2e cases: the card offers a follows list and no longer claims a graph, and the panel's link resolves to the focused network URL.

Note for reviewers: the button's accessible name comes from its `aria-label`, not its visible text — my first test asserted on the visible text via role name and failed for that reason.

50/50 Playwright, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)