### PR TITLE
Show when a profile started logging, and send Investigate somewhere useful

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -27,7 +27,7 @@ from api.routes.watchlist_insights import router as watchlist_insights_router
 from api.routes.rating_comparison import router as rating_comparison_router
 from auth import ClerkUser, get_admin_user, get_current_user, get_upload_user
 from database.connection import engine, get_db, init_db
-from database.models import Movie, Profile, ProfileFavoriteMovie
+from database.models import Movie, Profile, ProfileFavoriteMovie, WatchEvent
 from database.repository import (
     ProfileRepository, RatingRepository, ReviewRepository, AnalyticsRepository
 )
@@ -51,6 +51,7 @@ from services.operational_health import (
     readiness_report,
     rss_operational_report,
 )
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -512,7 +513,21 @@ def extract_zip_file(uploaded_file, temp_dir):
 def _serialize_profiles(db: Session, profiles) -> dict:
     rating_repo = RatingRepository(db)
     profile_list = []
-    for profile in (profile for profile in profiles if profile.is_active):
+    active = [profile for profile in profiles if profile.is_active]
+    # Letterboxd does not publish a join date on a public profile page -- it
+    # only appears in an account's own export -- so every scraped profile has
+    # none and the card read "Member Since: Unknown" for all but one. The first
+    # logged diary entry is something we do hold for everyone, and for the one
+    # profile that has both they agree to within a week.
+    first_logged: Dict[int, Any] = {}
+    if active:
+        first_logged = dict(
+            db.query(WatchEvent.profile_id, func.min(WatchEvent.watched_date))
+            .filter(WatchEvent.profile_id.in_([profile.id for profile in active]))
+            .group_by(WatchEvent.profile_id)
+            .all()
+        )
+    for profile in active:
         profile_dict = profile.to_dict()
         all_entries = rating_repo.get_ratings_by_profile(profile.id)
         
@@ -532,6 +547,8 @@ def _serialize_profiles(db: Session, profiles) -> dict:
             profile_dict['avg_rating'] = 0
 
         profile_dict['data_coverage'] = extract_data_coverage(profile.enhanced_metrics)
+        earliest = first_logged.get(profile.id)
+        profile_dict['first_logged_date'] = earliest.isoformat() if earliest else None
             
         profile_list.append(profile_dict)
     

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -70,7 +70,9 @@ export const profiles = PROFILE_NAMES.map((username, index) => ({
   liked_films: 180 - index * 7,
   avg_rating: 3.4 + (index % 4) * 0.1,
   total_reviews: 80 - index * 3,
-  join_date: '2020-01-01',
+  // Export-only in reality; most profiles have none.
+  join_date: index === 0 ? '2020-01-01' : null,
+  first_logged_date: '2021-03-14',
   last_scraped_at: '2026-07-29T12:00:00Z',
   scraping_status: 'completed',
   data_coverage: {
@@ -961,7 +963,28 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     });
   }
   if (path === '/api/recent-changes') {
-    return json(route, { generated_at: '2026-07-29T12:00:00Z', scope: 'latest_sync', changes: [] });
+    // Carries entries: an empty list disables the Investigate control, so the
+    // hand-off it performs was never exercised.
+    return json(route, {
+      generated_at: '2026-07-29T12:00:00Z',
+      scope: 'latest_sync',
+      changes: [
+        {
+          id: 1,
+          change_type: 'review_added',
+          entity_type: 'review',
+          detected_at: '2026-07-29T11:00:00Z',
+          source_date: '2026-07-28',
+          source_kind: 'full_html_upload',
+          source_dataset: 'reviews',
+          username: profiles[1].username,
+          movie: { id: 501, title: 'Fixture Film', year: 2024, poster_url: null },
+          list: null,
+          before: null,
+          after: null,
+        },
+      ],
+    });
   }
   if (path === '/api/spy-signals') {
     const selected = url.searchParams.getAll('profiles');

--- a/frontend/e2e/profile-card-dates.spec.ts
+++ b/frontend/e2e/profile-card-dates.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Letterboxd publishes no join date on a public profile page — it exists only
+ * in an account's own export — so every scraped profile read
+ * "Member Since: Unknown". The first diary entry answers the same question and
+ * we hold it for everyone.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+});
+
+test('a profile without a join date shows when it started logging', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page.getByText('Logging Since').first()).toBeVisible();
+  // Never the old placeholder for a profile whose history we actually hold.
+  await expect(page.getByText('Unknown', { exact: true })).toHaveCount(0);
+});
+
+test('a profile that does have a join date still says Member Since', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  await expect(page.getByText('Member Since').first()).toBeVisible();
+});
+
+test('Investigate opens the changed profile, not the co-watch scanner', async ({ page }) => {
+  await page.goto('/dashboard');
+
+  const investigate = page.getByRole('button', { name: /^Investigate/ });
+  await expect(investigate).toBeVisible();
+  await investigate.click();
+
+  // It used to push to /spy-signals — the same place as the button beside it,
+  // and a different question from "what did this profile just do".
+  await expect(page).toHaveURL(/\/analysis/);
+});

--- a/frontend/src/components/ProfileCard.tsx
+++ b/frontend/src/components/ProfileCard.tsx
@@ -181,15 +181,23 @@ const ProfileCard: React.FC<ProfileCardProps> = ({
           animate={{ opacity: 1, x: 0 }}
           transition={{ delay: index * 0.1 + 0.7 }}
         >
+          {/* Letterboxd publishes no join date on a public profile page -- it
+              only appears in an account's own export -- so every scraped
+              profile read "Unknown" here. The first diary entry is something we
+              hold for everyone, and it answers the same question: how far back
+              does this person go. */}
           <div className="flex items-center space-x-2 mb-2">
             <CalendarIcon className="w-4 h-4 text-green-400" />
-            <span className="text-xs text-white/60 font-medium">Member Since</span>
+            <span className="text-xs text-white/60 font-medium">
+              {profile.join_date ? 'Member Since' : 'Logging Since'}
+            </span>
           </div>
           <div className="text-sm font-semibold text-white">
-            {profile.join_date 
+            {profile.join_date
               ? new Date(profile.join_date).getFullYear()
-              : 'Unknown'
-            }
+              : profile.first_logged_date
+                ? new Date(profile.first_logged_date).getFullYear()
+                : 'Unknown'}
           </div>
         </motion.div>
       </div>

--- a/frontend/src/components/insights/RecentChangesCard.tsx
+++ b/frontend/src/components/insights/RecentChangesCard.tsx
@@ -138,8 +138,22 @@ export default function RecentChangesCard({
           </div>
         )}
 
-        <button type="button" onClick={() => router.push('/spy-signals')} className="btn-ghost flex shrink-0 items-center justify-center gap-2 border-white/10 px-3 py-2 text-xs">
-          Investigate <ArrowRight className="h-3.5 w-3.5" />
+        {/* This card is about what changed, so "Investigate" opens the deep
+            dive for the profile that changed most recently. It used to push to
+            /spy-signals -- the same destination as the button beside it, and a
+            different question entirely: co-watch timing rather than this
+            profile's own new activity. */}
+        <button
+          type="button"
+          onClick={() => {
+            const latest = changes[0]?.username;
+            router.push(latest ? `/analysis?profile=${encodeURIComponent(latest)}` : '/analysis');
+          }}
+          disabled={changes.length === 0}
+          className="btn-ghost flex shrink-0 items-center justify-center gap-2 border-white/10 px-3 py-2 text-xs disabled:opacity-40"
+        >
+          {changes[0] ? `Investigate @${changes[0].username}` : 'Investigate'}
+          <ArrowRight className="h-3.5 w-3.5" />
         </button>
       </div>
     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -54,6 +54,10 @@ export interface DataCoverage {
 }
 
 export interface ProfileInfo {
+  /** Earliest diary entry we hold, derived from watch events, so it exists for
+   *  every synced profile. `join_date` is the real answer but appears only in
+   *  an account's own export, never on a public profile page. */
+  first_logged_date?: string | null;
   username: string;
   display_name?: string | null;
   profile_image_url?: string | null;


### PR DESCRIPTION
## "Member Since: Unknown" on 16 of 17 cards

Letterboxd publishes **no join date on a public profile page** — I checked two live profiles for every variant of the string and found nothing. It exists only inside an account's own export, which is why exactly one profile has it.

The field is declared on the scraper's dataclass and written to CSV, but **assigned nowhere**:

```python
join_date: Optional[str] = None      # line 45
'Join_Date': self.profile_info.join_date,   # line 1481 — always None
```

So this isn't a scraping gap I can fill. But the **first diary entry** answers the same question ("how far back does this person go") and we hold it for all 17:

```
er3nweeber      2015-04-22      whiteknight03x  2023-08-15
gnanendar       2022-07-10      snv710          2023-08-31
```

For the one profile with both, they agree to within six days. The card now says **"Member Since"** when a real join date exists and **"Logging Since"** otherwise, rather than claiming ignorance of something it can measure.

## "Investigate" went to the wrong place
It sits under **"New Since Last Sync"** but pushed to `/spy-signals` — the same destination as the button beside it, and a different question entirely: co-watch timing rather than what this profile just did. It now opens the deep dive for the most recently changed profile, and names them: *"Investigate @gnanendar"*.

The e2e fixture returned an empty change list, so this control was disabled in every test run and its hand-off had never been exercised. It carries an entry now.

599 backend tests, 58/58 Playwright (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)