### PR TITLE
Make the Signal Calendar, Who-watched-first and empty states tell the truth

### DIFF
--- a/backend/services/insights.py
+++ b/backend/services/insights.py
@@ -574,6 +574,17 @@ def _merge_provider_availability(
     )
 
 
+
+def _negated_iso_date(value: str) -> str:
+    """Sort key that puts the newest ISO date first.
+
+    ISO dates sort lexically, so reversing them means inverting each digit
+    rather than negating a number.
+    """
+
+    return "".join(chr(ord("9") - (ord(ch) - ord("0"))) if ch.isdigit() else ch for ch in value)
+
+
 class InsightsService:
     """Source-backed insight calculations over the additive, event-corrected schema."""
 
@@ -2156,7 +2167,17 @@ class InsightsService:
                     ),
                 }
             )
-        influence_paths.sort(key=lambda item: (item["gap_days"], item["leader_date"], item["movie"]["title"]))
+        # Newest first. Ordering by gap and then by *ascending* leader date
+        # filled the panel with the pair's oldest one-day-apart films and never
+        # reached recent activity, however active they had been lately; the
+        # tight gap remains the tiebreaker within a day.
+        influence_paths.sort(
+            key=lambda item: (
+                _negated_iso_date(item["leader_date"]),
+                item["gap_days"],
+                item["movie"]["title"],
+            )
+        )
 
         monthly: Dict[str, Dict[str, Any]] = defaultdict(
             lambda: {"ratings_left": [], "ratings_right": [], "gaps": [], "overlap_count": 0}

--- a/frontend/src/components/SpySignalsResults.tsx
+++ b/frontend/src/components/SpySignalsResults.tsx
@@ -135,7 +135,7 @@ const MetricCard: React.FC<{
 function SignalStrength({ event }: { event: GroupSignalEvent }) {
   const gap = event.max_rating_gap;
   const strength = gap === null || gap === undefined
-    ? { label: 'Ratings unavailable', classes: 'border-white/15 bg-white/5 text-white/50' }
+    ? { label: 'Gap unknown', classes: 'border-white/15 bg-white/5 text-white/50' }
     : gap <= 0.5
       ? { label: 'Strong', classes: 'border-emerald-400/40 bg-emerald-500/10 text-emerald-300' }
       : gap <= 1.5

--- a/frontend/src/components/insights/ComparePanels.tsx
+++ b/frontend/src/components/insights/ComparePanels.tsx
@@ -408,6 +408,11 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
                   </div>
                 ))}
               </div>
+              {(data.shared_signature ?? []).flatMap((trait) => trait.top_movies ?? []).length === 0 && (
+                <p className="py-6 text-center text-sm text-white/40">
+                  No films both profiles have rated in a shared trait yet.
+                </p>
+              )}
             </section>
             <section className="panel-insight p-4">
               <h3 className="flex items-center gap-2 text-sm font-semibold text-white"><Film className="h-4 w-4 text-cinema-400" /> Semantic neighbors</h3>
@@ -421,6 +426,11 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
                   </div>
                 ))}
               </div>
+              {(data.semantic_neighbors ?? []).length === 0 && (
+                <p className="py-6 text-center text-sm text-white/40">
+                  No contextual matches close enough in time yet.
+                </p>
+              )}
             </section>
           </div>
         </>
@@ -466,8 +476,11 @@ export function SignalCalendarPanel({ data, coverage }: {
   const effectiveCoverage = data?.coverage ?? coverage;
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const days = useMemo(() => data ? calendarDays(data.from, data.to, data.buckets ?? []) : [], [data]);
+  // The heatmap counts each event once, on its start date. Filtering the detail
+  // list by span instead listed events belonging to other cells -- and a blank
+  // grey day could open a populated list -- so the two now agree.
   const selectedEvents = selectedDate && data
-    ? (data.events ?? []).filter((event) => event.start_date <= selectedDate && event.end_date >= selectedDate)
+    ? (data.events ?? []).filter((event) => event.start_date === selectedDate)
     : [];
   const peakBucket = data?.buckets?.reduce<SignalCalendarBucket | null>((peak, bucket) => !peak || bucket.signal_count > peak.signal_count ? bucket : peak, null) ?? null;
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1008,12 +1008,16 @@ export const insightsApi = {
 
   getSignalCalendar: async (
     profiles: string[],
-    options: { gapDays: number; from: string; to: string },
+    // `from`/`to` are optional on purpose. Sending a fixed window overrides the
+    // backend's data-aware default, which anchors on the pair's own latest
+    // event -- a pair whose newest activity predates the window then renders a
+    // year of empty cells rather than the period they were actually active in.
+    options: { gapDays: number; from?: string; to?: string },
   ): Promise<SignalCalendarResponse> => {
     const params = selectedProfileParams(profiles);
     params.set('gap_days', String(options.gapDays));
-    params.set('from', options.from);
-    params.set('to', options.to);
+    if (options.from) params.set('from', options.from);
+    if (options.to) params.set('to', options.to);
     const response = await api.get('/api/signal-calendar', { params });
     return response.data;
   },

--- a/frontend/src/views/Compare.tsx
+++ b/frontend/src/views/Compare.tsx
@@ -54,13 +54,6 @@ function featureCoverageFromResponse(
   };
 }
 
-function getDateRange(): { from: string; to: string } {
-  const now = new Date();
-  const to = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  const from = new Date(to.getTime() - 364 * 86_400_000);
-  return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
-}
-
 function PairProfileField({
   label,
   value,
@@ -130,10 +123,10 @@ export default function Compare() {
     enabled: canCompare && activeTab === 'timeline',
     staleTime: 10 * 60 * 1000,
   });
-  const dateRange = useMemo(() => getDateRange(), []);
   const calendarQuery = useQuery({
-    queryKey: ['signal-calendar', activeProfiles, windowDays, dateRange.from, dateRange.to],
-    queryFn: () => insightsApi.getSignalCalendar(activeProfiles, { gapDays: windowDays, ...dateRange }),
+    queryKey: ['signal-calendar', activeProfiles, windowDays],
+    // No explicit window: the backend anchors on the pair's own activity.
+    queryFn: () => insightsApi.getSignalCalendar(activeProfiles, { gapDays: windowDays }),
     enabled: canCompare && activeTab === 'calendar',
     staleTime: 5 * 60 * 1000,
   });


### PR DESCRIPTION
## Signal Calendar showed the wrong events for the cell you clicked
The heatmap buckets each event once, on its `start_date`. The detail list filtered by **span**:

```ts
.filter((e) => e.start_date <= selectedDate && e.end_date >= selectedDate)
```

With the default 7-day window, gap co-watches routinely span several days — so clicking a cell listed events belonging to other cells, and a **blank grey day could open a populated list**. The filter now matches the bucket.

## The calendar was pinned to the last 365 days from today
It sent a fixed window, overriding the backend's data-aware default (which anchors on `max_event_date`). Any pair whose newest activity predates that window — a stale profile, a scrape that fell behind — got a year of empty cells instead of the period they were actually active in. The range is omitted now.

## "Who watched first?" never showed recent activity
```python
influence_paths.sort(key=lambda i: (i["gap_days"], i["leader_date"], ...))
```
Gap first, then **ascending** date — so the eight rows were the pair's *oldest* one-day-apart films, however active the pair had been lately. Newest first now, tight gap as tiebreaker.

Verified live: the panel leads with 2026-07-17 where it previously showed the oldest entries.

## Two smaller ones
- Both Taste DNA poster rows rendered a heading over nothing when empty, unlike every sibling list on the tab.
- A co-watch with no rating gap was badged **"Ratings unavailable"** beside an average rating the same card had just displayed — the *gap* is what's missing.

597 backend tests, 55/55 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)