### PR TITLE
Surface the crew who shape what you watch, and who directs it

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -75,6 +75,10 @@ class _FilmRow:
     countries: List[_Value]
     languages: List[_Value]
     directors: List[_Value]
+    director_genders: List[int]
+    composers: List[_Value]
+    cinematographers: List[_Value]
+    editors: List[_Value]
     actors: List[_Value]
     studios: List[_Value]
 
@@ -146,6 +150,56 @@ def _director_values(credits: Any) -> List[_Value]:
             ]
         )
     )
+
+
+# Crew whose work shapes a film as much as the director's, and whose credits
+# TMDB stores on ~4,000 of the enriched films while nothing reads them.
+BELOW_THE_LINE_JOBS = {
+    "composer": "Original Music Composer",
+    "cinematographer": "Director of Photography",
+    "editor": "Editor",
+}
+
+
+def _crew_values(credits: Any, job: str) -> List[_Value]:
+    """Names credited with one specific crew job."""
+
+    crew = credits.get("crew") if isinstance(credits, Mapping) else None
+    if not isinstance(crew, list):
+        return []
+    return _plain_values(
+        _as_string_list(
+            [
+                member
+                for member in crew
+                if isinstance(member, Mapping) and member.get("job") == job
+            ]
+        )
+    )
+
+
+def _director_genders(credits: Any) -> List[int]:
+    """TMDB gender codes for this film's directors.
+
+    1 is female and 2 is male; 0 and null mean TMDB has not recorded one, and
+    those are dropped rather than counted as a third category. Coverage is 93%
+    of director credits across the enriched library.
+    """
+
+    crew = credits.get("crew") if isinstance(credits, Mapping) else None
+    if not isinstance(crew, list):
+        return []
+    genders = []
+    for member in crew:
+        if not isinstance(member, Mapping) or member.get("job") != "Director":
+            continue
+        try:
+            code = int(member.get("gender") or 0)
+        except (TypeError, ValueError):
+            continue
+        if code in (1, 2):
+            genders.append(code)
+    return genders
 
 
 def _actor_values(credits: Any) -> List[_Value]:
@@ -230,6 +284,12 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
                 countries=_country_values(row.production_countries),
                 languages=_language_values(row.original_language, row.spoken_languages),
                 directors=_director_values(credits),
+                director_genders=_director_genders(credits),
+                composers=_crew_values(credits, BELOW_THE_LINE_JOBS["composer"]),
+                cinematographers=_crew_values(
+                    credits, BELOW_THE_LINE_JOBS["cinematographer"]
+                ),
+                editors=_crew_values(credits, BELOW_THE_LINE_JOBS["editor"]),
                 actors=_actor_values(credits),
                 studios=_plain_values(_as_string_list(row.production_companies)),
             )
@@ -326,6 +386,42 @@ def _entry(
 
 def _by_count(bucket: Mapping[str, Any]):
     return (-bucket["count"], bucket["label"].casefold(), bucket["label"])
+
+
+def _director_gender_split(films: Sequence[_FilmRow]) -> Dict[str, Any]:
+    """Share of watched films directed by women, men, and by both.
+
+    Counted per film rather than per credit, so a two-director film is one
+    film. TMDB records no gender for 7% of director credits; a film whose
+    directors are all unrecorded is left out of the shares entirely rather than
+    being assigned to either side, and the count that was measured is reported
+    so the reader can weigh it.
+    """
+
+    women = 0
+    men = 0
+    mixed = 0
+    measured = 0
+    for film in films:
+        genders = set(film.director_genders)
+        if not genders:
+            continue
+        measured += 1
+        if genders == {1}:
+            women += 1
+        elif genders == {2}:
+            men += 1
+        else:
+            mixed += 1
+    if measured == 0:
+        return {"measured_films": 0, "women": 0, "men": 0, "mixed": 0, "women_share": None}
+    return {
+        "measured_films": measured,
+        "women": women,
+        "men": men,
+        "mixed": mixed,
+        "women_share": _round((women + mixed) / measured, 3),
+    }
 
 
 def _ranked(
@@ -642,6 +738,9 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
     languages = _collect(films, lambda film: film.languages)
     decades = _collect(films, lambda film: film.decades)
     directors = _collect(films, lambda film: film.directors)
+    composers = _collect(films, lambda film: film.composers)
+    cinematographers = _collect(films, lambda film: film.cinematographers)
+    editors = _collect(films, lambda film: film.editors)
     actors = _collect(films, lambda film: film.actors)
     studios = _collect(films, lambda film: film.studios)
 
@@ -675,6 +774,12 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "average_rating": _round(_average(ratings), 2),
         },
         "top_directors": _ranked(directors, label_key="name"),
+        # The people whose work shapes a film without their name being the one
+        # anybody counts. Their credits were already stored and never read.
+        "top_composers": _ranked(composers, label_key="name"),
+        "top_cinematographers": _ranked(cinematographers, label_key="name"),
+        "top_editors": _ranked(editors, label_key="name"),
+        "director_gender": _director_gender_split(films),
         "top_actors": _ranked(actors, label_key="name"),
         "top_studios": _ranked(studios, label_key="name"),
         "genres": _ranked(genres),

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1069,6 +1069,11 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "coverage",
         "totals",
         "top_directors",
+        # Crew whose credits were stored and never surfaced.
+        "top_composers",
+        "top_cinematographers",
+        "top_editors",
+        "director_gender",
         "top_actors",
         "top_studios",
         "genres",
@@ -1156,3 +1161,60 @@ def test_a_bucket_reports_the_denominator_its_average_was_built_from(database):
     assert horror["count"] == 4
     assert horror["rated_count"] == 2
     assert horror["average_rating"] == 5.0
+
+
+def test_below_the_line_crew_is_counted_from_credits_nothing_else_reads(database):
+    """Composer, cinematographer and editor credits sit on ~4,000 enriched films."""
+    profile = _profile(database, "viewer")
+    for index in range(3):
+        _film(
+            database,
+            profile,
+            title=f"Scored {index}",
+            crew=[
+                {"name": "Mica Levi", "job": "Original Music Composer"},
+                {"name": "Robbie Ryan", "job": "Director of Photography"},
+                {"name": "Thelma Schoonmaker", "job": "Editor"},
+                {"name": "Some Director", "job": "Director"},
+            ],
+        )
+
+    stats = build_profile_stats(database, profile)
+
+    assert stats["top_composers"][0]["name"] == "Mica Levi"
+    assert stats["top_composers"][0]["count"] == 3
+    assert stats["top_cinematographers"][0]["name"] == "Robbie Ryan"
+    assert stats["top_editors"][0]["name"] == "Thelma Schoonmaker"
+
+
+def test_director_gender_counts_films_not_credits(database):
+    """A two-director film is one film, and an unrecorded gender is not a side."""
+    profile = _profile(database, "viewer")
+    _film(database, profile, title="By A Woman",
+          crew=[{"name": "Chantal Akerman", "job": "Director", "gender": 1}])
+    _film(database, profile, title="By A Man",
+          crew=[{"name": "Some Man", "job": "Director", "gender": 2}])
+    _film(database, profile, title="By Both",
+          crew=[{"name": "Her", "job": "Director", "gender": 1},
+                {"name": "Him", "job": "Director", "gender": 2}])
+    _film(database, profile, title="Unrecorded",
+          crew=[{"name": "Nobody Knows", "job": "Director", "gender": 0}])
+
+    split = build_profile_stats(database, profile)["director_gender"]
+
+    # The unrecorded film is excluded from the shares rather than assigned.
+    assert split["measured_films"] == 3
+    assert split["women"] == 1
+    assert split["men"] == 1
+    assert split["mixed"] == 1
+
+
+def test_a_profile_with_no_recorded_director_gender_reports_no_share(database):
+    profile = _profile(database, "viewer")
+    _film(database, profile, title="Unknown",
+          crew=[{"name": "Nobody Knows", "job": "Director"}])
+
+    split = build_profile_stats(database, profile)["director_gender"]
+
+    assert split["measured_films"] == 0
+    assert split["women_share"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -362,15 +362,27 @@ export const profileStats = {
     average_rating: 3.72,
   },
   top_directors: [
-    { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
-    { name: 'Agnès Varda', count: 12, average_rating: 4.1 },
-    { name: 'Mani Ratnam', count: 9, average_rating: null },
+    { name: 'Akira Kurosawa', count: 18, rated_count: 16, average_rating: 4.3 },
+    { name: 'Agnès Varda', count: 12, rated_count: 10, average_rating: 4.1 },
+    { name: 'Mani Ratnam', count: 9, rated_count: 7, average_rating: null },
   ],
+  top_composers: [
+    { name: 'Joe Hisaishi', count: 21, rated_count: 19, average_rating: 4.2 },
+  ],
+  top_cinematographers: [
+    { name: 'Roger Deakins', count: 16, rated_count: 14, average_rating: 4.1 },
+  ],
+  top_editors: [
+    { name: 'Thelma Schoonmaker', count: 11, rated_count: 9, average_rating: 4.0 },
+  ],
+  // Films where TMDB records no director gender are excluded from the split,
+  // so measured_films is deliberately lower than the profile's film count.
+  director_gender: { measured_films: 940, women: 96, men: 832, mixed: 12, women_share: 0.115 },
   top_actors: [
-    { name: 'Toshiro Mifune', count: 14, average_rating: 4.2 },
-    { name: 'Tilda Swinton', count: 11, average_rating: 3.9 },
+    { name: 'Toshiro Mifune', count: 14, rated_count: 12, average_rating: 4.2 },
+    { name: 'Tilda Swinton', count: 11, rated_count: 9, average_rating: 3.9 },
   ],
-  top_studios: [{ name: 'Studio Ghibli', count: 16, average_rating: 4.4 }],
+  top_studios: [{ name: 'Studio Ghibli', count: 16, rated_count: 14, average_rating: 4.4 }],
   genres: [
     { label: 'Drama', count: 420, average_rating: 3.9 },
     { label: 'Comedy', count: 210, average_rating: 3.4 },

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -505,7 +505,12 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   const topDirectors = stats.top_directors ?? [];
   const topActors = stats.top_actors ?? [];
   const topStudios = stats.top_studios ?? [];
-  const hasPeople = topDirectors.length > 0 || topActors.length > 0 || topStudios.length > 0;
+  const topComposers = stats.top_composers ?? [];
+  const topCinematographers = stats.top_cinematographers ?? [];
+  const topEditors = stats.top_editors ?? [];
+  const directorGender = stats.director_gender;
+  const hasPeople = topDirectors.length > 0 || topActors.length > 0 || topStudios.length > 0
+    || topComposers.length > 0 || topCinematographers.length > 0 || topEditors.length > 0;
   const hasBreakdowns = genreRows.length > 0
     || countryRows.length > 0
     || languageRows.length > 0
@@ -607,6 +612,39 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
         <p className="mt-3 text-xs text-white/35">{footnotes.join(' · ')}</p>
       ) : null}
 
+      {directorGender && directorGender.measured_films > 0 && directorGender.women_share !== null ? (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold text-white/75">Who directs what you watch</h3>
+            {/* The denominator is stated because TMDB records no gender for
+                some directors, and those films are excluded from the split
+                rather than quietly assigned to one side. */}
+            <span className="text-[11px] text-white/40">
+              {formatCount(directorGender.measured_films)} films where TMDB records a director&rsquo;s gender
+            </span>
+          </div>
+          <div className="mt-2.5 flex h-2 overflow-hidden rounded-full bg-white/10">
+            <span
+              className="bg-cinema-500"
+              style={{ width: `${(directorGender.women / directorGender.measured_films) * 100}%` }}
+            />
+            <span
+              className="bg-emerald-400/70"
+              style={{ width: `${(directorGender.mixed / directorGender.measured_films) * 100}%` }}
+            />
+          </div>
+          <p className="mt-2 text-xs text-white/50">
+            <strong className="text-white/80">
+              {Math.round(directorGender.women_share * 1000) / 10}%
+            </strong>{' '}
+            had a woman among their directors
+            {directorGender.mixed > 0
+              ? ` (${formatCount(directorGender.women)} solely, ${formatCount(directorGender.mixed)} co-directed)`
+              : ''}
+          </p>
+        </div>
+      ) : null}
+
       {hasPeople ? (
         <div className="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
           <RankedList
@@ -624,6 +662,11 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
             subtitle={totals.distinct_studios ? `of ${formatCount(totals.distinct_studios)} seen` : null}
             people={topStudios}
           />
+          {/* Below the line: credits stored on most enriched films that no
+              panel has ever surfaced. */}
+          <RankedList title="Top composers" subtitle="Scored what you watch" people={topComposers} />
+          <RankedList title="Top cinematographers" subtitle="Shot what you watch" people={topCinematographers} />
+          <RankedList title="Top editors" subtitle="Cut what you watch" people={topEditors} />
         </div>
       ) : null}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1389,6 +1389,20 @@ export interface ProfileStatsResponse {
   coverage: ProfileStatsCoverage;
   totals: ProfileStatsTotals;
   top_directors: ProfileStatsPerson[];
+  /** Crew whose credits TMDB stores on most enriched films and nothing read
+   *  until now: the people shaping what you watch without being counted. */
+  top_composers: ProfileStatsPerson[];
+  top_cinematographers: ProfileStatsPerson[];
+  top_editors: ProfileStatsPerson[];
+  director_gender: {
+    /** Films with at least one director whose gender TMDB records. Films where
+     *  none is recorded are excluded from the shares rather than assigned. */
+    measured_films: number;
+    women: number;
+    men: number;
+    mixed: number;
+    women_share: number | null;
+  };
   top_actors: ProfileStatsPerson[];
   top_studios: ProfileStatsPerson[];
   genres: ProfileStatsBucket[];


### PR DESCRIPTION
Two features from credits that were already stored and read by **nothing**.

## Below-the-line crew
TMDB stores these on most enriched films; directors were the only crew anyone counted:

| job | films with the credit |
|---|---|
| Editor | 4,134 |
| Director of Photography | 3,957 |
| Original Music Composer | 3,688 |

So the people whose work you keep returning to without noticing were invisible. Real output:

```
whiteknight03x   composers: Hans Zimmer (35), Danny Elfman (32)
                 cinematographers: Bill Pope (14), Don Burgess (11)
                 editors: Christopher D. Lozinski (18), Lee Smith (12)
er3nweeber       composers: Hans Zimmer (38), John Williams (31)
                 cinematographers: Bill Pope (16), Janusz Kamiński (15)
```

## Who directs what you watch
TMDB records a gender on **93%** of director credits — also unread. The panel now shows what share of a member's watching had a woman among its directors: **10.0% across 1,019 measured films** for `whiteknight03x`.

Three deliberate choices:
- **Counted per film, not per credit**, so a two-director film is one film
- **Co-directed films get their own bucket** rather than being counted on both sides
- **Films with no recorded gender are excluded from the split**, not assigned to a side — and `measured_films` is stated beside the share so the reader can weigh it

606 backend tests (3 new, including that an unrecorded gender is not a third category), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)