### PR TITLE
Ask whether the crowd agreed, not just how big it was

### DIFF
--- a/backend/services/obscurity.py
+++ b/backend/services/obscurity.py
@@ -37,6 +37,7 @@ describe the same set of films.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import sqrt
 from statistics import median
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
@@ -56,6 +57,13 @@ LEAN_PERCENTILE_MARGIN = 15.0
 # Half-star ratings are exact multiples of 0.5, but they arrive as floats;
 # compare with a tolerance so 3.5 is never excluded from its own bucket.
 _RATING_EPSILON = 1e-9
+
+# Below this many ratings a histogram's shape is sampling noise, not a verdict.
+MIN_SPREAD_RATINGS = 100
+# Guard against calling a decile from a library too small to have one.
+MIN_LIBRARY_FILMS = 200
+CONTESTED_DECILE = 0.90
+AGREED_DECILE = 0.10
 
 
 @dataclass(frozen=True)
@@ -256,6 +264,49 @@ def _share_at_or_below(distribution: Any, rating: float) -> Optional[float]:
     return at_or_below / total
 
 
+def _crowd_spread(distribution: Any) -> Optional[float]:
+    """How divided the crowd was about a film, as the histogram's own spread.
+
+    ``letterboxd_average_rating`` cannot answer this: a film averaging 3.5
+    because everybody rated it 3.5 and a film averaging 3.5 because half the
+    world rated it 1 and half rated it 5 are opposite experiences reduced to the
+    same number. The standard deviation of the histogram separates them.
+
+    Returns ``None`` below ``MIN_SPREAD_RATINGS``, where the shape is sampling
+    noise rather than an argument.
+    """
+
+    buckets = _numeric_buckets(distribution)
+    total = sum(buckets.values())
+    if total < MIN_SPREAD_RATINGS:
+        return None
+    mean = sum(star * size for star, size in buckets.items()) / total
+    variance = sum(size * (star - mean) ** 2 for star, size in buckets.items()) / total
+    return sqrt(variance)
+
+
+def _library_spread_thresholds(db: Session) -> Optional[Tuple[float, float]]:
+    """The contested and agreed-on deciles across every film we hold.
+
+    Thresholds come from the whole library rather than from the profile being
+    measured, so "contested" means the same thing on every profile's panel.
+    """
+
+    spreads: List[float] = []
+    for (distribution,) in db.query(Movie.letterboxd_rating_distribution).filter(
+        Movie.letterboxd_rating_distribution.isnot(None)
+    ):
+        spread = _crowd_spread(distribution)
+        if spread is not None:
+            spreads.append(spread)
+    if len(spreads) < MIN_LIBRARY_FILMS:
+        return None
+    spreads.sort()
+    contested = spreads[int(len(spreads) * CONTESTED_DECILE)]
+    agreed = spreads[int(len(spreads) * AGREED_DECILE)]
+    return contested, agreed
+
+
 def _film_identities(db: Session, movie_ids: Iterable[int]) -> Dict[int, Dict[str, Any]]:
     """Display fields for the handful of films that reached an output list.
 
@@ -379,6 +430,29 @@ def build_obscurity_index(
     all_shares = [share for _, share in positioned]
     typical_share = median(all_shares) if all_shares else None
 
+    # Not how big the crowd was, nor where this rating sat inside it, but
+    # whether the crowd agreed with itself at all.
+    thresholds = _library_spread_thresholds(db)
+    contested_films: List[Tuple[_RatedFilm, float]] = []
+    measured_spreads: List[float] = []
+    contested_count = agreed_count = 0
+    if thresholds is not None:
+        contested_cut, agreed_cut = thresholds
+        for film in films:
+            spread = _crowd_spread(film.distribution)
+            if spread is None:
+                continue
+            measured_spreads.append(spread)
+            if spread >= contested_cut:
+                contested_count += 1
+                contested_films.append((film, spread))
+            elif spread <= agreed_cut:
+                agreed_count += 1
+    contested_films.sort(
+        key=lambda pair: (-pair[1], pair[0].title.casefold(), pair[0].movie_id)
+    )
+    most_contested = [pair[0] for pair in contested_films[:limit]]
+
     identities = _film_identities(
         db,
         [
@@ -386,6 +460,7 @@ def build_obscurity_index(
             for film in (
                 *most_obscure,
                 *most_mainstream,
+                *most_contested,
                 *(pair[0] for pair in crowd_position),
             )
         ],
@@ -438,5 +513,26 @@ def build_obscurity_index(
                 else "harsh" if typical_share < 0.45
                 else "typical"
             ),
+        },
+        # Whether this person gravitates toward films the world argues about.
+        # Every film's contestedness comes from Letterboxd's own histogram --
+        # tens of thousands of ratings -- rather than from the handful of
+        # tracked profiles who happen to have rated it.
+        "contested_taste": {
+            "measured_films": len(measured_spreads),
+            "contested_films": contested_count,
+            "agreed_films": agreed_count,
+            "median_spread": (
+                _round(median(measured_spreads), 3) if measured_spreads else None
+            ),
+            # Above 1 leans toward films that divide the crowd, below 1 toward
+            # films it agrees on. Null rather than infinity when a profile has
+            # no agreed-on films at all: a ratio needs a denominator.
+            "lean_ratio": (
+                _round(contested_count / agreed_count, 2) if agreed_count else None
+            ),
+            "most_contested": [
+                _audience_entry(film, identity(film)) for film in most_contested
+            ],
         },
     }

--- a/backend/tests/test_obscurity.py
+++ b/backend/tests/test_obscurity.py
@@ -680,6 +680,9 @@ def test_route_serves_the_frozen_contract(database: Session, client) -> None:
         # The other tail, and the whole distribution behind both.
         "crowd_position_below",
         "crowd_percentile",
+        # Not the crowd's size or this rating's place in it, but whether the
+        # crowd agreed with itself.
+        "contested_taste",
     }
     assert payload["username"] == "subject"
     assert set(payload["coverage"]) == {"rated_films", "films_with_rating_count"}
@@ -805,3 +808,87 @@ def test_a_profile_whose_films_carry_no_histogram_has_no_percentile(
     assert percentile["measured_films"] == 0
     assert percentile["typical_share"] is None
     assert percentile["lean"] is None
+
+
+# A film's average cannot say whether the crowd agreed. Two films can share an
+# average of 3.0 while one was rated 3.0 by everybody and the other split the
+# room between 1 and 5, and only the histogram's shape tells them apart.
+
+def _flat(size: int = 400) -> Dict[str, int]:
+    """Everyone rated it 3.0."""
+    return {"3.0": size}
+
+
+def _split(size: int = 200) -> Dict[str, int]:
+    """Half rated it 0.5, half rated it 5.0 -- same 2.75 average as no film."""
+    return {"0.5": size, "5.0": size}
+
+
+def _spread_library(database: Session, count: int) -> None:
+    """Enough films for the deciles to mean something."""
+    for index in range(count):
+        # A spread of shapes so the thresholds are not degenerate.
+        weight = index % 5
+        _film(
+            database,
+            f"Library {index}",
+            rating_count=5_000,
+            distribution={"2.5": 300 - weight * 40, "3.0": 300, "3.5": 100 + weight * 60},
+        )
+
+
+def test_a_split_crowd_and_a_united_one_are_told_apart(database):
+    """Both films average near the middle; only one was argued about."""
+    profile = _profile(database, "viewer")
+    _spread_library(database, 240)
+    united = _film(database, "United", rating_count=90_000, distribution=_flat())
+    split = _film(database, "Split", rating_count=90_000, distribution=_split())
+    _rate(database, profile, united, 3.0)
+    _rate(database, profile, split, 4.0)
+
+    contested = build_obscurity_index(database, profile)["contested_taste"]
+
+    assert contested["contested_films"] == 1
+    assert contested["agreed_films"] == 1
+    titles = [entry["title"] for entry in contested["most_contested"]]
+    assert titles == ["Split"]
+
+
+def test_a_histogram_too_small_to_argue_about_is_not_counted(database):
+    """Under a hundred ratings the shape is noise, not a verdict."""
+    profile = _profile(database, "viewer")
+    _spread_library(database, 240)
+    thin = _film(database, "Thin", rating_count=12, distribution={"0.5": 6, "5.0": 6})
+    _rate(database, profile, thin, 4.0)
+
+    contested = build_obscurity_index(database, profile)["contested_taste"]
+
+    assert contested["measured_films"] == 0
+    assert contested["most_contested"] == []
+    assert contested["lean_ratio"] is None
+
+
+def test_the_lean_ratio_is_null_rather_than_infinite_without_agreed_films(database):
+    """A ratio needs a denominator; dividing by zero would print an inflated lie."""
+    profile = _profile(database, "viewer")
+    _spread_library(database, 240)
+    split = _film(database, "Split", rating_count=90_000, distribution=_split())
+    _rate(database, profile, split, 4.0)
+
+    contested = build_obscurity_index(database, profile)["contested_taste"]
+
+    assert contested["contested_films"] == 1
+    assert contested["agreed_films"] == 0
+    assert contested["lean_ratio"] is None
+
+
+def test_a_library_too_small_for_deciles_measures_nothing(database):
+    """Thresholds drawn from a handful of films would be arbitrary."""
+    profile = _profile(database, "viewer")
+    split = _film(database, "Split", rating_count=90_000, distribution=_split())
+    _rate(database, profile, split, 4.0)
+
+    contested = build_obscurity_index(database, profile)["contested_taste"]
+
+    assert contested["measured_films"] == 0
+    assert contested["median_spread"] is None

--- a/frontend/e2e/contested-taste.spec.ts
+++ b/frontend/e2e/contested-taste.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * A film's average rating cannot say whether the crowd agreed about it: 3.0
+ * from everybody and 3.0 from a room split between 0.5 and 5.0 are opposite
+ * experiences flattened to the same number. Letterboxd publishes the histogram
+ * behind that average and Spyboxd already stores it, so this panel asks the
+ * question the average cannot.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the panel reports how often the crowd was divided, with its denominator', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const heading = page.getByRole('heading', { name: 'Films the world argues about' });
+  await expect(heading).toBeVisible();
+
+  const panel = heading.locator('..').locator('..');
+  await expect(panel).toContainText('86');
+  await expect(panel).toContainText('47');
+  // Stated, not implied: a share is meaningless without knowing how many films
+  // carried a histogram at all.
+  await expect(panel).toContainText('706 films with a readable histogram');
+});
+
+test('a lean toward contested films is named rather than left as a bare ratio', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const panel = page
+    .getByRole('heading', { name: 'Films the world argues about' })
+    .locator('..')
+    .locator('..');
+
+  await expect(panel).toContainText('they seek out the arguments');
+  await expect(panel).toContainText('Divisive Fixture Film');
+});

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -635,6 +635,24 @@ export const obscurity = {
   // Where they usually land, plus the opposite tail: somebody can be out on a
   // limb in both directions at once.
   crowd_percentile: { measured_films: 706, typical_share: 0.653, lean: 'generous' },
+  // Leans toward films the site splits over: 86 contested against 47 agreed-on.
+  contested_taste: {
+    measured_films: 706,
+    contested_films: 86,
+    agreed_films: 47,
+    median_spread: 0.863,
+    lean_ratio: 1.83,
+    most_contested: [
+      {
+        title: 'Divisive Fixture Film',
+        year: 2023,
+        poster_url: null,
+        letterboxd_url: 'https://letterboxd.com/film/divisive-fixture-film/',
+        rating_count: 367_241,
+        profile_rating: 3.0,
+      },
+    ],
+  },
   crowd_position_below: [
     {
       title: 'Adored By Everyone Else',

--- a/frontend/src/components/insights/ObscurityPanel.tsx
+++ b/frontend/src/components/insights/ObscurityPanel.tsx
@@ -141,6 +141,7 @@ const ObscurityPanel: React.FC<{ username: string; delay?: number }> = ({
   const crowdPosition = data.crowd_position ?? [];
   const crowdBelow = data.crowd_position_below ?? [];
   const crowdPercentile = data.crowd_percentile;
+  const contested = data.contested_taste;
   const median = index?.median_rating_count ?? null;
   if (median === null && mostObscure.length === 0 && mostMainstream.length === 0) return null;
 
@@ -249,6 +250,40 @@ const ObscurityPanel: React.FC<{ username: string; delay?: number }> = ({
                 : ' — right about average'}
               .
             </p>
+          ) : null}
+          {contested && contested.lean_ratio !== null && contested.measured_films > 0 ? (
+            /* A different question from the two above: not how big the crowd
+               was, nor where this rating sat inside it, but whether the crowd
+               agreed with itself at all. */
+            <div className="rounded-lg border border-white/[0.07] bg-black/15 px-3 py-2.5">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h3 className="text-xs font-semibold text-white/70">Films the world argues about</h3>
+                <span className="text-[11px] text-white/35">
+                  {contested.measured_films.toLocaleString()} films with a readable histogram
+                </span>
+              </div>
+              <p className="mt-1.5 text-xs leading-5 text-white/50">
+                <strong className="text-white/85">
+                  {contested.contested_films.toLocaleString()}
+                </strong>{' '}
+                of their films are ones Letterboxd splits over, against{' '}
+                <strong className="text-white/85">
+                  {contested.agreed_films.toLocaleString()}
+                </strong>{' '}
+                the crowd broadly agrees on
+                {contested.lean_ratio >= 1.25
+                  ? ' — they seek out the arguments'
+                  : contested.lean_ratio <= 0.8
+                    ? ' — they stay with the settled ones'
+                    : ' — no strong pull either way'}
+                .
+              </p>
+              {contested.most_contested.length > 0 ? (
+                <p className="mt-1 line-clamp-2 text-[11px] text-white/30">
+                  Most divided: {contested.most_contested.slice(0, 4).map((film) => film.title).join(' · ')}
+                </p>
+              ) : null}
+            </div>
           ) : null}
           <ListSection
             title="Furthest above the crowd"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1715,6 +1715,18 @@ export interface ObscurityResponse {
     typical_share: number | null;
     lean: 'generous' | 'harsh' | 'typical' | null;
   };
+  /** Whether they gravitate toward films Letterboxd splits over. Contestedness
+   *  comes from each film's own histogram, so it rests on the site's whole
+   *  audience rather than on the handful of tracked profiles who rated it. */
+  contested_taste: {
+    measured_films: number;
+    contested_films: number;
+    agreed_films: number;
+    median_spread: number | null;
+    /** Null rather than infinity when there are no agreed-on films to divide by. */
+    lean_ratio: number | null;
+    most_contested: ObscurityFilm[];
+  };
 }
 
 export const obscurityApi = {


### PR DESCRIPTION
## The unused data

`movies.letterboxd_rating_distribution` holds Letterboxd's full histogram for
5,246 of 5,301 films we track. We read exactly one number out of it —
`share_at_or_below` — and threw the shape away.

An average cannot answer what the shape can:

```
United  {"3.0": 400}              average 3.0, nobody argued
Split   {"0.5": 200, "5.0": 200}  average 2.75, the room split in half
```

## What it measures

The standard deviation of each film's histogram, compared against the library's
top and bottom deciles. Sanity check on real data — the extremes are exactly
who you'd expect:

| most argued-over | spread | most agreed-on | spread |
|---|---|---|---|
| The Room | 1.83 | Band of Brothers | 0.55 |
| Salò | 1.35 | Chernobyl | 0.60 |
| Fifty Shades Freed | 1.34 | Cowboy Bebop | 0.60 |

And it separates profiles by **30×**:

| profile | contested | agreed | lean |
|---|---|---|---|
| whiteknight03x | 86 | 47 | **1.83×** |
| er3nweeber | 200 | 140 | 1.43× |
| pamarvss | 26 | 177 | 0.15× |
| snv710 | 2 | 31 | **0.06×** |

## Why this beats the existing "most divisive"

That panel measures spread across the 2–8 tracked profiles who rated a film.
This rests on the site's entire audience — often hundreds of thousands of
ratings — so it is not thin evidence dressed up as a verdict.

## Guards

- histograms under 100 ratings are sampling noise, not an argument → skipped
- a library under 200 measured films has no meaningful decile → measures nothing
- `lean_ratio` is null, never infinity, when there are no agreed-on films

Each guard has a test. 640 backend, 88 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)