### PR TITLE
Name the requester in the admin queue instead of a Clerk id

### DIFF
--- a/backend/services/profile_access.py
+++ b/backend/services/profile_access.py
@@ -810,6 +810,13 @@ def request_summary(
                 "requester_user_id": (
                     request.user.clerk_user_id if request.user else None
                 ),
+                # Who asked, in the only name an admin can act on. The Clerk id
+                # identifies the account but says nothing a human recognises,
+                # and it stays in the payload because grandfathered users have
+                # no linked username to fall back to.
+                "requester_letterboxd_username": (
+                    request.user.letterboxd_username if request.user else None
+                ),
                 "note": request.admin_note,
                 "resolved_by_user_id": request.resolved_by_clerk_user_id,
             }

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -1113,6 +1113,8 @@ def test_non_admin_request_payload_omits_internal_identity_and_notes(database):
 
     ordinary = list_profile_requests(database, _user("requester"))[0]
     assert "requester_user_id" not in ordinary
+    # Naming the requester is as much an identity leak as the Clerk id is.
+    assert "requester_letterboxd_username" not in ordinary
     assert "resolved_by_user_id" not in ordinary
     assert "note" not in ordinary
 
@@ -1124,6 +1126,35 @@ def test_non_admin_request_payload_omits_internal_identity_and_notes(database):
     assert privileged["requester_user_id"] == "requester"
     assert privileged["resolved_by_user_id"] == "admin"
     assert privileged["note"] == "internal moderation note"
+    # This requester never linked an account, so there is no name to show and
+    # the queue is left with the opaque id.
+    assert privileged["requester_letterboxd_username"] is None
+
+
+def test_admin_queue_names_the_requester_when_an_account_is_linked(database):
+    """The Clerk id identifies an account; it does not tell an admin who asked."""
+    requester = AppUser(clerk_user_id="user_3HDeXHfN", letterboxd_username="prani_1234")
+    database.add_all([requester, AppUser(clerk_user_id="admin")])
+    database.flush()
+    database.add(
+        ProfileAccessRequest(
+            user_id=requester.id,
+            requested_username="Alpha",
+            normalized_username="alpha",
+            status="pending",
+        )
+    )
+    database.commit()
+
+    privileged = list_profile_requests(
+        database,
+        _user("admin", admin=True),
+        include_all=True,
+    )[0]
+
+    assert privileged["requester_letterboxd_username"] == "prani_1234"
+    # Kept alongside, not replaced: it is still the only stable identifier.
+    assert privileged["requester_user_id"] == "user_3HDeXHfN"
 
 
 def test_profile_username_is_unique_case_insensitively(database):

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -14,6 +14,20 @@ test('backend admin truth exposes management and the residential sync queue', as
   await expect(page.getByText('Awaiting residential sync', { exact: true })).toBeVisible();
 });
 
+test('the request queue names the requester rather than printing a Clerk id', async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+
+  await page.goto('/profiles');
+
+  // Scoped to the admin queue: the same username also appears on the ordinary
+  // request card, which deliberately carries no requester line at all.
+  const queued = page.locator('article').filter({ hasText: 'Requester' }).first();
+  await expect(queued).toContainText('Requester @e2erequester');
+  // The opaque id is what an admin was reading before, and it must not be what
+  // they read when a linked account exists.
+  await expect(queued).not.toContainText('user_e2e');
+});
+
 test('admin can upload residential full-sync bundles without owner-export publishing consent', async ({ page }) => {
   await installApiMocks(page, { isAdmin: true });
 

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -862,6 +862,7 @@ interface ApiFixtureState {
   requests: Array<{
     id: number;
     requester_user_id: string;
+    requester_letterboxd_username: string | null;
     requested_username: string;
     status: 'pending' | 'approved' | 'rejected' | 'fulfilled';
     note: string | null;
@@ -962,6 +963,7 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     const request = {
       id: state.requests.length + 1,
       requester_user_id: 'user_e2e',
+      requester_letterboxd_username: null,
       requested_username: username,
       status: 'pending' as const,
       note: null,
@@ -1417,6 +1419,7 @@ export async function installApiMocks(
     requests: [{
       id: 1,
       requester_user_id: 'user_e2e',
+      requester_letterboxd_username: 'e2erequester',
       requested_username: 'queuedprofile',
       status: 'approved',
       note: 'Accepted for the next sync.',

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -103,6 +103,9 @@ export interface ProfileRequest {
 
 export interface AdminProfileRequest extends ProfileRequest {
   requester_user_id: string;
+  /** Null for grandfathered accounts that never linked a Letterboxd username;
+   *  the queue falls back to `requester_user_id` in that case. */
+  requester_letterboxd_username: string | null;
   note: string | null;
   resolved_by_user_id: string | null;
 }

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -805,7 +805,18 @@ const ProfileManager: React.FC = () => {
                         {request.status === 'approved' ? 'Awaiting residential sync' : REQUEST_STATUS_COPY[request.status].label}
                       </span>
                     </div>
-                    <p className="mt-1 text-xs text-white/40">Requester {request.requester_user_id} · {new Date(request.requested_at).toLocaleString()}</p>
+                    {/* The Letterboxd name when we hold one. Falling back to the
+                        Clerk id is deliberate: a grandfathered account has no
+                        linked username, and showing nothing would hide who
+                        asked. */}
+                    <p className="mt-1 text-xs text-white/40">
+                      Requester{' '}
+                      {request.requester_letterboxd_username
+                        ? `@${request.requester_letterboxd_username}`
+                        : request.requester_user_id}
+                      {' · '}
+                      {new Date(request.requested_at).toLocaleString()}
+                    </p>
                   </div>
                   {request.status === 'pending' ? (
                     <input


### PR DESCRIPTION
## What

The admin profile request queue rendered `requester_user_id` directly:

> Requester user_3HDeXHfN4c9ld4TMErvpPe9eZa8 · 8/1/2026, 11:28:16 PM

That is the Clerk account id. It is stable and unique and it tells an admin
nothing about who is asking — which is the one thing the queue exists to
support a decision on.

## Why it was there

`AppUser` already stores `letterboxd_username`. `request_summary()` just never
put it in the payload, so the frontend had only the opaque id to render.

## The change

- `request_summary()` adds `requester_letterboxd_username` beside the id
- the queue renders `@name`, falling back to the id when there is no linked account
- both fields stay behind `include_admin_fields`

The fallback is deliberate rather than lazy: grandfathered accounts have no
linked username, and rendering an empty string there would hide who asked.

## Tests

- admin sees the name when an account is linked, and `None` when it is not
- the non-admin payload omits `requester_letterboxd_username`, same as the id —
  naming the requester is as much an identity leak
- e2e asserts the queue shows `Requester @e2erequester` and does **not** show
  `user_e2e`

622 backend tests, 85 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)