### PR TITLE
Give every figure in the Analysis panels its own denominator

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -316,6 +316,10 @@ def _entry(
     if include_code:
         entry["code"] = bucket["code"]
     entry["count"] = bucket["count"]
+    # `count` is every film in the bucket; the average is over the rated ones
+    # only. Presenting them together read as "4.6 average across 12 films" when
+    # the average came from three, so the rated count travels with it.
+    entry["rated_count"] = len(bucket["ratings"])
     entry["average_rating"] = _round(_average(bucket["ratings"]), 2)
     return entry
 

--- a/backend/services/rating_comparison.py
+++ b/backend/services/rating_comparison.py
@@ -265,7 +265,12 @@ def _divisive_entry(row: _FilmRow, identity: Dict[str, Any]) -> Dict[str, Any]:
     return {
         **identity,
         "rating_spread": _round(max(ratings) - min(ratings), 2),
+        # The spread is measured across everyone who rated the film, the group
+        # average deliberately excludes the profile being viewed. Reporting one
+        # count for both presented a four-person average as a five-person one,
+        # so each figure now carries its own denominator.
         "rater_count": len(ratings),
+        "group_rater_count": len(row.other_ratings),
         "group_average": _round(row.group_average, 2),
         "profile_rating": _round(row.profile_rating, 2),
     }

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -383,6 +383,7 @@ def test_studios_come_from_the_raw_payload_production_companies(database: Sessio
     assert stats["top_studios"][0] == {
         "name": "A24",
         "count": 2,
+        "rated_count": 0,
         "average_rating": None,
     }
     assert stats["totals"]["distinct_studios"] == 2
@@ -409,6 +410,7 @@ def test_highest_rated_ignores_buckets_below_three_rated_films(database: Session
     assert stats["highest_rated"]["genre"] == {
         "label": "Drama",
         "count": 3,
+        "rated_count": 3,
         "average_rating": 4.0,
     }
 
@@ -424,7 +426,7 @@ def test_highest_rated_is_null_when_nothing_clears_the_floor(database: Session) 
     assert stats["highest_rated"] == {"genre": None, "decade": None, "director": None}
     # The genre still appears in the distribution, with its honest average.
     assert stats["genres"] == [
-        {"label": "Horror", "count": 2, "average_rating": 5.0}
+        {"label": "Horror", "count": 2, "rated_count": 1, "average_rating": 5.0}
     ]
 
 
@@ -437,7 +439,7 @@ def test_bucket_averages_use_only_rated_films(database: Session) -> None:
     stats = build_profile_stats(database, profile)
 
     assert stats["genres"] == [
-        {"label": "Comedy", "count": 3, "average_rating": 4.0}
+        {"label": "Comedy", "count": 3, "rated_count": 2, "average_rating": 4.0}
     ]
     assert stats["coverage"]["rated_films"] == 2
     assert stats["totals"]["average_rating"] == 4.0
@@ -475,7 +477,7 @@ def test_a_profile_with_no_enrichment_returns_nulls_not_zeros(database: Session)
     ):
         assert totals[dimension] is None, dimension
     # Decade survives without TMDB: the release year comes from the film row.
-    assert stats["decades"] == [{"label": "2000s", "count": 1, "average_rating": 4.5}]
+    assert stats["decades"] == [{"label": "2000s", "count": 1, "rated_count": 1, "average_rating": 4.5}]
     assert stats["top_directors"] == []
     assert stats["highest_rated"]["director"] is None
     assert stats["letterboxd_reported"] is None
@@ -526,7 +528,7 @@ def test_malformed_enrichment_payloads_never_crash(database: Session) -> None:
 
     stats = build_profile_stats(database, profile)
 
-    assert stats["genres"] == [{"label": "Drama", "count": 1, "average_rating": None}]
+    assert stats["genres"] == [{"label": "Drama", "count": 1, "rated_count": 0, "average_rating": None}]
     assert stats["top_directors"] == []
     assert stats["top_studios"] == []
     assert stats["decades"] == []
@@ -558,8 +560,8 @@ def test_countries_carry_their_iso_code_and_languages_are_named(database: Sessio
     stats = build_profile_stats(database, profile)
 
     assert stats["countries"] == [
-        {"label": "Latvia", "code": "LV", "count": 1, "average_rating": None},
-        {"label": "South Korea", "code": "KR", "count": 1, "average_rating": None},
+        {"label": "Latvia", "code": "LV", "count": 1, "rated_count": 0, "average_rating": None},
+        {"label": "South Korea", "code": "KR", "count": 1, "rated_count": 0, "average_rating": None},
     ]
     # A code the payload never names falls back to the uppercased code itself.
     assert sorted(entry["label"] for entry in stats["languages"]) == ["Korean", "LV"]
@@ -1128,3 +1130,29 @@ def test_route_refuses_an_untracked_profile(database: Session, client) -> None:
     response = client(user).get(f"/api/profiles/{profile.username}/stats")
 
     assert response.status_code == 403
+
+
+def test_a_bucket_reports_the_denominator_its_average_was_built_from(database):
+    """`count` is every film in the bucket; the average covers the rated ones.
+
+    The highlight card read "{average} average across {count} films", so a
+    director with twelve films and three ratings advertised a three-rating
+    average over twelve. The rated count now travels with the average.
+    """
+    profile = _profile(database, "viewer")
+    for index in range(4):
+        _film(
+            database,
+            profile,
+            title=f"Horror {index}",
+            # Only the first two carry a rating.
+            rating=5.0 if index < 2 else None,
+            genres=["Horror"],
+        )
+
+    stats = build_profile_stats(database, profile)
+    horror = next(entry for entry in stats["genres"] if entry["label"] == "Horror")
+
+    assert horror["count"] == 4
+    assert horror["rated_count"] == 2
+    assert horror["average_rating"] == 5.0

--- a/backend/tests/test_rating_comparison.py
+++ b/backend/tests/test_rating_comparison.py
@@ -760,7 +760,10 @@ def test_route_serves_the_payload_for_a_tracked_profile(
         "poster_url",
         "letterboxd_url",
         "rating_spread",
+        # The spread spans every rater; the group average excludes the profile
+        # being viewed. Each figure carries its own denominator.
         "rater_count",
+        "group_rater_count",
         "group_average",
         "profile_rating",
     }
@@ -798,3 +801,22 @@ def test_route_refuses_an_untracked_profile(database: Session, client) -> None:
     response = client().get("/api/profiles/subject/rating-comparison")
 
     assert response.status_code == 403
+
+
+def test_the_group_average_reports_its_own_denominator(database: Session) -> None:
+    """The spread counts everyone; the group average excludes the viewer.
+
+    One count served both, so a four-person average was presented beside
+    "5 raters" and read as a five-person one.
+    """
+    subject = _profile(database, "subject")
+    circle = _circle(database, size=4)
+    _shared(database, subject, circle, "Argued About", subject_rating=1.0,
+            other_ratings=[5.0, 4.5, 4.0, 3.5])
+
+    payload = build_rating_comparison(database, subject, limit=5)
+    entry = payload["most_divisive"][0]
+
+    assert entry["rater_count"] == 5          # the spread spans all five
+    assert entry["group_rater_count"] == 4    # the average is over the others
+    assert entry["group_average"] == 4.25

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -389,10 +389,12 @@ export const profileStats = {
     { label: '1990s', count: 260, average_rating: 3.9 },
     { label: '2000s', count: 310, average_rating: 3.6 },
   ],
+  // `count` is the bucket; `rated_count` is what the average was built from.
+  // They differ in real data, so the fixture makes them differ here too.
   highest_rated: {
-    genre: { label: 'Documentary', count: 34, average_rating: 4.15 },
-    decade: { label: '1970s', count: 90, average_rating: 4 },
-    director: { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
+    genre: { label: 'Documentary', count: 34, rated_count: 29, average_rating: 4.15 },
+    decade: { label: '1970s', count: 90, rated_count: 71, average_rating: 4 },
+    director: { name: 'Akira Kurosawa', count: 18, rated_count: 12, average_rating: 4.3 },
   },
   // Folded into the same panel. One rewatched film is unrated and one review
   // has no publication date, so both omission branches render.
@@ -650,6 +652,7 @@ export const ratingComparison = {
       letterboxd_url: 'https://letterboxd.com/film/divisive-fixture-film/',
       rating_spread: 3,
       rater_count: 6,
+      group_rater_count: 5,
       group_average: 3.08,
       profile_rating: 4.5,
     },
@@ -660,6 +663,7 @@ export const ratingComparison = {
       letterboxd_url: null,
       rating_spread: 2.5,
       rater_count: 4,
+      group_rater_count: 3,
       group_average: 2.88,
       profile_rating: null,
     },

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -516,7 +516,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       ? {
           label: 'Highest-rated genre',
           name: highestRated.genre.label,
-          ratedCount: highestRated.genre.rated_count,
+          ratedCount: highestRated.genre.rated_count ?? highestRated.genre.count,
           average: highestRated.genre.average_rating,
         }
       : null,
@@ -524,7 +524,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       ? {
           label: 'Highest-rated decade',
           name: highestRated.decade.label,
-          ratedCount: highestRated.decade.rated_count,
+          ratedCount: highestRated.decade.rated_count ?? highestRated.decade.count,
           average: highestRated.decade.average_rating,
         }
       : null,
@@ -532,7 +532,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       ? {
           label: 'Highest-rated director',
           name: highestRated.director.name,
-          ratedCount: highestRated.director.rated_count,
+          ratedCount: highestRated.director.rated_count ?? highestRated.director.count,
           average: highestRated.director.average_rating,
         }
       : null,

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -511,12 +511,12 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
     || languageRows.length > 0
     || decadeRows.length > 0;
 
-  const highlightCandidates: Array<{ label: string; name: string; count: number; average: number } | null> = [
+  const highlightCandidates: Array<{ label: string; name: string; ratedCount: number; average: number } | null> = [
     highestRated?.genre
       ? {
           label: 'Highest-rated genre',
           name: highestRated.genre.label,
-          count: highestRated.genre.count,
+          ratedCount: highestRated.genre.rated_count,
           average: highestRated.genre.average_rating,
         }
       : null,
@@ -524,7 +524,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       ? {
           label: 'Highest-rated decade',
           name: highestRated.decade.label,
-          count: highestRated.decade.count,
+          ratedCount: highestRated.decade.rated_count,
           average: highestRated.decade.average_rating,
         }
       : null,
@@ -532,13 +532,13 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       ? {
           label: 'Highest-rated director',
           name: highestRated.director.name,
-          count: highestRated.director.count,
+          ratedCount: highestRated.director.rated_count,
           average: highestRated.director.average_rating,
         }
       : null,
   ];
   const highlights = highlightCandidates.filter(
-    (item): item is { label: string; name: string; count: number; average: number } => item !== null,
+    (item): item is { label: string; name: string; ratedCount: number; average: number } => item !== null,
   );
 
   // Rewatching and reviewing are part of the same "about this profile" story,
@@ -554,7 +554,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   // One caveat for the whole panel rather than a footnote on every row.
   const enrichmentCaveat = coverage.films_total > 0
     && coverage.enrichment_ratio < ENRICHMENT_CAVEAT_THRESHOLD
-    ? `Film metadata is in for ${formatRatio(coverage.enrichment_ratio)} of ${formatCount(coverage.films_total)} synced films (${formatCount(coverage.films_enriched)}), so the credits, country, language and runtime figures below are drawn from that subset.`
+    ? `Film metadata is in for ${formatRatio(coverage.enrichment_ratio)} of ${formatCount(coverage.films_total)} synced films (${formatCount(coverage.films_enriched)}), so the genre, credits, country, language and runtime figures below are drawn from that subset.`
     : null;
 
   return (
@@ -659,7 +659,10 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
                 {highlight.name}
               </p>
               <p className="mt-0.5 text-[11px] text-white/40">
-                {highlight.average.toFixed(2)} average across {formatCount(highlight.count)} films
+                {/* The bucket holds more films than this; the average only
+                    covers the rated ones, and quoting the bucket size made a
+                    three-rating average look like a twelve-film one. */}
+                {highlight.average.toFixed(2)} average across {formatCount(highlight.ratedCount)} rated {highlight.ratedCount === 1 ? 'film' : 'films'}
               </p>
             </div>
           ))}

--- a/frontend/src/components/insights/RatingComparisonPanel.tsx
+++ b/frontend/src/components/insights/RatingComparisonPanel.tsx
@@ -138,8 +138,10 @@ function DeltaRow({ film }: { film: RatingComparisonFilm }) {
 
 function DivisiveRow({ film, username }: { film: RatingComparisonDivisiveFilm; username: string }) {
   const references = [
-    `group ${film.group_average.toFixed(2)}`,
-    raterNote(film.rater_count),
+    // The group average excludes this profile, so it is quoted with the count
+    // it was actually built from; the spread's wider count is named separately.
+    `group ${film.group_average.toFixed(2)} from ${raterNote(film.group_rater_count)}`,
+    `${film.rater_count} rated in total`,
     film.profile_rating === null ? `@${username} unrated` : `@${username} ${film.profile_rating.toFixed(1)}`,
   ];
 

--- a/frontend/src/components/insights/RatingComparisonPanel.tsx
+++ b/frontend/src/components/insights/RatingComparisonPanel.tsx
@@ -140,7 +140,7 @@ function DivisiveRow({ film, username }: { film: RatingComparisonDivisiveFilm; u
   const references = [
     // The group average excludes this profile, so it is quoted with the count
     // it was actually built from; the spread's wider count is named separately.
-    `group ${film.group_average.toFixed(2)} from ${raterNote(film.group_rater_count)}`,
+    `group ${film.group_average.toFixed(2)} from ${raterNote(film.group_rater_count ?? film.rater_count)}`,
     `${film.rater_count} rated in total`,
     film.profile_rating === null ? `@${username} unrated` : `@${username} ${film.profile_rating.toFixed(1)}`,
   ];

--- a/frontend/src/components/insights/TasteProfilePanel.tsx
+++ b/frontend/src/components/insights/TasteProfilePanel.tsx
@@ -93,8 +93,18 @@ const TasteProfilePanel: React.FC<{ username: string; delay?: number }> = ({
                         style={{ width: `${Math.max(2, score)}%` }}
                       />
                     </span>
-                    <span className="w-9 shrink-0 text-right text-xs tabular-nums text-white/45">
+                    {/* Without the sample size a trait built from two films
+                        reads exactly like one built from twenty-five, and for a
+                        single profile the score tops out at 100% on two
+                        five-star films. */}
+                    <span
+                      className="w-9 shrink-0 text-right text-xs tabular-nums text-white/45"
+                      title={`${score}% from ${trait.sample_size} ${trait.sample_size === 1 ? 'film' : 'films'}`}
+                    >
                       {score}%
+                    </span>
+                    <span className="w-12 shrink-0 text-right text-[10px] tabular-nums text-white/30">
+                      {trait.sample_size} {trait.sample_size === 1 ? 'film' : 'films'}
                     </span>
                   </li>
                 );

--- a/frontend/src/components/insights/WatchlistPanel.tsx
+++ b/frontend/src/components/insights/WatchlistPanel.tsx
@@ -253,7 +253,7 @@ const WatchlistPanel: React.FC<{ username: string; delay?: number }> = ({
         <div className="mt-6">
           <ListSection
             title="Watch next"
-            subtitle="Highest circle average first, then the number of members behind it"
+            subtitle="Ranked on the circle's average, weighted down when only one or two members have seen it"
           >
             {visibleQueue.map((film, index) => (
               <QueueRow

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1278,12 +1278,16 @@ export interface ProfileStatsTotals {
 export interface ProfileStatsPerson {
   name: string;
   count: number;
+  /** Films in this bucket that carry a rating — the average's real denominator. */
+  rated_count: number;
   average_rating: number | null;
 }
 
 export interface ProfileStatsBucket {
   label: string;
   count: number;
+  /** Films in this bucket that carry a rating — the average's real denominator. */
+  rated_count: number;
   average_rating: number | null;
 }
 
@@ -1297,9 +1301,10 @@ export interface ProfileStatsCountryBucket extends ProfileStatsBucket {
  * always present here even though it is nullable in the plain buckets.
  */
 export interface ProfileStatsHighestRated {
-  genre: { label: string; count: number; average_rating: number } | null;
-  decade: { label: string; count: number; average_rating: number } | null;
-  director: { name: string; count: number; average_rating: number } | null;
+  /** `count` is every film in the bucket; `rated_count` is the average's denominator. */
+  genre: { label: string; count: number; rated_count: number; average_rating: number } | null;
+  decade: { label: string; count: number; rated_count: number; average_rating: number } | null;
+  director: { name: string; count: number; rated_count: number; average_rating: number } | null;
 }
 
 export interface ProfileStatsRewatchedFilm {
@@ -1453,7 +1458,10 @@ export interface RatingComparisonDivisiveFilm {
   letterboxd_url: string | null;
   /** Widest gap between any two ratings of this film across all profiles. */
   rating_spread: number;
+  /** Everyone who rated it — the spread's denominator, including this profile. */
   rater_count: number;
+  /** The others only — the group average's denominator. */
+  group_rater_count: number;
   group_average: number;
   /** Null when this profile has not rated a film the rest of the group split over. */
   profile_rating: number | null;


### PR DESCRIPTION
Five confirmed issues, all variations on a figure being quoted next to a number it wasn't built from.

## 1. "Highest-rated" printed the wrong denominator
```python
entry["count"] = bucket["count"]                        # every film
entry["average_rating"] = _average(bucket["ratings"])   # only the rated ones
```
`_highest_rated` qualifies a bucket on three **ratings**, so a director with twelve films and three ratings advertised *"4.60 average across 12 films"*. Buckets now carry `rated_count` and the card quotes it.

A test fixture makes it concrete: Horror with `count: 2, rated_count: 1` — "5.00 average across 2 films" was one rating.

## 2. Divisive films mixed two populations
`rater_count` counted **everyone** (the spread's denominator) while `group_average` excludes the profile being viewed — rendered adjacent as *"group 3.80 · 5 raters · @user 4.5"*, presenting a four-person average as five. Each figure now names its own count.

## 3. Taste traits had no sample size
A percentage and nothing else. For a single profile the score is `average/5*70 + 30`, so two five-star films read a flat **100%**, and the credibility floor is two — indistinguishable from a twenty-five-film trait. Each row now shows its sample size.

## 4. The watchlist subtitle described a ranking that isn't running
It promised *"highest circle average first"* while the ranking is the shrinkage-weighted score from #75, which deliberately pulls thin averages down — one 5.0 ranks *below* four at 4.5. Correct behaviour, wrong description. Now describes what runs.

## 5. The enrichment caveat omitted genres
It named credits, country, language and runtime as coming from the enriched subset; genres come from the same place and went unqualified.

595 backend tests (2 new pinning the denominators), 52/52 Playwright, `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)