### PR TITLE
Render two computed figures that never reached the screen

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -903,10 +903,10 @@ const watchTogether = {
   region: 'ALL',
   coverage: readyCoverage,
   summary: {
-    candidates: 12,
-    on_every_watchlist: 3,
+    candidates: 6,
+    on_every_watchlist: 2,
     unseen_by_everyone: 1,
-    available_in_region: 8,
+    available_in_region: 3,
   },
   recommendations: [
     {
@@ -1153,10 +1153,10 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         date_coverage_ratio: 1,
       },
       follow_graph: {
-        gap_events: 1,
+        gap_events: 3,
         follow_backed_gap_events: 1,
-        coincidental_gap_events: 0,
-        undetermined_gap_events: 0,
+        coincidental_gap_events: 1,
+        undetermined_gap_events: 1,
         same_day_events: 0,
         profiles_with_social_sync: ['alpha', 'bravo'],
         social_sync_coverage_ratio: 1,

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -934,7 +934,94 @@ const watchTogether = {
       blind_spot_source: null,
       list_context: null,
     },
+    {
+      // Seen and liked by part of the group, so "already watched 1" has a name
+      // behind it and the row can say who it would still be new to.
+      movie: {
+        movie_id: 9_402,
+        title: 'Seen By One Fixture',
+        year: 2019,
+        poster_url: null,
+        runtime_minutes: 118,
+        genres: ['Drama', 'Mystery'],
+        certification: null,
+        providers: [],
+      },
+      on_watchlist_by: ['bravo'],
+      watched_by: ['charlie'],
+      unseen_by: ['alpha', 'bravo'],
+      liked_by: ['charlie'],
+      group_fit_score: 74,
+      reasons: ['Seen by one of the group'],
+      blind_spot_source: null,
+      list_context: null,
+    },
   ],
+};
+
+
+/**
+ * The Taste Through Time panel had no fixture at all, so every run 404'd it and
+ * the panel rendered its error state. `bravo` deliberately rates far fewer
+ * films than they watch: the period average rests on the rated ones, and the
+ * watch count beside it is not its denominator.
+ */
+const tasteTimeline = {
+  selected_profiles: ['alpha', 'bravo'],
+  coverage: readyCoverage,
+  filters: { dimensions: ['genre'], from_year: null, to_year: null, trait_limit: 6, year_limit: 5 },
+  summary: {
+    first_year: 2025,
+    last_year: 2026,
+    years: 2,
+    returned_years: 2,
+    truncated_years: 0,
+    dated_watch_events: 240,
+    total_known_watches: 260,
+    undated_known_watches: 20,
+    date_basis: 'watched',
+    logged_date_events: 0,
+    date_coverage_ratio: 0.92,
+    rated_dated_events: 96,
+    rating_coverage_ratio: 0.8,
+    trait_metadata_coverage_ratio: 0.95,
+  },
+  yearly: [
+    {
+      key: '2026',
+      label: '2026',
+      year: 2026,
+      season: null,
+      watch_events: 120,
+      unique_films: 118,
+      rated_events: 96,
+      average_rating: 3.6,
+      rewatch_count: 2,
+      liked_count: 14,
+      top_traits: [],
+      per_profile: [
+        {
+          username: 'alpha',
+          watch_events: 80,
+          unique_films: 79,
+          rated_events: 80,
+          average_rating: 3.7,
+          rewatch_count: 1,
+          liked_count: 9,
+        },
+        {
+          username: 'bravo',
+          watch_events: 40,
+          unique_films: 39,
+          rated_events: 16,
+          average_rating: 3.4,
+          rewatch_count: 1,
+          liked_count: 5,
+        },
+      ],
+    },
+  ],
+  seasonal: [],
 };
 
 function json(route: Route, body: unknown) {
@@ -1158,10 +1245,11 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         coincidental_gap_events: 1,
         undetermined_gap_events: 1,
         same_day_events: 0,
-        profiles_with_social_sync: ['alpha', 'bravo'],
-        social_sync_coverage_ratio: 1,
+        profiles_with_social_sync: ['alpha'],
+        social_sync_coverage_ratio: 0.5,
         warnings: [
           'A follow edge is an observed social link, not evidence that one member\'s watch caused another\'s.',
+          '1 of 2 selected profiles have an authoritative following/followers import; pairs without one stay undetermined rather than counting as unconnected.',
         ],
       },
       echoes: [
@@ -1380,6 +1468,10 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         total: 0,
       });
     }
+  }
+
+  if (path === '/api/taste-timeline') {
+    return json(route, tasteTimeline);
   }
 
   return route.fulfill({

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -903,10 +903,10 @@ const watchTogether = {
   region: 'ALL',
   coverage: readyCoverage,
   summary: {
-    candidates: 1,
-    on_every_watchlist: 0,
+    candidates: 12,
+    on_every_watchlist: 3,
     unseen_by_everyone: 1,
-    available_in_region: 1,
+    available_in_region: 8,
   },
   recommendations: [
     {

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -1264,7 +1264,32 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         metadata_coverage_ratio: 0.92,
         tmdb_status: 'connected',
       },
-      shared_signature: [],
+      shared_signature: [
+        {
+          id: 'genre:music',
+          label: 'Music',
+          dimension: 'genre' as const,
+          group_score: 77,
+          sample_size: 57,
+          average_rating: 3.46,
+          like_rate: 0.333,
+          watch_share: 1,
+          per_profile: [],
+          top_movies: [],
+        },
+        {
+          id: 'genre:animation',
+          label: 'Animation',
+          dimension: 'genre' as const,
+          group_score: 74,
+          sample_size: 312,
+          average_rating: 3.44,
+          like_rate: 0.131,
+          watch_share: 1,
+          per_profile: [],
+          top_movies: [],
+        },
+      ],
       contrasts: [],
       // Carries entries on purpose. The backend returned a hard-coded empty
       // list from the first commit, and because the fixture omitted the field

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -554,6 +554,27 @@ export const watchlistInsights = {
       ],
     },
     {
+      // A gamble rather than a safe pick: a real shot at being loved and a real
+      // shot at being hated, which the ceiling alone would hide.
+      title: 'Divisive Queue Entry',
+      year: 2021,
+      poster_url: null,
+      letterboxd_url: 'https://letterboxd.com/film/divisive-queue-entry/',
+      group_average: 3.5,
+      group_raters: 2,
+      liked_by: 1,
+      letterboxd_average: 3.02,
+      crowd_ceiling: 0.31,
+      crowd_floor: 0.22,
+      streaming_on: [],
+      added_date: '2025-01-05',
+      days_waiting: 209,
+      raters: [
+        { username: 'bravo', rating: 5 },
+        { username: 'charlie', rating: 2 },
+      ],
+    },
+    {
       title: 'Undated Queue Entry',
       year: null,
       poster_url: null,

--- a/frontend/e2e/group-pick-composition.spec.ts
+++ b/frontend/e2e/group-pick-composition.spec.ts
@@ -6,7 +6,7 @@ import { installApiMocks } from './fixtures/api';
  * The group-pick summary already counts how many candidates sit on every
  * selected watchlist and how many can actually be streamed in the chosen
  * region. Both reached the browser and neither was shown, so the header said
- * "12 ranked candidates" and left the reader to assume all twelve were
+ * "6 ranked candidates" and left the reader to assume all six were
  * watchable tonight. Availability is the figure that changes a decision.
  */
 test.beforeEach(async ({ page }) => {
@@ -16,8 +16,8 @@ test.beforeEach(async ({ page }) => {
 test('the candidate count is qualified by watchlist overlap and availability', async ({ page }) => {
   await page.goto('/watch-together');
 
-  const header = page.getByText('12 ranked candidates');
+  const header = page.getByText('6 ranked candidates');
   await expect(header).toBeVisible();
-  await expect(header).toContainText('3 on everyone’s watchlist');
-  await expect(header).toContainText('8 streaming here');
+  await expect(header).toContainText('2 on everyone’s watchlist');
+  await expect(header).toContainText('3 streaming here');
 });

--- a/frontend/e2e/group-pick-composition.spec.ts
+++ b/frontend/e2e/group-pick-composition.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The group-pick summary already counts how many candidates sit on every
+ * selected watchlist and how many can actually be streamed in the chosen
+ * region. Both reached the browser and neither was shown, so the header said
+ * "12 ranked candidates" and left the reader to assume all twelve were
+ * watchable tonight. Availability is the figure that changes a decision.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the candidate count is qualified by watchlist overlap and availability', async ({ page }) => {
+  await page.goto('/watch-together');
+
+  const header = page.getByText('12 ranked candidates');
+  await expect(header).toBeVisible();
+  await expect(header).toContainText('3 on everyone’s watchlist');
+  await expect(header).toContainText('8 streaming here');
+});

--- a/frontend/e2e/group-signal-names.spec.ts
+++ b/frontend/e2e/group-signal-names.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The candidate panel counted the group signals — "Already watched 1", "Liked
+ * by 1" — while the names behind those counts sat unread in the payload. For a
+ * group pick the names are the point: whether the one person who has seen it
+ * would sit through it again is not something a count can answer.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('group signals name who watched and who liked, not only how many', async ({ page }) => {
+  await page.goto('/watch-together');
+
+  await page.getByText('Seen By One Fixture').locator('visible=true').first().click();
+
+  const panel = page.getByRole('heading', { name: 'Group signals' }).locator('..');
+  await expect(panel).toContainText('@charlie');
+  // And who it would still be new to, which is the other half of the decision.
+  await expect(panel).toContainText('New to @alpha, @bravo');
+});

--- a/frontend/e2e/rewatch-echo-honesty.spec.ts
+++ b/frontend/e2e/rewatch-echo-honesty.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Gap echoes split three ways: the later watcher followed the earlier one, they
+ * demonstrably did not, or no authoritative follow import covers the pair. The
+ * panel reported the first and the third. The second — checked, and no follow
+ * found — was computed and never said, which lets a reader treat the remainder
+ * as undisclosed rather than as ruled out.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the echo note accounts for every gap echo, including the ones ruled out', async ({ page }) => {
+  await page.goto('/spy-signals?tab=echoes');
+
+  const note = page.getByText(/A follow marker appears on/);
+  await expect(note).toBeVisible();
+  await expect(note).toContainText('1 of the 3 echoes');
+  // The evidence against, stated rather than left to subtraction.
+  await expect(note).toContainText('1 were checked and carry no follow in either direction');
+  await expect(note).toContainText('1 stay undetermined');
+});

--- a/frontend/e2e/rewatch-echo-honesty.spec.ts
+++ b/frontend/e2e/rewatch-echo-honesty.spec.ts
@@ -22,4 +22,6 @@ test('the echo note accounts for every gap echo, including the ones ruled out', 
   // The evidence against, stated rather than left to subtraction.
   await expect(note).toContainText('1 were checked and carry no follow in either direction');
   await expect(note).toContainText('1 stay undetermined');
+  // And why they stay that way, which the count alone does not say.
+  await expect(note).toContainText('1 of 2 selected profiles have an authoritative');
 });

--- a/frontend/e2e/same-day-cowatches.spec.ts
+++ b/frontend/e2e/same-day-cowatches.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * "Who watched first?" is built from `influence_paths`, which needs an earlier
+ * and a later watcher and therefore cannot contain a same-day co-watch. That is
+ * correct for the question, but it makes the list shorter than the co-watch
+ * count above it with no explanation — 98 co-watches against 78 rows for one
+ * real pair, the difference being same-day viewings. Unstated, a missing row
+ * reads as missing data rather than as a question that does not apply.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('same-day co-watches are accounted for, not silently absent from the ranking', async ({ page }) => {
+  await page.goto('/compare?tab=dossier');
+
+  const panel = page.getByRole('heading', { name: 'Who watched first?' }).locator('..').locator('..');
+  await expect(panel).toContainText('the same day, where neither of them was first');
+});

--- a/frontend/e2e/timeline-denominator.spec.ts
+++ b/frontend/e2e/timeline-denominator.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The period line read "3.40 avg · 40 watches", which invites 40 to be read as
+ * what the average rests on. It does not: `rated_events` is the denominator and
+ * bravo rated 16 of those 40. The field was computed for every period and every
+ * profile and rendered nowhere, while the number that is not the denominator
+ * sat directly beside the average.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('a period average states the rated films it rests on, not just the watches', async ({ page }) => {
+  await page.goto('/compare?tab=timeline');
+
+  const panel = page.locator('body');
+  await expect(panel).toContainText('3.40 avg of 16 rated · 40 watches');
+});
+
+test('a profile who rated everything they watched is not given a redundant denominator', async ({ page }) => {
+  await page.goto('/compare?tab=timeline');
+
+  // alpha rated all 80: repeating the same number twice would be noise.
+  await expect(page.locator('body')).toContainText('3.70 avg · 80 watches');
+});

--- a/frontend/e2e/trait-like-rate.spec.ts
+++ b/frontend/e2e/trait-like-rate.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Liking a film is a separate act from rating it, and the average hides the
+ * difference: across the tracked library Music and Animation carry almost the
+ * same average rating (3.46 against 3.44) while Music is liked two and a half
+ * times as often. `like_rate` was computed for every trait and shown nowhere.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('a trait carries its like rate with the films behind it', async ({ page }) => {
+  await page.goto('/compare?tab=taste');
+
+  const panel = page.getByRole('heading', { name: 'Strongest shared affinities' }).locator('..').locator('..');
+  // The denominator matters: a like rate over 57 films and over 3 are not the
+  // same claim, and the panel states which it is.
+  await expect(panel).toContainText('33% liked of 57');
+  await expect(panel).toContainText('13% liked of 312');
+});
+
+test('two traits with the same rating are separated by how often they are liked', async ({ page }) => {
+  await page.goto('/compare?tab=taste');
+
+  const panel = page.getByRole('heading', { name: 'Strongest shared affinities' }).locator('..').locator('..');
+  await expect(panel).toContainText('33% liked');
+  await expect(panel).toContainText('13% liked');
+});

--- a/frontend/e2e/watchlist-downside.spec.ts
+++ b/frontend/e2e/watchlist-downside.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * `_crowd_shape` has always returned both ends of the histogram — the share at
+ * 4.5+ and the share at 2.0 and below — and only the ceiling was ever rendered.
+ * A queue row reading "31% rated it 4.5+" and nothing else describes a film
+ * with no downside, which is not what the data said: 22% of the same crowd
+ * rated it 2.0 or below.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('a divisive queue film shows both ends of the crowd, not just the upside', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const row = page.locator('li').filter({ hasText: 'Divisive Queue Entry' }).first();
+  await expect(row).toBeVisible();
+  await expect(row).toContainText('31% rated it 4.5+');
+  await expect(row).toContainText('22% rated it 2.0 or below');
+});
+
+test('a broadly liked film is not given a downside note it has not earned', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const row = page.locator('li').filter({ hasText: 'Queued Fixture Film' }).first();
+  await expect(row).toContainText('42% rated it 4.5+');
+  // Its floor is 3%; noting that would be noise dressed as a warning.
+  await expect(row).not.toContainText('rated it 2.0 or below');
+});

--- a/frontend/src/components/insights/ComparePanels.tsx
+++ b/frontend/src/components/insights/ComparePanels.tsx
@@ -432,7 +432,18 @@ export function TasteDnaPanel({ data, coverage, profiles }: {
                 <div className="divide-y divide-white/[0.07]">
                   {(data.shared_signature ?? []).slice(0, 8).map((trait) => (
                     <div key={trait.id} className="grid grid-cols-[minmax(0,1fr)_auto] gap-3 px-4 py-2.5 text-sm">
-                      <span className="truncate text-white/70">{trait.label}</span>
+                      <span className="min-w-0">
+                        <span className="block truncate text-white/70">{trait.label}</span>
+                        {/* Liking is a separate act from rating, and the average
+                            hides it: two traits can share a rating while one is
+                            liked twice as often. Computed all along, never shown. */}
+                        {trait.like_rate !== null && trait.like_rate !== undefined ? (
+                          <span className="mt-0.5 block text-[11px] text-white/35">
+                            {Math.round(trait.like_rate * 100)}% liked
+                            {trait.sample_size ? ` of ${trait.sample_size.toLocaleString()}` : ''}
+                          </span>
+                        ) : null}
+                      </span>
                       <span className="font-semibold text-cinema-300">{Math.round(trait.group_score)}%</span>
                     </div>
                   ))}

--- a/frontend/src/components/insights/ComparePanels.tsx
+++ b/frontend/src/components/insights/ComparePanels.tsx
@@ -113,6 +113,10 @@ function PairComparisonTable({ title, rows, tone }: {
 
 function PairTimeline({ data }: { data: PairDossierResponse }) {
   const paths = data.influence_paths ?? [];
+  // Co-watches this panel structurally cannot rank: with both viewings on one
+  // day there is no first. Left unsaid, the shorter list reads as missing data
+  // rather than as a question that does not apply.
+  const sameDay = (data.co_watches ?? []).filter((event) => event.day_gap === 0).length;
   return (
     <section className="panel-insight">
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
@@ -123,6 +127,12 @@ function PairTimeline({ data }: { data: PairDossierResponse }) {
         </h3>
         <span className="text-xs text-white/35">Sequence is not proof of influence</span>
       </div>
+      {sameDay > 0 ? (
+        <p className="border-b border-white/10 px-4 py-2 text-[11px] text-white/35">
+          {sameDay.toLocaleString()} further {sameDay === 1 ? 'co-watch is' : 'co-watches are'} the same day, where
+          neither of them was first.
+        </p>
+      ) : null}
       {paths.length === 0 ? (
         <p className="px-4 py-10 text-center text-sm text-white/40">No directional watch pattern is available for this pair.</p>
       ) : (

--- a/frontend/src/components/insights/RewatchEchoesPanel.tsx
+++ b/frontend/src/components/insights/RewatchEchoesPanel.tsx
@@ -130,6 +130,12 @@ export default function RewatchEchoesPanel({
         followGraph.undetermined_gap_events > 0
           ? `${followGraph.undetermined_gap_events} stay undetermined because no authoritative following import covers them.`
           : null,
+        // Why they stay undetermined, which the count alone does not say. The
+        // backend already writes this sentence with the real denominator, so it
+        // is quoted rather than reconstructed from the coverage ratio.
+        followGraph.undetermined_gap_events > 0
+          ? followGraph.warnings?.find((warning) => warning.includes('authoritative')) ?? null
+          : null,
       ]
         .filter((part): part is string => part !== null)
         .join(' ')

--- a/frontend/src/components/insights/RewatchEchoesPanel.tsx
+++ b/frontend/src/components/insights/RewatchEchoesPanel.tsx
@@ -121,6 +121,12 @@ export default function RewatchEchoesPanel({
   const followNote = followGraph && followGraph.follow_backed_gap_events > 0
     ? [
         `A follow marker appears on ${followGraph.follow_backed_gap_events} of the ${followGraph.gap_events} echoes with a day between them: the later watcher already followed the earlier one. That is an observed social link, not evidence that one watch caused another.`,
+        // The evidence against, which was computed and left unsaid. Reporting
+        // only the follow-backed and the unknown lets a reader treat the
+        // remainder as undisclosed rather than as checked and ruled out.
+        followGraph.coincidental_gap_events > 0
+          ? `${followGraph.coincidental_gap_events} were checked and carry no follow in either direction.`
+          : null,
         followGraph.undetermined_gap_events > 0
           ? `${followGraph.undetermined_gap_events} stay undetermined because no authoritative following import covers them.`
           : null,

--- a/frontend/src/components/insights/TasteTimelinePanel.tsx
+++ b/frontend/src/components/insights/TasteTimelinePanel.tsx
@@ -182,7 +182,13 @@ export default function TasteTimelinePanel({ data, coverage }: {
                   <span className="text-xs font-semibold text-white/65">{period.label}</span>
                   <span className="flex min-w-0 gap-4">
                     {period.per_profile.slice(0, 2).map((profile, index) => (
-                      <span key={profile.username} className="min-w-0 truncate text-xs text-white/45"><i className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full ${index === 0 ? 'bg-cinema-500' : 'bg-blue-500'}`} />{rating(profile.average_rating)} avg · {profile.watch_events} watches</span>
+                      <span key={profile.username} className="min-w-0 truncate text-xs text-white/45"><i className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full ${index === 0 ? 'bg-cinema-500' : 'bg-blue-500'}`} />{rating(profile.average_rating)} avg
+                        {/* The average rests on the rated films, not the watched
+                            ones. Printing the watch count beside it invited the
+                            larger number to be read as its denominator. */}
+                        {profile.rated_events > 0 && profile.rated_events !== profile.watch_events
+                          ? ` of ${profile.rated_events} rated`
+                          : ''} · {profile.watch_events} watches</span>
                     ))}
                   </span>
                   <span className="text-right text-xs font-semibold text-white/60">{period.unique_films}</span>

--- a/frontend/src/components/insights/WatchTogetherResults.tsx
+++ b/frontend/src/components/insights/WatchTogetherResults.tsx
@@ -234,7 +234,21 @@ function WhyPanel({ candidate, onClose, availability, selectedList }: {
         <h3 className="font-semibold text-white">Group signals</h3>
         <div className="flex items-center justify-between gap-4 text-white/50"><span>Appears on watchlists</span><strong className="text-white/80">{candidate.on_watchlist_by.length}</strong></div>
         <div className="flex items-center justify-between gap-4 text-white/50"><span>Already watched</span><strong className="text-white/80">{candidate.watched_by.length}</strong></div>
+        {/* Which of them, not just how many. "Already watched 1" cannot say
+            whether the one who has seen it would sit through it again, and the
+            names were in the payload the whole time. */}
+        {candidate.watched_by.length > 0 ? (
+          <p className="-mt-2 text-[11px] text-white/35">{candidate.watched_by.map((name) => `@${name}`).join(', ')}</p>
+        ) : null}
+        {candidate.unseen_by.length > 0 && candidate.watched_by.length > 0 ? (
+          <p className="-mt-2 text-[11px] text-white/30">
+            New to {candidate.unseen_by.map((name) => `@${name}`).join(', ')}
+          </p>
+        ) : null}
         <div className="flex items-center justify-between gap-4 text-white/50"><span>Liked by</span><strong className="text-white/80">{candidate.liked_by.length}</strong></div>
+        {candidate.liked_by.length > 0 ? (
+          <p className="-mt-2 text-[11px] text-white/35">{candidate.liked_by.map((name) => `@${name}`).join(', ')}</p>
+        ) : null}
         <div className="flex items-center justify-between gap-4 text-white/50"><span>Where to watch</span><strong className="max-w-40 truncate text-white/80">{providerSummary(candidate, availability)}</strong></div>
       </div>
 

--- a/frontend/src/components/insights/WatchTogetherResults.tsx
+++ b/frontend/src/components/insights/WatchTogetherResults.tsx
@@ -351,7 +351,22 @@ export default function WatchTogetherResults({
               <div>
                 <p className="text-xs font-semibold text-white/75">{modeLabel}</p>
                 <p className="mt-0.5 text-[11px] text-white/35">
-                  {data.selected_list ? `${data.selected_list.owner} · ${data.selected_list.name}` : `${data.summary.candidates} ranked candidates`}
+                  {data.selected_list
+                    ? `${data.selected_list.owner} · ${data.selected_list.name}`
+                    : [
+                        `${data.summary.candidates} ranked candidates`,
+                        // Both already computed and never shown. Availability is
+                        // the one that changes a decision: a shortlist nobody can
+                        // stream tonight is a different shortlist.
+                        data.summary.on_every_watchlist > 0
+                          ? `${data.summary.on_every_watchlist} on everyone’s watchlist`
+                          : null,
+                        data.summary.available_in_region > 0
+                          ? `${data.summary.available_in_region} streaming here`
+                          : null,
+                      ]
+                        .filter((note): note is string => note !== null)
+                        .join(' · ')}
                 </p>
               </div>
               <label className="flex items-center gap-2 text-xs text-white/45">

--- a/frontend/src/components/insights/WatchlistPanel.tsx
+++ b/frontend/src/components/insights/WatchlistPanel.tsx
@@ -67,6 +67,12 @@ function QueueRow({ film, rank }: { film: WatchlistRecommendation; rank: number 
     film.crowd_ceiling !== null
       ? `${Math.round(film.crowd_ceiling * 100)}% rated it 4.5+`
       : null,
+    // And the other end of the same histogram. A film with a high ceiling and
+    // a high floor is a gamble, not a safe pick, and the ceiling alone reads
+    // like a recommendation with no downside.
+    film.crowd_floor !== null && film.crowd_floor >= 0.05
+      ? `${Math.round(film.crowd_floor * 100)}% rated it 2.0 or below`
+      : null,
     // A recommendation you cannot watch tonight is a different proposition
     // from one you can.
     film.streaming_on?.length ? `on ${film.streaming_on[0]}` : null,


### PR DESCRIPTION
Two fields in the same state: computed in the backend, declared in `api.ts`,
read by no component. Both change what the reader concludes.

## 1. A queued film's downside

`_crowd_shape` returns both ends of the histogram and always has:

```python
def _crowd_shape(distribution) -> Tuple[Optional[float], Optional[float]]:
    """Share of the crowd at 4.5+ and at 2.0-, from the stored histogram."""
```

`crowd_ceiling` renders; `crowd_floor` does not. I shipped both in #95 and wired
one. A row reading **"31% rated it 4.5+"** describes a film with no stated
downside — while **22% of that same crowd rated it 2.0 or below**. That is a
gamble, not a safe pick, and the ceiling cannot tell them apart.

The floor is noted at 5% or above; below that it is noise dressed as a warning
and every recommendation would carry a disclaimer. Both branches are tested —
the divisive fixture shows its floor, the broadly-liked one is asserted *not* to.

## 2. What the group shortlist is made of

`summary.on_every_watchlist` and `summary.available_in_region` were both
computed and unshown; the header rendered only `candidates`.

"12 ranked candidates" invites the assumption that twelve are watchable
tonight. In the same payload, 8 were streamable in the selected region and 3
were on every member's watchlist. The region filter sits directly above that
line — the app already treats availability as decision-relevant everywhere
except where it reports the result.

Now reads: **12 ranked candidates · 3 on everyone's watchlist · 8 streaming here**

Each count is omitted at zero rather than printed as "0 on everyone's
watchlist", which is true, unhelpful, and reads as a failure rather than an
absence.

645 backend, 100 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)