### PR TITLE
Scope the profile catalog to the caller's own follow graph

### DIFF
--- a/backend/services/profile_access.py
+++ b/backend/services/profile_access.py
@@ -15,6 +15,7 @@ from database.models import (
     AppUser,
     Profile,
     ProfileAccessRequest,
+    ProfileFollowEdge,
     Rating,
     UserTrackedProfile,
 )
@@ -143,6 +144,54 @@ def tracked_profiles(
     )
 
 
+def _connected_profile_ids(db: Session, app_user: AppUser) -> set[int]:
+    """Profiles in the caller's own corner of the follow graph.
+
+    Connection is read in both directions and from both sides of the edge
+    table, because only one end of a pair may be synced: an edge stored on
+    someone else's profile naming the caller counts, and so does an edge stored
+    on the caller's own profile naming someone else. The caller's own profile is
+    included -- not being able to see yourself would be strange.
+
+    Returns an empty set when the caller has no linked Letterboxd username,
+    which is a real state (a fresh sign-up) and not an error.
+    """
+
+    handle = (app_user.letterboxd_username or "").strip().casefold()
+    if not handle:
+        return set()
+
+    connected: set[int] = set()
+
+    # Edges other profiles hold that name the caller.
+    connected.update(
+        profile_id
+        for (profile_id,) in db.query(ProfileFollowEdge.profile_id)
+        .filter(
+            ProfileFollowEdge.counterpart_username_normalized == handle,
+            ProfileFollowEdge.removed_at.is_(None),
+        )
+        .all()
+    )
+
+    own = _single_profile_by_normalized_username(db, handle)
+    if own is not None:
+        connected.add(own.id)
+        # Edges the caller's own profile holds that resolve to a synced profile.
+        connected.update(
+            counterpart_id
+            for (counterpart_id,) in db.query(ProfileFollowEdge.counterpart_profile_id)
+            .filter(
+                ProfileFollowEdge.profile_id == own.id,
+                ProfileFollowEdge.counterpart_profile_id.isnot(None),
+                ProfileFollowEdge.removed_at.is_(None),
+            )
+            .all()
+        )
+
+    return connected
+
+
 def list_profile_catalog(
     db: Session,
     clerk_user: ClerkUser,
@@ -156,6 +205,17 @@ def list_profile_catalog(
     The catalog intentionally exposes only recognition fields and aggregate film
     counts. Pending, errored, and inactive profiles stay in the admin library
     and are never offered as selectable monitoring targets.
+
+    For a non-admin the list is narrowed to their own corner of the follow
+    graph. Browsing every tracked profile revealed who Spyboxd watches, which is
+    not something Letterboxd publishes even though the profiles themselves are
+    public, and one sign-up would otherwise have been a directory of everybody
+    under observation. Reaching someone outside that corner still works: typing
+    a known username in "request another profile" resolves immediately when the
+    profile is already synced, so this restricts *discovery*, not access.
+
+    A caller with no linked Letterboxd username has no connections to compute,
+    so their catalog is empty and the request path is the way in.
     """
 
     app_user = ensure_app_user(db, clerk_user)
@@ -172,6 +232,9 @@ def list_profile_catalog(
         Profile.is_active.is_(True),
         Profile.scraping_status == "completed",
     )
+    if not clerk_user.is_admin:
+        connected = _connected_profile_ids(db, app_user)
+        query = query.filter(Profile.id.in_(connected) if connected else false())
     normalized_search = (search or "").strip().casefold()
     if normalized_search:
         pattern = f"%{normalized_search}%"

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -23,6 +23,7 @@ from backend.database.models import (
     ProfileAccessRequest,
     ProfileFavoriteMovie,
     ProfileFilm,
+    ProfileFollowEdge,
     Rating,
     Review,
     UserTrackedProfile,
@@ -74,6 +75,7 @@ def database():
             AppUser.__table__,
             UserTrackedProfile.__table__,
             ProfileAccessRequest.__table__,
+            ProfileFollowEdge.__table__,
             Movie.__table__,
             MovieEnrichment.__table__,
             MovieWatchProvider.__table__,
@@ -127,6 +129,19 @@ def _legacy_user(
         )
         database.commit()
     return _user(user_id, admin=admin)
+
+
+def _link_handle(database, clerk_user_id: str, handle: str) -> None:
+    """Give an app user a Letterboxd identity.
+
+    The catalog is scoped to the caller's own follow-graph corner, which cannot
+    be computed without one.
+    """
+    app_user = (
+        database.query(AppUser).filter(AppUser.clerk_user_id == clerk_user_id).one()
+    )
+    app_user.letterboxd_username = handle
+    database.commit()
 
 
 def _profile(profile_id: int, username: str, *, completed: bool = True) -> Profile:
@@ -609,8 +624,20 @@ def test_signed_in_catalog_lists_only_selectable_profiles_and_tracks_by_id(datab
             rating=4.0,
         )
     )
+    # The catalog is scoped to the caller's own follow-graph corner, so the
+    # selectable profile has to be connected to them to appear at all.
+    database.add(
+        ProfileFollowEdge(
+            id=1,
+            profile_id=1,
+            direction="follower",
+            counterpart_username="viewer",
+            counterpart_username_normalized="viewer",
+        )
+    )
     database.commit()
     user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
 
     initial = list_profile_catalog(database, user)
     assert initial["total"] == 1
@@ -636,9 +663,21 @@ def test_signed_in_catalog_lists_only_selectable_profiles_and_tracks_by_id(datab
 
 def test_profile_catalog_tracking_is_isolated_per_user(database):
     database.add(_profile(1, "Alpha"))
+    for index, handle in enumerate(("first_viewer", "second_viewer"), start=1):
+        database.add(
+            ProfileFollowEdge(
+                id=index,
+                profile_id=1,
+                direction="follower",
+                counterpart_username=handle,
+                counterpart_username_normalized=handle,
+            )
+        )
     database.commit()
     first_user = _legacy_user(database, "first")
     second_user = _legacy_user(database, "second")
+    _link_handle(database, "first", "first_viewer")
+    _link_handle(database, "second", "second_viewer")
 
     track_profile_by_id(database, first_user, 1)
 
@@ -1320,3 +1359,110 @@ def test_admin_allowlist_is_server_side_and_metadata_boolean_is_strict(monkeypat
     assert _payload_grants_admin({}, "user_admin") is True
     assert _payload_grants_admin({"metadata": {"is_admin": True}}, "regular") is True
     assert _payload_grants_admin({"public_metadata": {"is_admin": "false"}}, "regular") is False
+
+
+def _edge(edge_id: int, profile_id: int, handle: str, *, direction: str = "follower"):
+    return ProfileFollowEdge(
+        id=edge_id,
+        profile_id=profile_id,
+        direction=direction,
+        counterpart_username=handle,
+        counterpart_username_normalized=handle.casefold(),
+    )
+
+
+def test_a_non_admin_only_browses_their_own_corner_of_the_follow_graph(database):
+    """Browsing every tracked profile told a new sign-up who Spyboxd watches.
+
+    Letterboxd does not publish that list even though the profiles are public,
+    so the catalog is narrowed to people the caller is actually connected to.
+    """
+    connected = _profile(1, "Connected")
+    stranger = _profile(2, "Stranger")
+    database.add_all([connected, stranger])
+    database.add(_edge(1, connected.id, "viewer"))
+    database.commit()
+    user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
+
+    catalog = list_profile_catalog(database, user)
+
+    assert [entry["username"] for entry in catalog["profiles"]] == ["Connected"]
+    assert catalog["total"] == 1
+
+
+def test_an_admin_still_sees_the_whole_library(database):
+    database.add_all([_profile(1, "Alpha"), _profile(2, "Beta")])
+    database.commit()
+    admin = _legacy_user(database, "admin_user", admin=True)
+
+    catalog = list_profile_catalog(database, admin)
+
+    assert {entry["username"] for entry in catalog["profiles"]} == {"Alpha", "Beta"}
+
+
+def test_a_caller_with_no_linked_letterboxd_identity_browses_nothing(database):
+    """A fresh sign-up has no connections to compute, which is a real state.
+
+    They are not stuck: typing a known username still resolves.
+    """
+    database.add(_profile(1, "Alpha"))
+    database.commit()
+    user = _legacy_user(database)
+
+    catalog = list_profile_catalog(database, user)
+
+    assert catalog["profiles"] == []
+    assert catalog["total"] == 0
+
+
+def test_connection_counts_from_either_side_of_the_edge(database):
+    """Only one end of a pair may be synced, so both sides have to be read."""
+    theirs = _profile(1, "TheyFollowMe")
+    mine = _profile(2, "Viewer")
+    reached = _profile(3, "IFollowThem")
+    database.add_all([theirs, mine, reached])
+    database.add(_edge(1, theirs.id, "viewer"))
+    edge_out = _edge(2, mine.id, "ifollowthem", direction="following")
+    edge_out.counterpart_profile_id = reached.id
+    database.add(edge_out)
+    database.commit()
+    user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
+
+    usernames = {entry["username"] for entry in list_profile_catalog(database, user)["profiles"]}
+
+    # Their edge naming me, my edge naming them, and my own profile.
+    assert usernames == {"TheyFollowMe", "IFollowThem", "Viewer"}
+
+
+def test_a_removed_follow_edge_is_not_a_connection(database):
+    database.add(_profile(1, "Formerly"))
+    stale = _edge(1, 1, "viewer")
+    stale.removed_at = datetime.now(timezone.utc)
+    database.add(stale)
+    database.commit()
+    user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
+
+    assert list_profile_catalog(database, user)["profiles"] == []
+
+
+def test_a_known_username_outside_the_catalog_still_resolves_directly(database):
+    """The restriction is on discovery, not on access.
+
+    Someone who knows a username can still reach an already-synced profile
+    without an admin in the loop, which is what makes the narrower catalog
+    acceptable rather than obstructive.
+    """
+    database.add(_profile(1, "Unconnected"))
+    database.commit()
+    user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
+
+    assert list_profile_catalog(database, user)["profiles"] == []
+
+    result = track_or_request_profile(database, user, "Unconnected")
+
+    assert result["status"] == "tracked"
+    assert authorize_profile_usernames(database, user, None) == ["Unconnected"]

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -442,8 +442,9 @@ const ProfileManager: React.FC = () => {
               </span>
             </div>
             <p className="mt-2 max-w-3xl text-sm leading-6 text-white/60">
-              Select any synced profile already in Spyboxd. Your choices are private to your account, power the Monitored view in My Dashboard, and can be changed at any time.
-              {isAdmin ? ' The default global admin dashboard and library controls remain explicit and separate.' : ''}
+              {isAdmin
+                ? 'Select any synced profile already in Spyboxd. Your choices are private to your account, power the Monitored view in My Dashboard, and can be changed at any time. The default global admin dashboard and library controls remain explicit and separate.'
+                : 'Profiles you are connected to on Letterboxd. Your choices are private to your account, power the Monitored view in My Dashboard, and can be changed at any time. Know someone who is not listed? Ask for them by username below.'}
             </p>
           </div>
           <label className="relative w-full lg:max-w-sm">
@@ -470,7 +471,11 @@ const ProfileManager: React.FC = () => {
           </div>
         ) : catalogProfiles.length === 0 ? (
           <p className="mt-5 rounded-xl border border-white/10 bg-black/15 p-4 text-sm text-white/45">
-            {catalogSearchTerm.trim() ? 'No synced profiles match that search.' : 'No synced profiles are available yet.'}
+            {catalogSearchTerm.trim()
+              ? 'No synced profiles match that search.'
+              : isAdmin
+                ? 'No synced profiles are available yet.'
+                : 'Nobody you follow on Letterboxd is synced here yet. You can still ask for anyone by username below.'}
           </p>
         ) : (
           <>


### PR DESCRIPTION
Any signed-in account could browse **every** synced profile and monitor any of them instantly. The chain, verified in code:

1. `/profiles/catalog` — `get_current_user`, **no admin gate** → all 17 profiles
2. `trackExisting` — self-serve, no approval
3. `require_profile_access` — tracked ⇒ **full analytics**: watch history, ratings, reviews, social graph, spy signals

So one sign-up was a directory of everybody under observation. The profiles themselves are public on Letterboxd, but *the list of who Spyboxd watches* is not — and that list was the part being handed out.

## What changed
A non-admin's catalog is now the people they are actually connected to. Connection is read from **both sides** of the edge table, because only one end of a pair may be synced:

- an edge another profile holds naming the caller, **and**
- an edge the caller's own profile holds naming someone else (resolved via `counterpart_profile_id`)

Their own profile is included. Removed edges don't count. Admins still see the whole library.

## This restricts discovery, not access
Typing a known username in "request another profile" **already** resolves immediately when the profile is synced — that path is untouched. Nobody needs an admin in the loop to reach someone they already know of, which is what makes the narrower catalog acceptable rather than obstructive. There's a test pinning exactly that.

## Empty is a real state
A caller with no linked Letterboxd username has no connections to compute, so their catalog is empty. The copy now says *"Nobody you follow on Letterboxd is synced here yet. You can still ask for anyone by username below."* rather than looking broken.

## Verification
593 backend tests. Six new: connection-scoped browsing, admin still sees everything, no-identity sees nothing, both edge directions count, removed edges don't, and a known username outside the catalog still resolves. Two existing catalog tests encoded the old policy and were updated to the new one. 48/48 Playwright.

**No non-admin accounts exist yet** (`app_users` is empty), so nothing was exposed in practice — this closes it before the first sign-up rather than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)