### PR TITLE
Render the watching rhythm the API has been serving all along

### DIFF
--- a/frontend/e2e/watching-rhythm.spec.ts
+++ b/frontend/e2e/watching-rhythm.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * `cadence` shipped to production computed, serialised and typed — and with no
+ * component reading it, so the API answered with a weekday breakdown that
+ * nothing on the page displayed. The same failure as the semantic-neighbors
+ * panel, arrived at from the opposite direction: there the UI existed and the
+ * data was empty, here the data existed and the UI was missing.
+ *
+ * These assertions are about rendering, not arithmetic: the weekday maths is
+ * covered in `backend/tests/test_profile_stats.py`.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the watching rhythm panel renders the weekday breakdown it is given', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const heading = page.getByRole('heading', { name: 'Watching rhythm' });
+  await expect(heading).toBeVisible();
+
+  const panel = heading.locator('..').locator('..');
+  // Scoped to the chart: 'Sat' also appears in the sentence below it, and the
+  // point here is that the week itself is drawn.
+  const weekdays = panel.getByTestId('cadence-weekdays');
+  // Every weekday keeps its slot, so a quiet day reads as quiet rather than
+  // vanishing and shifting the week along.
+  for (const day of ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']) {
+    await expect(weekdays.getByText(day, { exact: true })).toBeVisible();
+  }
+  await expect(weekdays.getByText('123', { exact: true })).toBeVisible();
+
+  await expect(panel).toContainText('Most often a Sat');
+  await expect(panel).toContainText('301 days with an entry');
+});
+
+test('a long silence is named, since a run of quiet weeks is not the same as a slow one', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const panel = page.getByRole('heading', { name: 'Watching rhythm' }).locator('..').locator('..');
+
+  await expect(panel).toContainText('Longest silence: 41 days');
+  await expect(panel).toContainText('2024-05-26');
+});

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -533,6 +533,13 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   const decadeRows = toBarRows(stats.decades ?? []);
 
   const marathons = stats.marathons;
+  const cadence = stats.cadence;
+  // Fixed order so the row reads like a week rather than a ranking, and a
+  // weekday with no watches still occupies its slot.
+  const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const busiestWeekdayCount = cadence
+    ? Math.max(...WEEKDAYS.map((day) => cadence.weekday_counts?.[day] ?? 0), 0)
+    : 0;
   const topDirectors = stats.top_directors ?? [];
   const topActors = stats.top_actors ?? [];
   const topStudios = stats.top_studios ?? [];
@@ -641,6 +648,61 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
 
       {footnotes.length > 0 ? (
         <p className="mt-3 text-xs text-white/35">{footnotes.join(' · ')}</p>
+      ) : null}
+
+      {/* Rhythm rather than volume. Two profiles with the same film count look
+          nothing alike if one watches every Saturday and the other vanished for
+          six weeks and binged, and the total cannot tell them apart. */}
+      {cadence && cadence.active_days > 0 && busiestWeekdayCount > 0 ? (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold text-white/75">Watching rhythm</h3>
+            <span className="text-[11px] text-white/40">
+              {formatCount(cadence.active_days)} days with an entry
+              {cadence.span_days ? ` across ${formatCount(cadence.span_days)}` : ''}
+            </span>
+          </div>
+
+          <div className="mt-3 grid grid-cols-7 gap-1.5" data-testid="cadence-weekdays">
+            {WEEKDAYS.map((day) => {
+              const count = cadence.weekday_counts?.[day] ?? 0;
+              return (
+                <div key={day} className="flex flex-col items-center gap-1">
+                  <div className="flex h-16 w-full items-end rounded bg-white/5">
+                    <div
+                      className={`w-full rounded ${
+                        day === cadence.busiest_weekday ? 'bg-cinema-500' : 'bg-white/20'
+                      }`}
+                      style={{ height: `${Math.max((count / busiestWeekdayCount) * 100, 3)}%` }}
+                    />
+                  </div>
+                  <span className="text-[10px] text-white/40">{day}</span>
+                  <span className="text-[10px] tabular-nums text-white/55">{count}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          <p className="mt-3 text-xs text-white/55">
+            {cadence.busiest_weekday ? (
+              <>
+                Most often a <strong className="text-white/85">{cadence.busiest_weekday}</strong>
+              </>
+            ) : null}
+            {cadence.days_per_active_week
+              ? `${cadence.busiest_weekday ? ' · ' : ''}about ${cadence.days_per_active_week} days a week while active`
+              : ''}
+          </p>
+
+          {/* A gap is only worth naming when it reads as a stop rather than a
+              pause, so the backend leaves this null for ordinary quiet weeks. */}
+          {cadence.longest_dry_spell_days ? (
+            <p className="mt-1 text-[11px] text-white/35">
+              Longest silence: {formatCount(cadence.longest_dry_spell_days)} days
+              {cadence.dry_spell_started ? ` from ${cadence.dry_spell_started}` : ''}
+            </p>
+          ) : null}
+        </div>
       ) : null}
 
       {marathons && marathons.count > 0 && marathons.biggest ? (


### PR DESCRIPTION
## The bug

`cadence` shipped in #98 with a backend that computes it, a serialiser that
returns it, and a TypeScript interface that declares it — and **no component
that reads it**. It has been live on production this whole time, invisible.

Confirmed against the live API just now:

```json
"cadence": {
  "active_days": 301, "span_days": 1079, "days_per_active_week": 1.95,
  "weekday_counts": {"Mon":74,"Tue":41,"Wed":63,"Thu":77,"Fri":69,"Sat":91,"Sun":74},
  "busiest_weekday": "Sat",
  "longest_dry_spell_days": 41, "dry_spell_started": "2024-05-26"
}
```

Deployed is not the same as live. This is the second instance of that in this
codebase — `semantic-neighbors` was the first, arrived at from the opposite
direction (UI present, backend returning a hard-coded empty list).

## The panel

- the week in fixed Mon–Sun order, so a quiet day reads as quiet rather than
  disappearing and shifting the week along
- the busiest weekday highlighted
- "about N days a week while active" — rhythm, not volume
- the longest silence, only when the backend judged it long enough to read as a
  stop rather than an ordinary quiet stretch

## Tests

`watching-rhythm.spec.ts` asserts the week is drawn, the busiest day is named,
and the silence is reported. Rendering only — the weekday arithmetic is already
covered in `test_profile_stats.py`.

626 backend, 91 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)