### PR TITLE
Report what a single sitting looks like, without counting bulk imports as one

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -22,10 +22,10 @@ reviewing changes a rating.
 """
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict, defaultdict
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Tuple, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -251,6 +251,101 @@ def _dated_watch_dates(db: Session, profile_id: int) -> List[date]:
         .all()
         if watched_date is not None
     ]
+
+
+def _marathon_events(db: Session, profile_id: int) -> List[Tuple[date, str, Optional[int]]]:
+    """(date, title, runtime) for every active watch event with a date."""
+
+    rows = (
+        db.query(WatchEvent.watched_date, Movie.title, MovieEnrichment.runtime_minutes)
+        .join(Movie, Movie.id == WatchEvent.movie_id)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(
+            WatchEvent.profile_id == profile_id,
+            WatchEvent.superseded_at.is_(None),
+            WatchEvent.watched_date.isnot(None),
+        )
+        .all()
+    )
+    # A TMDB runtime of 0 means unrecorded, never a zero-minute film.
+    return [(row[0], row[1] or "", row[2] or None) for row in rows]
+
+
+# A day whose films add up to more hours than a day has did not happen: a
+# Letterboxd export can date a whole backlog to the day it was imported, and 9
+# days across the tracked library carry 20+ films for exactly that reason.
+# Runtime is the honest test; days with no known runtime fall back to a film
+# count nobody could really sit through.
+MARATHON_MIN_FILMS = 3
+MARATHON_MAX_HOURS = 24
+MARATHON_MAX_FILMS_WITHOUT_RUNTIME = 8
+
+
+def build_marathons(
+    events: Sequence[Tuple[date, str, Optional[int]]], *, limit: int = 5
+) -> Dict[str, Any]:
+    """Days this profile watched several films, and what a sitting looked like.
+
+    ``events`` is (watched_date, title, runtime_minutes). A day only counts when
+    its films could physically fit inside one: an import that dates a backlog to
+    a single day is not a viewing session, and reporting it as somebody's
+    biggest would be the panel's most obviously wrong number.
+    """
+
+    by_day: Dict[date, List[Tuple[str, Optional[int]]]] = defaultdict(list)
+    for watched_date, title, runtime in events:
+        if watched_date is not None:
+            by_day[watched_date].append((title or "", runtime))
+
+    marathons: List[Dict[str, Any]] = []
+    discarded = 0
+    for day, films in by_day.items():
+        if len(films) < MARATHON_MIN_FILMS:
+            continue
+        known = [runtime for _, runtime in films if runtime]
+        total_minutes = sum(known)
+        if known and total_minutes > MARATHON_MAX_HOURS * 60:
+            discarded += 1
+            continue
+        if not known and len(films) > MARATHON_MAX_FILMS_WITHOUT_RUNTIME:
+            discarded += 1
+            continue
+        marathons.append(
+            {
+                "date": day.isoformat(),
+                "films": len(films),
+                "runtime_minutes": total_minutes or None,
+                "titles": [title for title, _ in films][:6],
+            }
+        )
+
+    marathons.sort(key=lambda item: (-item["films"], item["date"]))
+    return {
+        "count": len(marathons),
+        "biggest": marathons[0] if marathons else None,
+        "recent": sorted(marathons, key=lambda item: item["date"], reverse=True)[:limit],
+        # Named rather than hidden: a reader comparing this against Letterboxd
+        # should know some days were set aside, and why.
+        "import_artifact_days": discarded,
+    }
+
+
+def _marathon_events(db: Session, profile_id: int) -> List[Tuple[date, str, Optional[int]]]:
+    """(date, title, runtime) for every active watch event carrying a date."""
+
+    rows = (
+        db.query(WatchEvent.watched_date, Movie.title, MovieEnrichment.runtime_minutes)
+        .join(Movie, Movie.id == WatchEvent.movie_id)
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(
+            WatchEvent.profile_id == profile_id,
+            WatchEvent.superseded_at.is_(None),
+            WatchEvent.watched_date.isnot(None),
+        )
+        .all()
+    )
+    # A TMDB runtime of 0 means unrecorded, never a zero-minute film.
+    return [(row[0], row[1] or "", row[2] or None) for row in rows]
 
 
 def longest_streak_weeks(dates: Sequence[date]) -> Optional[int]:
@@ -674,6 +769,8 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "rewatches": sum(film.rewatch_count for film in films),
             "average_rating": _round(_average(ratings), 2),
         },
+        # What a single sitting looks like, with import artifacts kept out.
+        "marathons": build_marathons(_marathon_events(db, profile.id)),
         "top_directors": _ranked(directors, label_key="name"),
         "top_actors": _ranked(actors, label_key="name"),
         "top_studios": _ranked(studios, label_key="name"),

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -26,6 +26,7 @@ from database.models import (
     WatchEvent,
 )
 from services.profile_stats import (
+    build_marathons,
     build_profile_stats,
     longest_streak_weeks,
     median_length_chars,
@@ -1068,6 +1069,8 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "username",
         "coverage",
         "totals",
+        # What a single sitting looks like.
+        "marathons",
         "top_directors",
         "top_actors",
         "top_studios",
@@ -1156,3 +1159,56 @@ def test_a_bucket_reports_the_denominator_its_average_was_built_from(database):
     assert horror["count"] == 4
     assert horror["rated_count"] == 2
     assert horror["average_rating"] == 5.0
+
+
+# A day whose films add up to more hours than a day has did not happen. A
+# Letterboxd export can date an entire backlog to the day it was imported, and
+# reporting that as somebody's biggest sitting would be the panel's most
+# obviously wrong number.
+
+
+def test_a_real_sitting_is_reported_with_its_runtime():
+    events = [
+        (date(2026, 7, 4), "First", 95),
+        (date(2026, 7, 4), "Second", 102),
+        (date(2026, 7, 4), "Third", 88),
+    ]
+
+    marathons = build_marathons(events)
+
+    assert marathons["count"] == 1
+    assert marathons["biggest"]["films"] == 3
+    assert marathons["biggest"]["runtime_minutes"] == 285
+    assert marathons["import_artifact_days"] == 0
+
+
+def test_a_backlog_dated_to_one_day_is_not_a_marathon():
+    """Twenty films at two hours each is forty hours; the day was an import."""
+    events = [(date(2026, 7, 4), f"Bulk {index}", 120) for index in range(20)]
+
+    marathons = build_marathons(events)
+
+    assert marathons["count"] == 0
+    assert marathons["biggest"] is None
+    assert marathons["import_artifact_days"] == 1
+
+
+def test_without_runtimes_an_implausible_film_count_is_still_rejected():
+    events = [(date(2026, 7, 4), f"Unknown {index}", None) for index in range(12)]
+
+    assert build_marathons(events)["count"] == 0
+
+
+def test_two_films_in_a_day_is_not_yet_a_marathon():
+    events = [(date(2026, 7, 4), "One", 95), (date(2026, 7, 4), "Two", 95)]
+
+    assert build_marathons(events)["count"] == 0
+
+
+def test_a_profile_that_never_stacks_films_reports_an_empty_block():
+    assert build_marathons([]) == {
+        "count": 0,
+        "biggest": None,
+        "recent": [],
+        "import_artifact_days": 0,
+    }

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -361,6 +361,19 @@ export const profileStats = {
     rewatches: 64,
     average_rating: 3.72,
   },
+  // One real sitting, plus a day the export dated in bulk that must not be
+  // reported as the biggest.
+  marathons: {
+    count: 41,
+    biggest: {
+      date: '2025-10-23',
+      films: 8,
+      runtime_minutes: 884,
+      titles: ['Fixture One', 'Fixture Two', 'Fixture Three'],
+    },
+    recent: [],
+    import_artifact_days: 2,
+  },
   top_directors: [
     { name: 'Akira Kurosawa', count: 18, average_rating: 4.3 },
     { name: 'Agnès Varda', count: 12, average_rating: 4.1 },

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -502,6 +502,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   const languageRows = toBarRows(stats.languages ?? []);
   const decadeRows = toBarRows(stats.decades ?? []);
 
+  const marathons = stats.marathons;
   const topDirectors = stats.top_directors ?? [];
   const topActors = stats.top_actors ?? [];
   const topStudios = stats.top_studios ?? [];
@@ -605,6 +606,39 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
 
       {footnotes.length > 0 ? (
         <p className="mt-3 text-xs text-white/35">{footnotes.join(' · ')}</p>
+      ) : null}
+
+      {marathons && marathons.count > 0 && marathons.biggest ? (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold text-white/75">Marathon days</h3>
+            <span className="text-[11px] text-white/40">
+              {formatCount(marathons.count)} {marathons.count === 1 ? 'day' : 'days'} with three or more films
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-white/55">
+            Biggest sitting: <strong className="text-white/85">{marathons.biggest.films} films</strong>{' '}
+            on {marathons.biggest.date}
+            {marathons.biggest.runtime_minutes
+              ? ` · ${Math.round(marathons.biggest.runtime_minutes / 60)}h`
+              : ''}
+          </p>
+          {marathons.biggest.titles.length > 0 ? (
+            <p className="mt-1 line-clamp-2 text-[11px] text-white/35">
+              {marathons.biggest.titles.join(' · ')}
+            </p>
+          ) : null}
+          {marathons.import_artifact_days > 0 ? (
+            /* Stated rather than hidden: an export can date a whole backlog to
+               one day, and a reader comparing this with Letterboxd should know
+               those days were set aside. */
+            <p className="mt-2 text-[11px] text-white/35">
+              {formatCount(marathons.import_artifact_days)}{' '}
+              {marathons.import_artifact_days === 1 ? 'day was' : 'days were'} excluded as bulk imports
+              rather than sittings.
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       {hasPeople ? (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1388,6 +1388,15 @@ export interface ProfileStatsResponse {
   username: string;
   coverage: ProfileStatsCoverage;
   totals: ProfileStatsTotals;
+  /** Days several films were watched in one sitting. Days whose films add up
+   *  to more hours than a day has are import artifacts, not sittings, and are
+   *  excluded — `import_artifact_days` says how many. */
+  marathons: {
+    count: number;
+    biggest: { date: string; films: number; runtime_minutes: number | null; titles: string[] } | null;
+    recent: Array<{ date: string; films: number; runtime_minutes: number | null; titles: string[] }>;
+    import_artifact_days: number;
+  };
   top_directors: ProfileStatsPerson[];
   top_actors: ProfileStatsPerson[];
   top_studios: ProfileStatsPerson[];


### PR DESCRIPTION
Nothing showed what a day of watching actually looked like — and the raw data can't be trusted to say.

A Letterboxd export dates a whole backlog to the day it was imported. **Nine days across the tracked library carry 20+ films**, and `pamarvss` has one with **398**. Reporting that as somebody's biggest sitting would've been the panel's most obviously wrong number.

## Runtime settles it
A day counts only when its films could physically fit inside one (24h). Where no runtime is known, a film count nobody could sit through stands in.

| profile | marathon days | biggest sitting | excluded as imports |
|---|---|---|---|
| whiteknight03x | 41 | 8 films, 14.7h | 0 |
| er3nweeber | 117 | 9 films, 13h | 1 |
| pamarvss | 43 | **6 films, 6.8h** (was 398) | **3** |

The discarded days are **reported, not hidden** — a reader comparing this against Letterboxd's own figures should know what was set aside and why.

## A note on the tooling
Two of my edit scripts silently no-oped earlier in this branch because they anchored on code from an unmerged PR, and `str.replace` doesn't complain about a missing target. Every substitution here asserts its anchor exists first, which is how I caught that this branch predates #97.

608 backend tests (5 new, including that a 20-film day is rejected and that the rejection is counted), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)