### PR TITLE
Show where a profile usually sits inside a crowd, and both ends of it

### DIFF
--- a/backend/services/obscurity.py
+++ b/backend/services/obscurity.py
@@ -368,6 +368,16 @@ def build_obscurity_index(
         )
     )
     crowd_position = positioned[:limit]
+    # The other end of the same ordering: films this profile rated below almost
+    # everyone. Showing only the contrarian tail told half the story -- somebody
+    # can be out on a limb in both directions at once.
+    crowd_position_below = list(reversed(positioned))[:limit]
+
+    # And the whole distribution behind those tails. The median share says where
+    # this profile usually sits inside the crowds it joins: above 0.5 means it
+    # typically rates a film higher than most of the people who rated it.
+    all_shares = [share for _, share in positioned]
+    typical_share = median(all_shares) if all_shares else None
 
     identities = _film_identities(
         db,
@@ -411,4 +421,22 @@ def build_obscurity_index(
         "crowd_position": [
             _crowd_entry(film, share, identity(film)) for film, share in crowd_position
         ],
+        "crowd_position_below": [
+            _crowd_entry(film, share, identity(film))
+            for film, share in crowd_position_below
+        ],
+        # Where this profile usually lands inside a crowd, across everything it
+        # rated that carries a histogram. Null when no film does -- "we never
+        # measured" rather than "exactly average".
+        "crowd_percentile": {
+            "measured_films": len(all_shares),
+            "typical_share": _round(typical_share, 3) if typical_share is not None else None,
+            "lean": (
+                None
+                if typical_share is None
+                else "generous" if typical_share > 0.55
+                else "harsh" if typical_share < 0.45
+                else "typical"
+            ),
+        },
     }

--- a/backend/tests/test_obscurity.py
+++ b/backend/tests/test_obscurity.py
@@ -677,6 +677,9 @@ def test_route_serves_the_frozen_contract(database: Session, client) -> None:
         "most_obscure",
         "most_mainstream",
         "crowd_position",
+        # The other tail, and the whole distribution behind both.
+        "crowd_position_below",
+        "crowd_percentile",
     }
     assert payload["username"] == "subject"
     assert set(payload["coverage"]) == {"rated_films", "films_with_rating_count"}
@@ -752,3 +755,53 @@ def test_route_requires_an_authenticated_user() -> None:
     assert "get_current_user" in {
         dependency.call.__name__ for dependency in route.dependant.dependencies
     }
+
+
+def test_the_crowd_percentile_says_where_a_profile_usually_lands(database: Session) -> None:
+    """Showing only the contrarian tail told half the story.
+
+    The median share across everything rated says whether somebody generally
+    sits above or below the crowds they join.
+    """
+    profile = _profile(database, "generous")
+    flat = {str(index / 2): 100 for index in range(1, 11)}
+    for index in range(3):
+        movie = _film(database, f"Loved {index}", rating_count=1000, distribution=flat)
+        _rate(database, profile, movie, 5.0)
+
+    percentile = build_obscurity_index(database, profile, limit=5)["crowd_percentile"]
+
+    assert percentile["measured_films"] == 3
+    assert percentile["typical_share"] == 1.0
+    assert percentile["lean"] == "generous"
+
+
+def test_both_tails_are_returned_so_a_profile_can_be_out_on_a_limb_either_way(
+    database: Session,
+) -> None:
+    profile = _profile(database, "mixed")
+    flat = {str(index / 2): 100 for index in range(1, 11)}
+    adored = _film(database, "Adored", rating_count=1000, distribution=flat)
+    hated = _film(database, "Hated", rating_count=1000, distribution=flat)
+    _rate(database, profile, adored, 5.0)
+    _rate(database, profile, hated, 0.5)
+
+    payload = build_obscurity_index(database, profile, limit=5)
+
+    assert payload["crowd_position"][0]["title"] == "Hated"
+    assert payload["crowd_position_below"][0]["title"] == "Adored"
+
+
+def test_a_profile_whose_films_carry_no_histogram_has_no_percentile(
+    database: Session,
+) -> None:
+    """Never measured is not the same as exactly average."""
+    profile = _profile(database, "unscraped")
+    movie = _film(database, "No Histogram")
+    _rate(database, profile, movie, 4.0)
+
+    percentile = build_obscurity_index(database, profile, limit=5)["crowd_percentile"]
+
+    assert percentile["measured_films"] == 0
+    assert percentile["typical_share"] is None
+    assert percentile["lean"] is None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -584,6 +584,20 @@ export const obscurity = {
       profile_rating: 4.5,
     },
   ],
+  // Where they usually land, plus the opposite tail: somebody can be out on a
+  // limb in both directions at once.
+  crowd_percentile: { measured_films: 706, typical_share: 0.653, lean: 'generous' },
+  crowd_position_below: [
+    {
+      title: 'Adored By Everyone Else',
+      year: 2018,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/adored-by-everyone-else/',
+      profile_rating: 5,
+      share_at_or_below: 0.9714,
+      crowd_average: 3.11,
+    },
+  ],
   crowd_position: [
     {
       title: 'Contrarian Fixture Film',

--- a/frontend/src/components/insights/ObscurityPanel.tsx
+++ b/frontend/src/components/insights/ObscurityPanel.tsx
@@ -139,6 +139,8 @@ const ObscurityPanel: React.FC<{ username: string; delay?: number }> = ({
   const mostObscure = data.most_obscure ?? [];
   const mostMainstream = data.most_mainstream ?? [];
   const crowdPosition = data.crowd_position ?? [];
+  const crowdBelow = data.crowd_position_below ?? [];
+  const crowdPercentile = data.crowd_percentile;
   const median = index?.median_rating_count ?? null;
   if (median === null && mostObscure.length === 0 && mostMainstream.length === 0) return null;
 
@@ -231,15 +233,41 @@ const ObscurityPanel: React.FC<{ username: string; delay?: number }> = ({
       ) : null}
 
       {crowdPosition.length > 0 ? (
-        <div className="mt-6">
+        <div className="mt-6 space-y-4">
+          {crowdPercentile && crowdPercentile.typical_share !== null ? (
+            /* The tails below are the extremes; this is where they usually sit.
+               Showing only the extremes told half the story. */
+            <p className="rounded-lg border border-white/[0.07] bg-black/15 px-3 py-2 text-xs leading-5 text-white/50">
+              Across {crowdPercentile.measured_films.toLocaleString()} rated films with a
+              crowd histogram, they typically rate above{' '}
+              <strong className="text-white/80">
+                {Math.round(crowdPercentile.typical_share * 100)}%
+              </strong>{' '}
+              of the people who rated the same film
+              {crowdPercentile.lean && crowdPercentile.lean !== 'typical'
+                ? ` — a ${crowdPercentile.lean} hand overall`
+                : ' — right about average'}
+              .
+            </p>
+          ) : null}
           <ListSection
-            title="Furthest from the crowd"
+            title="Furthest above the crowd"
             subtitle="Where their rating fell inside Letterboxd’s own histogram for the film"
           >
             {crowdPosition.map((film, index_) => (
               <CrowdPositionRow key={`${film.title}-${film.year ?? 'na'}-${index_}`} film={film} />
             ))}
           </ListSection>
+          {crowdBelow.length > 0 ? (
+            <ListSection
+              title="Furthest below the crowd"
+              subtitle="Films they rated lower than almost everyone who rated them"
+            >
+              {crowdBelow.map((film, index_) => (
+                <CrowdPositionRow key={`below-${film.title}-${film.year ?? 'na'}-${index_}`} film={film} />
+              ))}
+            </ListSection>
+          ) : null}
         </div>
       ) : null}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1645,6 +1645,17 @@ export interface ObscurityResponse {
   most_mainstream: ObscurityFilm[];
   /** Empty — never null — until the rating-distribution backfill has been run. */
   crowd_position: ObscurityCrowdPosition[];
+  /** The other tail: films rated below almost the whole crowd. Somebody can be
+   *  out on a limb in both directions at once. */
+  crowd_position_below: ObscurityCrowdPosition[];
+  /** Where this profile usually lands inside a crowd, across everything it
+   *  rated that carries a histogram. Null when none does — never measured is
+   *  not the same as exactly average. */
+  crowd_percentile: {
+    measured_films: number;
+    typical_share: number | null;
+    lean: 'generous' | 'harsh' | 'typical' | null;
+  };
 }
 
 export const obscurityApi = {


### PR DESCRIPTION
The obscurity panel listed films somebody rated **furthest above** the crowd and stopped there. That's one tail of a distribution the code already computes for every rated film, leaving two questions unanswered: what do they *hate* that everyone else loves, and where do they land when they're not being contrarian at all?

Both come from the same ordering — the opposite tail is its reverse, and the median share answers the second:

| profile | typical share | reading |
|---|---|---|
| whiteknight03x | **0.505** | almost exactly the middle of every crowd |
| er3nweeber | 0.653 | rates above 65% of people who rated the same film |
| harsha4123 | 0.754 | generous |

706 films measured for `whiteknight03x`, 1,642 for `er3nweeber` — this isn't a thin sample.

## Null, not 0.5
When no rated film carries a histogram the percentile is `null`. Never measured is not the same as exactly average, and inventing 0.5 would claim a placement we never made — the same rule the obscurity percentile beside it already follows, and there's a test for it.

611 backend tests (3 new), 58/58 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)