### PR TITLE
Keep the newest matches in the Signal Feed, and stop promising unreachable rows

### DIFF
--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -441,29 +441,28 @@ def _calculate_event_source_timing(
             path["count"] += 1
             add_sample(path, movie_entries[0])
 
-    same_day_events.sort(
-        key=lambda event: (
-            -event["profile_count"],
-            -event["pair_count"],
-            -int(event["start_date"].replace("-", "")),
-            event["title"],
-        )
+    # These three lists are the Signal Feed, and the feed is presented newest
+    # first. They are truncated to `limit` further down, so whatever leads this
+    # sort decides which events survive -- and leading with crowd size meant the
+    # 100 kept rows were the biggest gatherings, not the latest ones. At a
+    # three-day gap that dropped every match from the most recent week while the
+    # header still said "most recent first". Recency leads; crowd size stays as
+    # the tiebreaker so a busy day still ranks its own events sensibly.
+    feed_order = lambda event: (
+        -int(event["start_date"].replace("-", "")),
+        -event["profile_count"],
+        -event["pair_count"],
+        event["title"],
     )
-    one_day_gap_events.sort(
-        key=lambda event: (
-            -event["profile_count"],
-            -event["pair_count"],
-            -int(event["start_date"].replace("-", "")),
-            event["title"],
-        )
-    )
+    same_day_events.sort(key=feed_order)
+    one_day_gap_events.sort(key=feed_order)
     if gap_days is not None:
         gap_events.sort(
             key=lambda event: (
+                -int(event["start_date"].replace("-", "")),
                 -event["profile_count"],
                 event["day_gap"],
                 -event["pair_count"],
-                -int(event["start_date"].replace("-", "")),
                 event["title"],
             )
         )

--- a/backend/tests/test_spy_signal_event_source.py
+++ b/backend/tests/test_spy_signal_event_source.py
@@ -528,3 +528,74 @@ class EventSourceSelectionTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SignalFeedOrderingTests(unittest.TestCase):
+    """The Signal Feed is presented newest first and truncated to a limit.
+
+    Whichever key leads the sort decides which events survive that truncation.
+    Leading with crowd size kept the biggest gatherings and dropped the latest
+    ones, so a three-day scan showed nothing from the most recent week while the
+    header still said "most recent first".
+    """
+
+    def _timing(self, entries, gap_days=3):
+        return _calculate_event_source_timing(entries, gap_days=gap_days)
+
+    def test_the_newest_match_leads_even_against_a_bigger_crowd(self) -> None:
+        entries = []
+        # An old film three people watched together.
+        for index, name in enumerate(("ana", "ben", "cal"), start=1):
+            entries.append(
+                timing_entry(
+                    profile_id=index,
+                    username=name,
+                    watched_date=date(2026, 1, 10),
+                    movie_id=1,
+                    title="Old Crowd",
+                )
+            )
+        # A recent film only two of them watched.
+        for index, name in enumerate(("ana", "ben"), start=1):
+            entries.append(
+                timing_entry(
+                    profile_id=index,
+                    username=name,
+                    watched_date=date(2026, 7, 30),
+                    movie_id=2,
+                    title="Recent Pair",
+                )
+            )
+
+        events = self._timing(entries)["gap_events"]
+
+        self.assertEqual(events[0]["title"], "Recent Pair")
+
+    def test_a_bigger_crowd_still_wins_within_the_same_day(self) -> None:
+        """Recency leads, but crowd size remains the tiebreaker."""
+        entries = []
+        for index, name in enumerate(("ana", "ben", "cal"), start=1):
+            entries.append(
+                timing_entry(
+                    profile_id=index,
+                    username=name,
+                    watched_date=date(2026, 7, 30),
+                    movie_id=1,
+                    title="Same Day Crowd",
+                )
+            )
+        for index, name in enumerate(("ana", "ben"), start=1):
+            entries.append(
+                timing_entry(
+                    profile_id=index,
+                    username=name,
+                    watched_date=date(2026, 7, 30),
+                    movie_id=2,
+                    title="Same Day Pair",
+                )
+            )
+
+        events = self._timing(entries)["gap_events"]
+        titles = [event["title"] for event in events]
+
+        self.assertLess(titles.index("Same Day Crowd"), titles.index("Same Day Pair"))

--- a/frontend/src/components/SpySignalsResults.tsx
+++ b/frontend/src/components/SpySignalsResults.tsx
@@ -419,7 +419,14 @@ const SpySignalsResults: React.FC<SpySignalsResultsProps> = ({
             <div>
               <h2 className="text-xl font-semibold text-white">Signal Feed</h2>
               <p className="mt-1 text-xs text-white/50">
-                Showing {Math.min(visibleCount, events.length)} of {totalEventCount} chronological {gapLabel(gapDays)} {totalEventCount === 1 ? 'match' : 'matches'}
+                {/* `totalEventCount` is every match the scan found; `events`
+                    is the most recent slice the API returns. Quoting the first
+                    as the denominator promised rows the feed could not reach,
+                    because "Show More" stops at the slice. */}
+                Showing {Math.min(visibleCount, events.length)} of {events.length} {gapLabel(gapDays)} {events.length === 1 ? 'match' : 'matches'}
+                {totalEventCount > events.length
+                  ? ` · the most recent ${events.length} of ${totalEventCount}`
+                  : ''}
               </p>
             </div>
             <span className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/55">


### PR DESCRIPTION
The Signal Feed is drawn **newest first** and the API returns at most **100** events — so whichever key led the sort decided which events survived truncation.

Crowd size led:

```python
gap_events.sort(key=lambda e: (-e["profile_count"], e["day_gap"], ...))
baseline["gap_events"] = gap_events[:limit]      # keeps the biggest, not the latest
```

The frontend then re-sorted that arbitrary slice by date and labelled it *"Most recent first"*.

## Measured on live data (gap_days=3, 17 profiles)
| | before | after |
|---|---|---|
| events found | 711 | 711 |
| returned | 100 | 100 |
| **newest reachable** | **2026-07-25** | **2026-07-31** |

Every match from the most recent week was dropped. Anyone opening Spy Signals to see what just happened saw nothing from those days, with no way to page to them.

## Fix
Recency leads the three feed sorts; crowd size stays as the tiebreaker so a busy day still ranks its own events sensibly. Verified: the same query now returns Spider-Man: Brand New Day, 2026-07-31, first.

The header also quoted the **untruncated** total as its denominator — "Showing 100 of 711" — while "Show More" stopped at 100. It now counts what is reachable and states the truncation rather than contradicting it.

## Tests
Two new: the newest match leads even against a bigger crowd, and a bigger crowd still wins *within* the same day (so the tiebreaker is pinned, not just the primary key).

589 backend tests, 50/50 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)