### PR TITLE
Show the rhythm behind a watch count, not just the total

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -253,6 +253,66 @@ def _dated_watch_dates(db: Session, profile_id: int) -> List[date]:
     ]
 
 
+WEEKDAY_NAMES = ("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
+# A gap this long reads as having stopped rather than having paused.
+DRY_SPELL_DAYS = 30
+
+
+def build_cadence(dates: Sequence[date]) -> Dict[str, Any]:
+    """The rhythm behind a watch count: how often, on which days, and when it stopped.
+
+    Two profiles with the same total look nothing alike if one watches every
+    Saturday and the other disappeared for four months and binged. Everything
+    here comes from watch-event dates alone.
+
+    Weekday counts use every event, so two films on one Saturday count twice --
+    the question is where the watching happens, not how many distinct days.
+    Active days and gaps deliberately collapse to distinct dates instead.
+    """
+
+    if not dates:
+        return {
+            "active_days": 0,
+            "span_days": None,
+            "days_per_active_week": None,
+            "weekday_counts": {name: 0 for name in WEEKDAY_NAMES},
+            "busiest_weekday": None,
+            "longest_dry_spell_days": None,
+            "dry_spell_started": None,
+        }
+
+    ordered = sorted(dates)
+    distinct = sorted(set(ordered))
+    span = (distinct[-1] - distinct[0]).days
+
+    weekday_counts = {name: 0 for name in WEEKDAY_NAMES}
+    for value in ordered:
+        weekday_counts[WEEKDAY_NAMES[value.weekday()]] += 1
+    busiest = max(weekday_counts.items(), key=lambda item: (item[1], -WEEKDAY_NAMES.index(item[0])))
+
+    longest_gap = 0
+    gap_started: Optional[date] = None
+    for earlier, later in zip(distinct, distinct[1:]):
+        gap = (later - earlier).days
+        if gap > longest_gap:
+            longest_gap = gap
+            gap_started = earlier
+
+    return {
+        "active_days": len(distinct),
+        "span_days": span or None,
+        # Days watched per week of the span, which separates a steady watcher
+        # from one who logged the same total in a handful of binges.
+        "days_per_active_week": (
+            _round(len(distinct) / (span / 7), 2) if span >= 7 else None
+        ),
+        "weekday_counts": weekday_counts,
+        "busiest_weekday": busiest[0] if busiest[1] > 0 else None,
+        "longest_dry_spell_days": longest_gap if longest_gap >= DRY_SPELL_DAYS else None,
+        "dry_spell_started": gap_started.isoformat() if longest_gap >= DRY_SPELL_DAYS and gap_started else None,
+    }
+
+
 def longest_streak_weeks(dates: Sequence[date]) -> Optional[int]:
     """Longest run of consecutive ISO weeks that each contain a watch.
 
@@ -674,6 +734,9 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "rewatches": sum(film.rewatch_count for film in films),
             "average_rating": _round(_average(ratings), 2),
         },
+        # Rhythm, not volume: the same film count looks different depending on
+        # whether it arrived weekly or in two binges either side of a silence.
+        "cadence": build_cadence(watch_dates),
         "top_directors": _ranked(directors, label_key="name"),
         "top_actors": _ranked(actors, label_key="name"),
         "top_studios": _ranked(studios, label_key="name"),

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -26,6 +26,7 @@ from database.models import (
     WatchEvent,
 )
 from services.profile_stats import (
+    build_cadence,
     build_profile_stats,
     longest_streak_weeks,
     median_length_chars,
@@ -1068,6 +1069,8 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "username",
         "coverage",
         "totals",
+        # Rhythm alongside volume.
+        "cadence",
         "top_directors",
         "top_actors",
         "top_studios",
@@ -1156,3 +1159,40 @@ def test_a_bucket_reports_the_denominator_its_average_was_built_from(database):
     assert horror["count"] == 4
     assert horror["rated_count"] == 2
     assert horror["average_rating"] == 5.0
+
+
+# Rhythm behind a watch count: two profiles with the same total look nothing
+# alike if one watches every Saturday and the other vanished for four months
+# and binged.
+
+
+def test_weekday_counts_use_every_event_not_distinct_days():
+    """Two films on one Saturday is two Saturday watches."""
+    cadence = build_cadence([date(2026, 7, 4), date(2026, 7, 4), date(2026, 7, 6)])
+
+    assert cadence["weekday_counts"]["Sat"] == 2
+    assert cadence["weekday_counts"]["Mon"] == 1
+    assert cadence["busiest_weekday"] == "Sat"
+
+
+def test_active_days_collapse_to_distinct_dates():
+    assert build_cadence([date(2026, 7, 4), date(2026, 7, 4)])["active_days"] == 1
+
+
+def test_a_long_silence_is_reported_with_the_date_it_began():
+    cadence = build_cadence([date(2026, 1, 1), date(2026, 1, 2), date(2026, 6, 1)])
+
+    assert cadence["longest_dry_spell_days"] == 150
+    assert cadence["dry_spell_started"] == "2026-01-02"
+
+
+def test_an_ordinary_week_off_is_not_a_dry_spell():
+    assert build_cadence([date(2026, 1, 1), date(2026, 1, 8)])["longest_dry_spell_days"] is None
+
+
+def test_a_profile_with_no_dated_events_reports_zeroes_not_nulls():
+    cadence = build_cadence([])
+
+    assert cadence["active_days"] == 0
+    assert cadence["busiest_weekday"] is None
+    assert cadence["weekday_counts"]["Mon"] == 0

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -361,6 +361,16 @@ export const profileStats = {
     rewatches: 64,
     average_rating: 3.72,
   },
+  // A profile that watches most on Saturdays and went quiet for six weeks.
+  cadence: {
+    active_days: 301,
+    span_days: 1079,
+    days_per_active_week: 1.95,
+    weekday_counts: { Mon: 221, Tue: 123, Wed: 187, Thu: 230, Fri: 207, Sat: 273, Sun: 222 },
+    busiest_weekday: 'Sat',
+    longest_dry_spell_days: 41,
+    dry_spell_started: '2024-05-26',
+  },
   top_directors: [
     { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
     { name: 'Agnès Varda', count: 12, average_rating: 4.1 },

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1388,6 +1388,18 @@ export interface ProfileStatsResponse {
   username: string;
   coverage: ProfileStatsCoverage;
   totals: ProfileStatsTotals;
+  /** Rhythm rather than volume: the same film count reads differently if it
+   *  arrived weekly or in two binges either side of a silence. */
+  cadence: {
+    active_days: number;
+    span_days: number | null;
+    days_per_active_week: number | null;
+    weekday_counts: Record<string, number>;
+    busiest_weekday: string | null;
+    /** Only set when the silence is long enough to read as a stop, not a pause. */
+    longest_dry_spell_days: number | null;
+    dry_spell_started: string | null;
+  };
   top_directors: ProfileStatsPerson[];
   top_actors: ProfileStatsPerson[];
   top_studios: ProfileStatsPerson[];


### PR DESCRIPTION
Two profiles with the same film count look nothing alike if one watches every Saturday and the other vanished for four months and binged. Nothing in the panel could tell them apart.

Watch-event dates already held the answer:

| | whiteknight03x | pamarvss |
|---|---|---|
| days watched | 301 of 1,079 | 471 of 838 |
| per week | **1.95** | **3.93** |
| busiest day | **Sat** | **Sun** |
| longest silence | 41 days, from 2024-05-26 | none |

## Three deliberate choices
- **Weekday counts use every event** — two films on one Saturday is two Saturday watches, because the question is where the watching *lands*.
- **Active days and gaps collapse to distinct dates** — a different question, so a different denominator.
- **A silence is only reported past thirty days**, so an ordinary week off doesn't read as having stopped. Tested both ways.

606 backend tests (5 new), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)