### PR TITLE
Show what a watchlist film's crowd average is hiding

### DIFF
--- a/backend/services/watchlist_insights.py
+++ b/backend/services/watchlist_insights.py
@@ -105,6 +105,11 @@ class _Candidate:
     title: str
     added_date: Optional[date]
     letterboxd_average: Optional[float]
+    # What the crowd's ten buckets say beyond their mean. Two films can share an
+    # average of 3.5 while one splits the room and the other bores it equally,
+    # and the mean cannot tell them apart.
+    crowd_ceiling: Optional[float]
+    crowd_floor: Optional[float]
     genres: Tuple[str, ...]
     opinions: _Opinions
 
@@ -119,6 +124,44 @@ class _Candidate:
         if self.added_date is None:
             return None
         return max(0, (today - self.added_date).days)
+
+
+# Half-star buckets counted as "this film can be a favourite" and "this film
+# can be a write-off". Deliberately not the extremes alone: a 4.5 is already an
+# enthusiastic verdict, and a 2.0 already a dismissal.
+CEILING_FROM = 4.5
+FLOOR_TO = 2.0
+
+
+def _crowd_shape(distribution: Any) -> Tuple[Optional[float], Optional[float]]:
+    """Share of the crowd at 4.5+ and at 2.0-, from the stored histogram.
+
+    Returns nulls when no histogram has been imported for the film, which is a
+    real state rather than a zero: "nobody rated it highly" and "we have not
+    looked" are different answers.
+    """
+
+    if not isinstance(distribution, dict) or not distribution:
+        return None, None
+    total = 0
+    ceiling = 0
+    floor = 0
+    for key, value in distribution.items():
+        try:
+            stars = float(key)
+            count = int(value)
+        except (TypeError, ValueError):
+            continue
+        if count < 0:
+            continue
+        total += count
+        if stars >= CEILING_FROM:
+            ceiling += count
+        if stars <= FLOOR_TO:
+            floor += count
+    if total <= 0:
+        return None, None
+    return round(ceiling / total, 4), round(floor / total, 4)
 
 
 def _letterboxd_average(value: Any) -> Optional[float]:
@@ -231,6 +274,7 @@ def _candidates(db: Session, profile_id: int) -> List[_Candidate]:
             WatchlistItem.added_date,
             Movie.title,
             Movie.letterboxd_average_rating,
+            Movie.letterboxd_rating_distribution,
             MovieEnrichment.genres,
         )
         .join(Movie, Movie.id == WatchlistItem.movie_id)
@@ -243,17 +287,22 @@ def _candidates(db: Session, profile_id: int) -> List[_Candidate]:
         .all()
     )
     opinions = _group_opinions(db, profile_id)
-    return [
-        _Candidate(
-            movie_id=int(row.movie_id),
-            title=row.title or "",
-            added_date=row.added_date,
-            letterboxd_average=_letterboxd_average(row.letterboxd_average_rating),
-            genres=tuple(_as_string_list(row.genres)),
-            opinions=opinions.get(int(row.movie_id), _Opinions()),
+    candidates = []
+    for row in rows:
+        ceiling, floor = _crowd_shape(row.letterboxd_rating_distribution)
+        candidates.append(
+            _Candidate(
+                movie_id=int(row.movie_id),
+                title=row.title or "",
+                added_date=row.added_date,
+                letterboxd_average=_letterboxd_average(row.letterboxd_average_rating),
+                crowd_ceiling=ceiling,
+                crowd_floor=floor,
+                genres=tuple(_as_string_list(row.genres)),
+                opinions=opinions.get(int(row.movie_id), _Opinions()),
+            )
         )
-        for row in rows
-    ]
+    return candidates
 
 
 def _film_identities(db: Session, movie_ids: Sequence[int]) -> Dict[int, Dict[str, Any]]:
@@ -340,6 +389,10 @@ def _recommendation(
         "group_raters": len(opinions.raters),
         "liked_by": opinions.liked_by,
         "letterboxd_average": _round(candidate.letterboxd_average, 2),
+        # The shape behind that average: what share of the crowd called it a
+        # favourite, and what share wrote it off.
+        "crowd_ceiling": candidate.crowd_ceiling,
+        "crowd_floor": candidate.crowd_floor,
         "added_date": candidate.added_date.isoformat() if candidate.added_date else None,
         "days_waiting": candidate.days_waiting(today),
         "raters": [

--- a/backend/tests/test_watchlist_insights.py
+++ b/backend/tests/test_watchlist_insights.py
@@ -733,6 +733,10 @@ def test_route_serves_the_payload_for_a_tracked_profile(
         "group_raters",
         "liked_by",
         "letterboxd_average",
+        # The distribution behind the average: two films can share a mean while
+        # one has a real chance of being loved and the other reliably does not.
+        "crowd_ceiling",
+        "crowd_floor",
         "added_date",
         "days_waiting",
         "raters",
@@ -831,3 +835,48 @@ def test_a_lone_five_star_does_not_outrank_a_corroborated_favourite(
     assert rows["Lone Favourite"]["group_average"] == 5.0
     assert rows["Lone Favourite"]["group_raters"] == 1
     assert rows["Crowd Favourite"]["group_raters"] == 5
+
+
+def test_the_crowd_shape_separates_two_films_with_the_same_average(
+    database: Session,
+) -> None:
+    """A mean cannot tell a divisive film from a uniformly mediocre one."""
+    subject = _profile(database, "viewer")
+    circle = _circle(database, size=3)
+    polarising = _queued(database, subject, circle, "Polarising", other_ratings=[4.0])
+    flat = _queued(database, subject, circle, "Flat", other_ratings=[4.0])
+    # Same crowd average, very different shapes.
+    polarising.letterboxd_average_rating = 3.5
+    polarising.letterboxd_rating_distribution = {
+        "0.5": 50, "1.0": 50, "1.5": 0, "2.0": 100, "2.5": 0,
+        "3.0": 100, "3.5": 0, "4.0": 100, "4.5": 300, "5.0": 300,
+    }
+    flat.letterboxd_average_rating = 3.5
+    flat.letterboxd_rating_distribution = {
+        "0.5": 0, "1.0": 0, "1.5": 0, "2.0": 0, "2.5": 200,
+        "3.0": 300, "3.5": 400, "4.0": 100, "4.5": 0, "5.0": 0,
+    }
+    database.commit()
+
+    entries = {
+        entry["title"]: entry
+        for entry in _insights(database, subject)["recommendations"]
+    }
+
+    assert entries["Polarising"]["crowd_ceiling"] > entries["Flat"]["crowd_ceiling"]
+    assert entries["Polarising"]["crowd_floor"] > entries["Flat"]["crowd_floor"]
+    assert entries["Flat"]["crowd_ceiling"] == 0.0
+
+
+def test_a_film_with_no_histogram_reports_no_shape_rather_than_zero(
+    database: Session,
+) -> None:
+    """"Nobody rated it highly" and "we have not looked" are different answers."""
+    subject = _profile(database, "viewer")
+    circle = _circle(database, size=3)
+    _queued(database, subject, circle, "Unscraped", other_ratings=[4.0])
+
+    entry = _insights(database, subject)["recommendations"][0]
+
+    assert entry["crowd_ceiling"] is None
+    assert entry["crowd_floor"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -473,6 +473,8 @@ export const watchlistInsights = {
       group_raters: 4,
       liked_by: 3,
       letterboxd_average: 4.11,
+      crowd_ceiling: 0.42,
+      crowd_floor: 0.03,
       added_date: '2024-02-11',
       days_waiting: 871,
       raters: [
@@ -620,6 +622,8 @@ export const ratingComparison = {
       delta: 1.75,
       rater_count: 4,
       letterboxd_average: 3.21,
+      crowd_ceiling: 0.42,
+      crowd_floor: 0.03,
     },
     {
       title: 'Unenriched Champion',
@@ -644,6 +648,8 @@ export const ratingComparison = {
       delta: -2.33,
       rater_count: 5,
       letterboxd_average: 3.94,
+      crowd_ceiling: 0.42,
+      crowd_floor: 0.03,
     },
   ],
   most_divisive: [

--- a/frontend/src/components/insights/WatchlistPanel.tsx
+++ b/frontend/src/components/insights/WatchlistPanel.tsx
@@ -61,6 +61,12 @@ function QueueRow({ film, rank }: { film: WatchlistRecommendation; rank: number 
     `${formatInsightCount(film.group_raters)} ${film.group_raters === 1 ? 'rater' : 'raters'}`,
     film.liked_by > 0 ? `${formatInsightCount(film.liked_by)} liked` : null,
     film.letterboxd_average !== null ? `Letterboxd ${film.letterboxd_average.toFixed(2)}` : null,
+    // Two films can share an average while one has a real chance of being loved
+    // and the other reliably does not; the crowd's own high-end share says
+    // which is which.
+    film.crowd_ceiling !== null
+      ? `${Math.round(film.crowd_ceiling * 100)}% rated it 4.5+`
+      : null,
   ].filter((note): note is string => note !== null);
 
   return (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1526,6 +1526,12 @@ export interface WatchlistRecommendation {
   group_raters: number;
   liked_by: number;
   letterboxd_average: number | null;
+  /** Share of Letterboxd's crowd that rated it 4.5+ — how much room the film has
+   *  to become a favourite. Null when no histogram has been imported, which is
+   *  not the same as nobody rating it highly. */
+  crowd_ceiling: number | null;
+  /** Share that rated it 2.0 or below. */
+  crowd_floor: number | null;
   added_date: string | null;
   /** Null when the import carried no added date: an unknown wait, not a zero-day one. */
   days_waiting: number | null;


### PR DESCRIPTION
The queue reported Letterboxd's **mean**, which cannot separate a film that splits the room from one that bores it equally. Two entries averaging 3.5 are a very different proposition if 30% of the crowd called one of them a favourite.

The ten-bucket histogram — imported for **1,970 of the 2,030** films on tracked watchlists — already answers this, and nothing read it.

Each row now carries:
- **`crowd_ceiling`** — share rated 4.5+, i.e. how much room it has to become a favourite
- **`crowd_floor`** — share rated 2.0 or below

Real queue for `whiteknight03x`:

| film | Letterboxd avg | 4.5+ | 2.0− |
|---|---|---|---|
| Portrait of a Lady on Fire | 4.43 | **63%** | 2% |
| Incendies | 4.45 | 61% | 1% |
| Little Miss Sunshine | 4.22 | 48% | 2% |
| Paterson | 3.89 | **27%** | 5% |

## Null is not zero
A film whose histogram hasn't been imported reports `null`, not `0`. *"Nobody rated it highly"* and *"we haven't looked"* are different answers and the panel must not conflate them — there's a test for it.

604 backend tests (2 new: the shape separates two films sharing an average, and a film with no histogram reports no shape), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)