### PR TITLE
Show whether the writing habit is growing, not just how many reviews exist

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -22,7 +22,7 @@ reviewing changes a rating.
 """
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence
@@ -526,9 +526,50 @@ def median_length_chars(lengths: Sequence[int]) -> Optional[int]:
     return (ordered[middle - 1] + ordered[middle]) // 2
 
 
+def _writing_rate_by_year(
+    reviews_per_year: Mapping[int, int],
+    watch_dates: Sequence[date],
+) -> List[Dict[str, Any]]:
+    """Share of a year's watching that got written about.
+
+    A rising review count can simply mean a busier year, so the count alone
+    cannot say whether somebody is writing more. Only years with watching to
+    measure against appear; a year of reviews whose films carry no date is left
+    out rather than reported as an impossible rate.
+    """
+
+    watched_per_year: Dict[int, int] = defaultdict(int)
+    for watched in watch_dates:
+        if watched is not None:
+            watched_per_year[watched.year] += 1
+
+    rows = []
+    for year in sorted(set(reviews_per_year) | set(watched_per_year)):
+        watched = watched_per_year.get(year, 0)
+        if watched <= 0:
+            continue
+        written = reviews_per_year.get(year, 0)
+        rows.append(
+            {
+                "year": year,
+                "reviews": written,
+                "films_watched": watched,
+                # Reviews are counted by the year they were published, films by
+                # the year they were watched, so the two describe overlapping
+                # but different sets -- somebody can publish in 2022 about films
+                # seen earlier. Where the counts imply a share above 100% they
+                # are not a share of anything, and clamping to 1.0 would have
+                # presented "127 reviews of 35 films" as a tidy 100%.
+                "share": _round(written / watched, 3) if written <= watched else None,
+            }
+        )
+    return rows
+
+
 def _review_block(
     reviews: Sequence[_ReviewRow],
     films: Sequence[_FilmRow],
+    watch_dates: Sequence[date] = (),
 ) -> Dict[str, Any]:
     """Writing habits, and how a profile rates the films it writes about.
 
@@ -606,6 +647,11 @@ def _review_block(
         "reviews_by_year": [
             {"year": year, "count": per_year[year]} for year in sorted(per_year)
         ],
+        # Whether the habit is growing or fading. A raw count per year rises
+        # simply because somebody watched more, so this is reviews against
+        # films watched in the same year -- the share of viewing they chose to
+        # write about.
+        "writing_rate_by_year": _writing_rate_by_year(per_year, watch_dates),
         "average_rating_reviewed": _round(_average(reviewed), 2),
         "average_rating_unreviewed": _round(_average(unreviewed), 2),
     }
@@ -687,6 +733,6 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "director": _highest_rated(directors, label_key="name"),
         },
         "rewatches": _rewatch_block(films),
-        "reviews": _review_block(reviews, films),
+        "reviews": _review_block(reviews, films, watch_dates),
         "letterboxd_reported": profile.stats_snapshot,
     }

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1006,6 +1006,8 @@ def test_a_profile_with_no_reviews_returns_the_block_with_nulls_not_absence(
         "longest": None,
         "most_liked": [],
         "reviews_by_year": [],
+        # No watching to measure the writing against.
+        "writing_rate_by_year": [],
         "average_rating_reviewed": None,
         "average_rating_unreviewed": None,
     }
@@ -1096,6 +1098,8 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "longest",
         "most_liked",
         "reviews_by_year",
+        # Share of each year's watching that got written about.
+        "writing_rate_by_year",
         "average_rating_reviewed",
         "average_rating_unreviewed",
     }
@@ -1156,3 +1160,52 @@ def test_a_bucket_reports_the_denominator_its_average_was_built_from(database):
     assert horror["count"] == 4
     assert horror["rated_count"] == 2
     assert horror["average_rating"] == 5.0
+
+
+def test_the_writing_rate_measures_reviews_against_that_year_s_watching(database):
+    """A rising review count can just mean a busier year.
+
+    The share of viewing somebody chose to write about is the question, so the
+    denominator has to be that year's watching rather than the total.
+    """
+    profile = _profile(database, "viewer")
+    for index in range(4):
+        movie = _film(database, profile, title=f"Watched {index}")
+        _watch(database, profile, movie, date(2026, 3, 1))
+    _review(database, profile, title="Watched 0", published=date(2026, 3, 2))
+    _review(database, profile, title="Watched 1", published=date(2026, 3, 3))
+
+    rows = build_profile_stats(database, profile)["reviews"]["writing_rate_by_year"]
+
+    assert rows == [{"year": 2026, "reviews": 2, "films_watched": 4, "share": 0.5}]
+
+
+def test_a_year_with_reviews_but_no_dated_watching_is_left_out(database):
+    """An impossible rate is worse than an absent one."""
+    profile = _profile(database, "viewer")
+    _film(database, profile, title="Undated")
+    _review(database, profile, title="Undated", published=date(2026, 3, 2))
+
+    rows = build_profile_stats(database, profile)["reviews"]["writing_rate_by_year"]
+
+    assert rows == []
+
+
+def test_more_reviews_than_films_watched_reports_no_share(database):
+    """Reviews are dated by publication, films by viewing.
+
+    Somebody can publish this year about films seen years ago, so the counts
+    can imply a share above 100%. That is not a share of anything, and
+    clamping it to 100% would present "127 reviews of 35 films" as tidy.
+    """
+    profile = _profile(database, "viewer")
+    movie = _film(database, profile, title="One Film")
+    _watch(database, profile, movie, date(2026, 3, 1))
+    for index in range(3):
+        _review(database, profile, title=f"Older {index}", published=date(2026, 3, 2))
+
+    row = build_profile_stats(database, profile)["reviews"]["writing_rate_by_year"][0]
+
+    assert row["reviews"] == 3
+    assert row["films_watched"] == 1
+    assert row["share"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -440,6 +440,15 @@ export const profileStats = {
       },
       { title: 'Undated Fixture Review', year: null, likes_count: 12, published_date: null },
     ],
+    // A habit that grew, plus a year whose reviews outnumber its watching --
+    // reviews are dated by publication, films by viewing, so that row carries
+    // no share rather than a clamped 100%.
+    writing_rate_by_year: [
+      { year: 2023, reviews: 27, films_watched: 61, share: 0.443 },
+      { year: 2024, reviews: 93, films_watched: 138, share: 0.674 },
+      { year: 2025, reviews: 110, films_watched: 165, share: 0.667 },
+      { year: 2026, reviews: 88, films_watched: 40, share: null },
+    ],
     reviews_by_year: [
       { year: 2024, count: 12 },
       { year: 2025, count: 18 },

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -327,6 +327,11 @@ function ReviewSection({
 }) {
   const liked = reviews.most_liked ?? [];
   const byYear = reviews.reviews_by_year ?? [];
+  // How much of each year's watching got written about. A rising review count
+  // can just mean a busier year, so the share is the honest trend line.
+  const writingRate = (reviews.writing_rate_by_year ?? []).filter(
+    (row) => row.share !== null,
+  );
   if (reviews.total_reviews === 0) return null;
 
   const subtitle = [
@@ -346,6 +351,33 @@ function ReviewSection({
         <p className="mt-2 text-[11px] leading-4 text-white/40">
           {`Longest: ${reviews.longest.title}${reviews.longest.year ? ` (${reviews.longest.year})` : ''}, ${formatCount(reviews.longest.length_chars)} characters`}
         </p>
+      ) : null}
+
+      {writingRate.length > 1 ? (
+        <div className="mt-3">
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-white/35">
+            How much they write about
+          </p>
+          <div className="mt-2 space-y-1">
+            {writingRate.map((row) => (
+              <div key={row.year} className="flex items-center gap-2 text-[11px]">
+                <span className="w-9 shrink-0 tabular-nums text-white/40">{row.year}</span>
+                <span className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10">
+                  <span
+                    className="block h-full rounded-full bg-cinema-500"
+                    style={{ width: `${Math.max(2, (row.share ?? 0) * 100)}%` }}
+                  />
+                </span>
+                <span
+                  className="w-20 shrink-0 text-right tabular-nums text-white/45"
+                  title={`${row.reviews} of ${row.films_watched} films watched`}
+                >
+                  {Math.round((row.share ?? 0) * 100)}% of {row.films_watched}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
       ) : null}
 
       {liked.length > 0 ? (

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1380,6 +1380,15 @@ export interface ProfileStatsReviews {
   longest: ProfileStatsLongestReview | null;
   most_liked: ProfileStatsLikedReview[];
   reviews_by_year: ProfileStatsReviewYear[];
+  /** Share of each year's watching that got written about. `share` is null when
+   *  the counts imply more than 100%: reviews are dated by publication and
+   *  films by viewing, so the two describe overlapping but different sets. */
+  writing_rate_by_year: Array<{
+    year: number;
+    reviews: number;
+    films_watched: number;
+    share: number | null;
+  }>;
   average_rating_reviewed: number | null;
   average_rating_unreviewed: number | null;
 }


### PR DESCRIPTION
A review count per year rises when somebody simply watched more, so it can't answer whether they're **writing more**. The share of a year's watching they chose to write about can — and both halves were already stored.

| | 2023 | 2024 | 2025 | 2026 |
|---|---|---|---|---|
| whiteknight03x | 44% | 67% | 67% | **70%** |
| gnanendar | 75% | 84% | 53% | 55% |

One grew and held; the other fell away.

## The case that needed care
Reviews are dated by **publication**, films by **viewing** — overlapping but different sets. `gnanendar` published **127 reviews in 2022 against 35 films watched** that year.

That is not a share of anything. My first version clamped it with `min(written / watched, 1.0)`, which would have presented *"127 reviews of 35 films"* as a tidy **100%**. Those years now report `share: null` and the panel leaves them out of the trend rather than drawing a bar that means nothing.

I only noticed because I checked the output against real profiles before writing the tests.

608 backend tests (3 new, including that an impossible share reports null), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)