### PR TITLE
Close the last audit findings: ego counts, a marker that could not appear, and error states

### DIFF
--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -1044,7 +1044,9 @@ class ProfileFollowEdge(Base):
     counterpart_profile_id = Column(
         Integer, ForeignKey("profiles.id", ondelete="SET NULL"), nullable=True
     )
-    # Source page order approximates recency; Letterboxd does not guarantee it.
+    # Letterboxd's follow lists default to a sort the UI labels "WHEN
+    # FOLLOWED", so this order is recency, newest first. It carries no dates --
+    # the rows expose no timestamp of any kind -- so the order is all there is.
     position = Column(Integer, nullable=True)
     first_seen_profile_sync_id = Column(
         BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True

--- a/frontend/src/components/FollowNetwork.tsx
+++ b/frontend/src/components/FollowNetwork.tsx
@@ -551,8 +551,22 @@ export default function FollowNetwork({
       if (!key || key === focusNode.key || groupIndexByKey.has(key)) return;
       outside.add(key);
     });
-    return Math.max(0, outside.size - extraNodes.length);
-  }, [focusNode, egoQuery.data?.edges, egoQuery.isError, groupIndexByKey, extraNodes.length]);
+    // The edge request is capped, and the endpoint serves followers before any
+    // following rows, so a profile with more followers than the cap returns no
+    // following edges at all -- counting only what arrived understated both the
+    // connections and the "not shown" note that exists to admit truncation.
+    // `total` is the unfiltered count the same response already carries.
+    const fetched = (egoQuery.data?.edges ?? []).length;
+    const beyondPage = Math.max(0, (egoQuery.data?.total ?? fetched) - fetched);
+    return Math.max(0, outside.size - extraNodes.length) + beyondPage;
+  }, [
+    focusNode,
+    egoQuery.data?.edges,
+    egoQuery.data?.total,
+    egoQuery.isError,
+    groupIndexByKey,
+    extraNodes.length,
+  ]);
 
   // Leaves keep the ring's angular order so the collapse into ego view reads
   // as a fold-in rather than a shuffle; outside counterparts come last.

--- a/frontend/src/components/SpySignalsResults.tsx
+++ b/frontend/src/components/SpySignalsResults.tsx
@@ -19,7 +19,6 @@ import type {
   GroupSignalPair,
   GroupSignals,
 } from '../services/api';
-import { FollowsEarlierWatcherMarker } from './insights/InsightUI';
 import type { SignalGapDays } from './SpySignalsControls';
 
 interface SpySignalsResultsProps {
@@ -60,19 +59,6 @@ function getWindowDays(event: GroupSignalEvent): number {
   return Math.max(0, Math.round((end - start) / 86_400_000));
 }
 
-/**
- * Whether this match carries the one social reading the data supports: the
- * later watcher already followed the earlier one.
- *
- * Same-day matches are excluded because there is no later watcher to speak of,
- * and an unobservable follow (no authoritative social import either way) stays
- * off rather than reading as an absence. A true here is a social link that
- * existed, never a claim that one watch produced the other.
- */
-function followsEarlierWatcher(event: GroupSignalEvent, windowDays: number): boolean {
-  if (windowDays <= 0) return false;
-  return event.follows_earlier_watcher === true || event.follow_backed === true;
-}
 
 function eventKey(event: GroupSignalEvent): string {
   return `${event.title}-${event.year ?? 'na'}-${event.start_date}-${event.end_date}`;
@@ -151,8 +137,6 @@ function SignalStrength({ event }: { event: GroupSignalEvent }) {
 
 const SignalEventCard: React.FC<{ event: GroupSignalEvent; index: number }> = ({ event, index }) => {
   const windowDays = getWindowDays(event);
-  const followMarked = followsEarlierWatcher(event, windowDays);
-  const relationship = event.follow_relationship ?? null;
   return (
     <motion.article
       className="relative overflow-hidden rounded-xl border border-white/10 bg-white/[0.035] transition-colors hover:border-cinema-400/25 hover:bg-white/[0.055]"
@@ -194,12 +178,6 @@ const SignalEventCard: React.FC<{ event: GroupSignalEvent; index: number }> = ({
                 </p>
               </div>
               <div className="flex flex-wrap items-center justify-end gap-2">
-                {followMarked ? (
-                  <FollowsEarlierWatcherMarker
-                    earlierWatcher={relationship?.earlier_watcher}
-                    laterWatcher={relationship?.later_watcher}
-                  />
-                ) : null}
                 <SignalStrength event={event} />
               </div>
             </div>
@@ -370,9 +348,6 @@ const SpySignalsResults: React.FC<SpySignalsResultsProps> = ({
 
   const strongestPair = summary.strongest_alignment_pair ?? groupSignals.aligned_pairs[0] ?? null;
   const mostDivisive = summary.most_divisive_title ?? groupSignals.divisive_titles[0] ?? null;
-  const followMarkedEvents = events.filter(
-    (event) => followsEarlierWatcher(event, getWindowDays(event)),
-  ).length;
 
   return (
     <div className="space-y-6">
@@ -436,9 +411,6 @@ const SpySignalsResults: React.FC<SpySignalsResultsProps> = ({
 
           <p className="mb-4 rounded-lg border border-white/10 bg-white/[0.025] px-3 py-2 text-xs leading-5 text-white/45">
             Coverage note: profiles with an authoritative diary use occurrence-level watch history; other profiles fall back to one stored date per title.
-            {followMarkedEvents > 0
-              ? ` A follow marker appears on ${followMarkedEvents} of these matches, meaning the later watcher already followed the earlier one — an observed social link, not evidence that one watch caused another. A match without the marker either had no follow between its watchers or no authoritative social import to read one from.`
-              : ''}
           </p>
 
           {events.length > 0 ? (

--- a/frontend/src/views/WatchTogether.tsx
+++ b/frontend/src/views/WatchTogether.tsx
@@ -319,6 +319,18 @@ export default function WatchTogether() {
         <FeatureState title="Choose a public list" message="Select a list mission above, then find movies to rank its unseen entries for this group." />
       ) : recommendationsQuery.isLoading ? (
         <FeatureState title="Ranking group picks" message="Combining watchlists, ratings, unseen status, metadata, and availability." loading />
+      ) : recommendationsQuery.error ? (
+        // A failure used to fall through to the results panel with no data,
+        // which then said "the recommendation service did not return group
+        // candidates" -- indistinguishable from an empty but successful search,
+        // and it swallowed whatever the API actually reported.
+        <FeatureState
+          title="Group picks could not be loaded"
+          message={
+            (recommendationsQuery.error as { message?: string })?.message
+            ?? 'The request failed. Adjust the selection or filters and try again.'
+          }
+        />
       ) : (
         <WatchTogetherResults
           data={recommendationsQuery.data}


### PR DESCRIPTION
The last four confirmed audit issues.

## Ego view understated its own truncation
`hiddenExtraCount` counted only the edges the request returned — but that request is capped at 80 and the endpoint orders `direction ASC`, serving **all followers before any following rows**. For a profile with 77 followers and 35 following, the page returns 77 followers and *zero* following edges, and both the connection count and the "not shown" note — which exists precisely to admit truncation — understated it.

The response already carries an unfiltered `total`. It's used now.

## A marker that could never appear
The Signal Feed read `follows_earlier_watcher` / `follow_backed` off group-signal events, with a full coverage sentence explaining the marker. The endpoint building those events **has never sent either field** — and cannot meaningfully: *"the later watcher followed the earlier one"* has no single answer once three people are involved.

The pair dossier carries this correctly, where exactly two people make it well defined. The dead marker and the sentence promising it are removed rather than left as something nothing can keep.

## Failure looked like emptiness
A failed request fell through to the results panel with `data` undefined, which reported *"the recommendation service did not return group candidates"* — indistinguishable from an empty but successful search, and it swallowed whatever the API actually said. There's an explicit error branch now.

## A comment upgraded from guess to fact
`ProfileFollowEdge.position` was commented *"source page order approximates recency; Letterboxd does not guarantee it."* Letterboxd's follow lists default to a sort its own UI labels **"WHEN FOLLOWED"**, so the order *is* recency. I also confirmed the pages carry no timestamps of any kind — zero date-shaped strings, person rows have only a `class` attribute — so that ordering is all that can be had.

**All 27 confirmed audit issues are now addressed.**

599 backend tests, 55/55 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)