### PR TITLE
Measure what revisiting a film actually does to its rating

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -22,10 +22,10 @@ reviewing changes a rating.
 """
 from __future__ import annotations
 
-from collections import Counter
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import date, timedelta
-from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence
+from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -479,16 +479,109 @@ def _distinct(buckets: Mapping[str, Dict[str, Any]]) -> Optional[int]:
 # --- rewatches --------------------------------------------------------------
 
 
+def _median(values: Sequence[int]) -> Optional[int]:
+    """Middle value, so one very old revisit cannot drag the typical one."""
+
+    if not values:
+        return None
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[middle]
+    return int(round((ordered[middle - 1] + ordered[middle]) / 2))
+
+
+def build_return_journeys(
+    events: Sequence[Tuple[int, date, Optional[float]]]
+) -> Dict[str, Any]:
+    """How long before somebody goes back to a film, and whether the score moves.
+
+    ``events`` is (movie_id, watched_date, rating). Unlike the two averages
+    below this IS a paired measurement: the same person rating the same film on
+    two separate viewings, so the difference is the effect of the revisit rather
+    than a difference between two sets of films.
+
+    Only films whose viewings fall on different dates count. A rewatch logged on
+    the same day as the first viewing carries no interval and says nothing about
+    returning to something later.
+    """
+
+    by_movie: Dict[int, List[Tuple[date, Optional[float]]]] = defaultdict(list)
+    for movie_id, watched, rating in events:
+        if watched is not None:
+            by_movie[movie_id].append((watched, rating))
+
+    gaps: List[int] = []
+    rose = 0
+    fell = 0
+    held = 0
+    deltas: List[float] = []
+    for viewings in by_movie.values():
+        if len(viewings) < 2:
+            continue
+        viewings.sort(key=lambda item: item[0])
+        first_date, _ = viewings[0]
+        last_date, _ = viewings[-1]
+        if last_date <= first_date:
+            continue
+        gaps.append((last_date - first_date).days)
+
+        rated = [(day, rating) for day, rating in viewings if rating is not None]
+        if len(rated) < 2:
+            continue
+        first_rating = rated[0][1]
+        last_rating = rated[-1][1]
+        delta = round(last_rating - first_rating, 2)
+        deltas.append(delta)
+        if delta > 0:
+            rose += 1
+        elif delta < 0:
+            fell += 1
+        else:
+            held += 1
+
+    return {
+        "revisited_films": len(gaps),
+        "median_days_to_return": _median(gaps) if gaps else None,
+        # The paired half: only films this profile rated on two separate
+        # viewings, which is a far smaller set than the one above.
+        "rated_twice": len(deltas),
+        "rating_rose": rose,
+        "rating_fell": fell,
+        "rating_held": held,
+        "average_change": _round(_average(deltas), 2) if deltas else None,
+    }
+
+
+def _return_events(db: Session, profile_id: int) -> List[Tuple[int, date, Optional[float]]]:
+    """(movie_id, watched_date, rating) for every active dated watch event."""
+
+    return [
+        (int(movie_id), watched, float(rating) if rating is not None else None)
+        for movie_id, watched, rating in db.query(
+            WatchEvent.movie_id, WatchEvent.watched_date, WatchEvent.rating
+        )
+        .filter(
+            WatchEvent.profile_id == profile_id,
+            WatchEvent.superseded_at.is_(None),
+            WatchEvent.watched_date.isnot(None),
+        )
+        .all()
+    ]
+
+
 def _rewatch_block(films: Sequence[_FilmRow]) -> Dict[str, Any]:
     """What a profile returns to, and how it rates the films it returns to.
 
     ``average_rating_rewatched`` and ``average_rating_once`` are two ordinary
     averages over two disjoint halves of the same profile's library -- the
     films carrying at least one rewatch, and the films seen exactly once. They
-    are not a paired measurement: nobody rated the same film twice here, the
-    films someone chooses to revisit are self-selected, and each side ignores
-    the films that profile never rated. A gap between them describes which
-    films get revisited, not what revisiting does to a rating.
+    are not a paired measurement: they compare two self-selected sets of films
+    and each side ignores the films that profile never rated, so a gap between
+    them describes which films get revisited, not what revisiting does to a
+    rating. ``return_journeys`` answers that question properly, from the
+    per-viewing ratings on watch events -- the same person, the same film,
+    twice.
 
     ``most_rewatched`` ranks by ``watch_count`` because that is the figure it
     reports, and lists only films with a rewatch -- a film seen once is not a
@@ -792,6 +885,9 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
             "director": _highest_rated(directors, label_key="name"),
         },
         "rewatches": _rewatch_block(films),
+        # A genuine paired measurement, unlike the two averages inside
+        # ``rewatches``: the same person, the same film, two viewings.
+        "return_journeys": build_return_journeys(_return_events(db, profile.id)),
         "reviews": _review_block(reviews, films),
         "letterboxd_reported": profile.stats_snapshot,
     }

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1,7 +1,7 @@
 """Profile stats: honest arithmetic over whatever enrichment we actually hold."""
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from itertools import count
 from typing import Any, Optional
 
@@ -27,6 +27,7 @@ from database.models import (
 )
 from services.profile_stats import (
     build_profile_stats,
+    build_return_journeys,
     longest_streak_weeks,
     median_length_chars,
     multi_film_days,
@@ -1082,6 +1083,8 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "decades",
         "highest_rated",
         "rewatches",
+        # The paired half: same person, same film, two viewings.
+        "return_journeys",
         "reviews",
         "letterboxd_reported",
     }
@@ -1218,3 +1221,61 @@ def test_a_profile_with_no_recorded_director_gender_reports_no_share(database):
 
     assert split["measured_films"] == 0
     assert split["women_share"] is None
+
+
+# Unlike the two averages in the rewatch block, this is a paired measurement:
+# the same person rating the same film on two separate viewings, so a
+# difference is the effect of the revisit rather than a difference between two
+# self-selected sets of films.
+
+
+def test_a_revisit_records_how_long_it_took_and_which_way_the_rating_moved():
+    events = [
+        (1, date(2024, 1, 1), 4.0),
+        (1, date(2026, 1, 1), 5.0),
+        (2, date(2025, 1, 1), 4.0),
+        (2, date(2025, 3, 1), 2.0),
+    ]
+
+    journeys = build_return_journeys(events)
+
+    assert journeys["revisited_films"] == 2
+    assert journeys["rated_twice"] == 2
+    assert journeys["rating_rose"] == 1
+    assert journeys["rating_fell"] == 1
+    assert journeys["average_change"] == -0.5
+
+
+def test_a_rewatch_logged_on_the_first_viewing_s_own_day_is_not_a_return():
+    """Two entries on one date carry no interval and say nothing about returning."""
+    events = [(1, date(2026, 1, 1), 4.0), (1, date(2026, 1, 1), 4.0)]
+
+    assert build_return_journeys(events)["revisited_films"] == 0
+
+
+def test_a_revisit_without_two_ratings_still_counts_as_a_return():
+    """The interval is knowable even when the score is not."""
+    events = [(1, date(2024, 1, 1), None), (1, date(2026, 1, 1), 5.0)]
+
+    journeys = build_return_journeys(events)
+
+    assert journeys["revisited_films"] == 1
+    assert journeys["rated_twice"] == 0
+    assert journeys["average_change"] is None
+
+
+def test_the_typical_return_is_the_median_not_the_mean():
+    """One revisit after a decade must not become everybody's typical wait."""
+    events = []
+    for movie_id, gap in enumerate([30, 40, 50, 4000], start=1):
+        events.append((movie_id, date(2020, 1, 1), 4.0))
+        events.append((movie_id, date(2020, 1, 1) + timedelta(days=gap), 4.0))
+
+    assert build_return_journeys(events)["median_days_to_return"] == 45
+
+
+def test_a_profile_that_never_returns_reports_nothing_rather_than_zero():
+    journeys = build_return_journeys([(1, date(2026, 1, 1), 4.0)])
+
+    assert journeys["revisited_films"] == 0
+    assert journeys["median_days_to_return"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -412,6 +412,17 @@ export const profileStats = {
   },
   // Folded into the same panel. One rewatched film is unrated and one review
   // has no publication date, so both omission branches render.
+  // Paired: the same person, the same film, two viewings. A much smaller set
+  // than the revisit count, because both viewings have to carry a rating.
+  return_journeys: {
+    revisited_films: 12,
+    median_days_to_return: 674,
+    rated_twice: 12,
+    rating_rose: 5,
+    rating_fell: 1,
+    rating_held: 6,
+    average_change: 0.38,
+  },
   rewatches: {
     total_rewatches: 64,
     films_rewatched: 41,

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -12,6 +12,7 @@ import type {
   ProfileStatsCoverage,
   ProfileStatsPerson,
   ProfileStatsReviews,
+  ProfileStatsResponse,
   ProfileStatsRewatches,
 } from '../../services/api';
 import { FilmTitle, MoviePoster, formatCalendarDate, toMovieSummary } from './InsightUI';
@@ -267,7 +268,13 @@ function PairedAverages({
  * What this member returns to. Films seen once are not listed: a film with no
  * rewatch is not a quiet entry at the bottom of a rewatch list.
  */
-function RewatchSection({ rewatches }: { rewatches: ProfileStatsRewatches }) {
+function RewatchSection({
+  rewatches,
+  journeys,
+}: {
+  rewatches: ProfileStatsRewatches;
+  journeys?: ProfileStatsResponse['return_journeys'];
+}) {
   const films = rewatches.most_rewatched ?? [];
   if (rewatches.total_rewatches === 0 && films.length === 0) return null;
 
@@ -282,6 +289,29 @@ function RewatchSection({ rewatches }: { rewatches: ProfileStatsRewatches }) {
 
   return (
     <SubSection title="Rewatches" subtitle={subtitle}>
+      {journeys && journeys.revisited_films > 0 ? (
+        <p className="mt-2 rounded-lg border border-white/[0.07] bg-black/15 px-3 py-2 text-[11px] leading-5 text-white/50">
+          Typically returns after{' '}
+          <strong className="text-white/80">
+            {formatCount(journeys.median_days_to_return ?? 0)} days
+          </strong>{' '}
+          across {formatCount(journeys.revisited_films)} revisited{' '}
+          {journeys.revisited_films === 1 ? 'film' : 'films'}.
+          {/* The paired half, and a much smaller set: only films rated on two
+              separate viewings can say what the revisit did to the score. */}
+          {journeys.rated_twice > 0 ? (
+            <>
+              {' '}Of the {formatCount(journeys.rated_twice)} rated on both viewings,{' '}
+              {journeys.rating_rose} went up, {journeys.rating_fell} down and{' '}
+              {journeys.rating_held} held
+              {journeys.average_change !== null
+                ? ` (${journeys.average_change > 0 ? '+' : ''}${journeys.average_change.toFixed(2)} on average)`
+                : ''}
+              .
+            </>
+          ) : null}
+        </p>
+      ) : null}
       {films.length > 0 ? (
         <ul className="mt-2 space-y-1.5">
           {films.map((film, index) => (
@@ -714,7 +744,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
 
       {hasRewatchSection || hasReviewSection ? (
         <div className="mt-6 grid gap-6 border-t border-white/10 pt-5 lg:grid-cols-2">
-          {hasRewatchSection && rewatches ? <RewatchSection rewatches={rewatches} /> : null}
+          {hasRewatchSection && rewatches ? <RewatchSection rewatches={rewatches} journeys={stats.return_journeys} /> : null}
           {hasReviewSection && reviews ? (
             <ReviewSection reviews={reviews} coverage={coverage} />
           ) : null}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1417,6 +1417,17 @@ export interface ProfileStatsResponse {
    * say "none yet" instead of guessing whether the block failed to compute.
    */
   rewatches: ProfileStatsRewatches;
+  /** A paired measurement, unlike the averages inside `rewatches`: the same
+   *  person rating the same film on two separate viewings. */
+  return_journeys: {
+    revisited_films: number;
+    median_days_to_return: number | null;
+    rated_twice: number;
+    rating_rose: number;
+    rating_fell: number;
+    rating_held: number;
+    average_change: number | null;
+  };
   reviews: ProfileStatsReviews;
   /**
    * Letterboxd's own stats-page figures, verbatim, for side-by-side


### PR DESCRIPTION
The rewatch block carried a caveat saying no paired measurement was possible:

> *"They are not a paired measurement: **nobody rated the same film twice here**..."*

True of the table it reads (`profile_films` holds one rating per film) — and **false of the database**. Watch events carry a rating per viewing, and **153 profile-film pairs hold two or more rated ones**.

So the question the caveat gave up on is answerable:

| profile | revisits | typical wait | rated twice | movement |
|---|---|---|---|---|
| er3nweeber | 12 | 674 days | 12 | ↑5 ↓1 =6 · **+0.38** |
| pamarvss | 74 | 383 days | 74 | ↑14 ↓11 =49 · +0.03 |
| whiteknight03x | 2 | 10 days | 2 | ↑1 =1 · +0.25 |

er3nweeber comes back warmer; pamarvss revisits far more and barely moves.

Real examples from the data: *Blade Runner* 4.5 → **5.0** after 840 days; *Mean Girls* 4.0 → **2.0** after 133.

## Why this one is different
It's genuinely **paired** — same person, same film, twice — unlike the two averages beside it, which compare self-selected sets of *different* films and can only describe which films get revisited. That distinction is now stated rather than used to explain an absence.

Two guards: a rewatch logged on the first viewing's own date carries no interval and isn't a return; and the typical wait is a **median**, so one revisit after a decade doesn't become everybody's.

613 backend tests (5 new), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)