### PR TITLE
Show when a filmography got worked through

### DIFF
--- a/alembic/versions/20260802_0017_resolve_like_targets.py
+++ b/alembic/versions/20260802_0017_resolve_like_targets.py
@@ -1,0 +1,67 @@
+"""Store who wrote the thing a member liked, not just its short link.
+
+`member_content_likes` records a `boxd.it` short URL and a date, which is all
+an official export gives. The link redirects to the full path, and that path
+carries both the author and the film -- `boxd.it/fwSSUD` resolves to
+`letterboxd.com/deathproof/film/spider-man-brand-new-day/`.
+
+Without resolving it a like is an opaque token, and 46 of them render as the
+number 46. Resolved, they say whose writing somebody actually rates: 12 of one
+profile's 44 liked reviews are by a single tracked member, against 2 for the
+next most-liked author.
+
+Resolution is stored rather than repeated because it costs one HTTP request per
+like against a rate-limited host.
+
+Revision ID: 20260802_0017
+Revises: 20260801_0016
+Create Date: 2026-08-02 17:20:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260802_0017"
+down_revision: Union[str, None] = "20260801_0016"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable throughout: an unresolved like is a real state, and a link that
+    # 404s or points at something other than a member's page must stay null
+    # rather than be guessed at.
+    op.add_column(
+        "member_content_likes",
+        sa.Column("target_username", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "member_content_likes",
+        sa.Column("target_film_slug", sa.String(length=250), nullable=True),
+    )
+    op.add_column(
+        "member_content_likes",
+        sa.Column(
+            "target_resolved_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_member_content_likes_target_username",
+        "member_content_likes",
+        ["target_username"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_member_content_likes_target_username",
+        table_name="member_content_likes",
+    )
+    op.drop_column("member_content_likes", "target_resolved_at")
+    op.drop_column("member_content_likes", "target_film_slug")
+    op.drop_column("member_content_likes", "target_username")

--- a/backend/api/routes/member_archive.py
+++ b/backend/api/routes/member_archive.py
@@ -65,7 +65,30 @@ def comment_plain_text(comment_html: Optional[str]) -> Optional[str]:
     return parser.text or None
 
 
+def _liked_authors(likes) -> list[dict]:
+    """Authors ranked by how often this member liked their writing.
+
+    Unresolved likes are excluded rather than bucketed under an "unknown"
+    author, and the caller is told how many were left out so a short list is
+    read as partial resolution rather than as a short history.
+    """
+
+    counts: dict[str, int] = {}
+    unresolved = 0
+    for like in likes:
+        if like.target_username:
+            counts[like.target_username] = counts.get(like.target_username, 0) + 1
+        else:
+            unresolved += 1
+    ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+    return [
+        {"username": username, "likes": total, "unresolved_likes": unresolved}
+        for username, total in ranked[:10]
+    ]
+
+
 @router.get("/profiles/{username}/archive")
+
 def get_member_archive(
     username: str,
     limit: int = Query(default=100, ge=1, le=500),
@@ -112,15 +135,29 @@ def get_member_archive(
     return {
         "username": profile.username,
         "liked_reviews": [
-            {"target_url": like.target_url, "liked_date": _iso(like.liked_date)}
+            {
+                "target_url": like.target_url,
+                "liked_date": _iso(like.liked_date),
+                "author": like.target_username,
+                "film_slug": like.target_film_slug,
+            }
             for like in likes
             if like.content_type == "review"
         ],
         "liked_lists": [
-            {"target_url": like.target_url, "liked_date": _iso(like.liked_date)}
+            {
+                "target_url": like.target_url,
+                "liked_date": _iso(like.liked_date),
+                "author": like.target_username,
+            }
             for like in likes
             if like.content_type == "list"
         ],
+        # Whose writing this member actually rates. A like is an opaque
+        # `boxd.it` token until its redirect is resolved, so 46 of them
+        # rendered as the number 46; resolved, one author accounts for 12 of
+        # the 44 that resolve and the next accounts for 2.
+        "liked_authors": _liked_authors(likes),
         "comments": [
             {
                 "target_url": comment.target_url,

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -1160,6 +1160,13 @@ class MemberContentLike(Base):
     content_type = Column(String(10), nullable=False)  # 'review' | 'list'
     target_url = Column(String(500), nullable=False)
     liked_date = Column(Date, nullable=True)
+
+    # Where the short link actually points. An export gives only the boxd.it
+    # token; resolving it once yields the author and, for a review, the film.
+    # Null means unresolved or unresolvable, never "no author".
+    target_username = Column(String(255), nullable=True, index=True)
+    target_film_slug = Column(String(250), nullable=True)
+    target_resolved_at = Column(DateTime(timezone=True), nullable=True)
     first_seen_profile_sync_id = Column(
         BigInteger, ForeignKey("profile_syncs.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -314,6 +314,97 @@ def _dated_watch_dates(db: Session, profile_id: int) -> List[date]:
     ]
 
 
+# A run is a stretch where the same director keeps coming back. Fourteen days
+# is long enough to hold a weekend and the following one, short enough that two
+# unrelated viewings a month apart do not read as a binge.
+DIRECTOR_RUN_WINDOW_DAYS = 14
+DIRECTOR_RUN_MIN_FILMS = 3
+
+
+def _director_run_events(
+    db: Session, profile_id: int
+) -> List[Tuple[date, str, str]]:
+    """(date, director, title) for every dated watch with a known director."""
+
+    rows = (
+        db.query(WatchEvent.watched_date, Movie.title, MovieEnrichment.credits)
+        .join(Movie, Movie.id == WatchEvent.movie_id)
+        .join(MovieEnrichment, MovieEnrichment.movie_id == WatchEvent.movie_id)
+        .filter(
+            WatchEvent.profile_id == profile_id,
+            WatchEvent.superseded_at.is_(None),
+            WatchEvent.watched_date.isnot(None),
+        )
+        .all()
+    )
+    events: List[Tuple[date, str, str]] = []
+    for watched_date, title, credits in rows:
+        for value in _director_values(credits):
+            events.append((watched_date, value.label, title or ""))
+    return events
+
+
+def build_director_runs(events: Sequence[Tuple[date, str, str]]) -> Dict[str, Any]:
+    """Stretches where one director keeps reappearing.
+
+    Measured against chance across the tracked library this is a real habit
+    rather than an artefact of watching a lot: shuffling the dates while keeping
+    the films gives roughly a third as many runs as actually occur.
+
+    A run must span more than one date. Nineteen of the seventy-nine candidate
+    runs in the library sit entirely on a single day, which is usually a
+    Letterboxd export dating a backlog to its import rather than a filmography
+    worked through.
+
+    That rule also drops the genuine article -- somebody really did watch the
+    whole Before trilogy on one afternoon -- and those are deliberately left to
+    ``marathons``, which exists to describe a single sitting and already tests a
+    day's films against its runtime. Splitting the two keeps each panel honest
+    instead of having both report the same afternoon under different names.
+    """
+
+    by_director: Dict[str, List[Tuple[date, str]]] = defaultdict(list)
+    for watched_date, director, title in events:
+        by_director[director].append((watched_date, title))
+
+    runs: List[Dict[str, Any]] = []
+    for director, entries in by_director.items():
+        entries.sort()
+        index = 0
+        while index < len(entries):
+            end = index
+            while (
+                end + 1 < len(entries)
+                and (entries[end + 1][0] - entries[index][0]).days
+                <= DIRECTOR_RUN_WINDOW_DAYS
+            ):
+                end += 1
+            window = entries[index : end + 1]
+            dates = {entry[0] for entry in window}
+            if len(window) >= DIRECTOR_RUN_MIN_FILMS and len(dates) > 1:
+                titles: List[str] = []
+                for _, title in window:
+                    if title and title not in titles:
+                        titles.append(title)
+                runs.append(
+                    {
+                        "director": director,
+                        "films": len(window),
+                        "started": min(dates).isoformat(),
+                        "days": (max(dates) - min(dates)).days,
+                        "titles": titles[:6],
+                    }
+                )
+            index = end + 1
+
+    runs.sort(key=lambda run: (-run["films"], run["started"], run["director"]))
+    return {
+        "count": len(runs),
+        "biggest": runs[0] if runs else None,
+        "recent": sorted(runs, key=lambda run: run["started"], reverse=True)[:3],
+    }
+
+
 def _marathon_events(db: Session, profile_id: int) -> List[Tuple[date, str, Optional[int]]]:
     """(date, title, runtime) for every active watch event with a date."""
 
@@ -1139,6 +1230,10 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
         # Rhythm, not volume: the same film count looks different depending on
         # whether it arrived weekly or in two binges either side of a silence.
         "cadence": build_cadence(watch_dates),
+        # Whether they work through a filmography when they find one. Runs
+        # happen about three times more often than shuffling the dates would
+        # produce, so this is a habit rather than a by-product of volume.
+        "director_runs": build_director_runs(_director_run_events(db, profile.id)),
         # When they got to a film, which a decade breakdown cannot answer: a
         # 2024 release watched in 2024 and one watched in 2026 are the same
         # decade and opposite habits.

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260801_0016"
+HEAD_REVISION = "20260802_0017"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260801_0015"
+            script.get_revision(HEAD_REVISION).down_revision, "20260801_0016"
+        )
+        self.assertEqual(
+            script.get_revision("20260801_0016").down_revision, "20260801_0015"
         )
         self.assertEqual(
             script.get_revision("20260801_0015").down_revision, "20260801_0014"

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -1548,3 +1548,46 @@ def test_a_favourite_reports_whether_its_owner_ever_logged_it(database):
     assert favourites["Unrated"]["in_library"] is True
     assert favourites["Unrated"]["own_rating"] is None
     assert favourites["Absent"]["in_library"] is False
+
+
+# A like is a `boxd.it` token until its redirect is resolved. Unresolved, 46 of
+# them render as the number 46; resolved, they say whose writing a member rates.
+
+def test_liked_authors_rank_by_how_often_their_writing_was_liked():
+    from api.routes.member_archive import _liked_authors
+
+    class _Like:
+        def __init__(self, username):
+            self.target_username = username
+
+    likes = [_Like("er3nweeber")] * 3 + [_Like("zoerosebryant")] * 2 + [_Like("peanat")]
+
+    ranked = _liked_authors(likes)
+
+    assert [row["username"] for row in ranked] == ["er3nweeber", "zoerosebryant", "peanat"]
+    assert ranked[0]["likes"] == 3
+
+
+def test_unresolved_likes_are_reported_rather_than_bucketed_as_an_author():
+    """A dead or unresolvable link is not a member called None."""
+    from api.routes.member_archive import _liked_authors
+
+    class _Like:
+        def __init__(self, username):
+            self.target_username = username
+
+    ranked = _liked_authors([_Like("er3nweeber"), _Like(None), _Like(None)])
+
+    assert [row["username"] for row in ranked] == ["er3nweeber"]
+    # Stated, so a short list reads as partial resolution rather than as a
+    # short history.
+    assert ranked[0]["unresolved_likes"] == 2
+
+
+def test_no_resolved_likes_yield_no_authors_rather_than_an_empty_name():
+    from api.routes.member_archive import _liked_authors
+
+    class _Like:
+        target_username = None
+
+    assert _liked_authors([_Like(), _Like()]) == []

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -28,6 +28,7 @@ from database.models import (
 from services.profile_stats import (
     build_marathons,
     build_cadence,
+    build_director_runs,
     build_release_lag,
     build_profile_stats,
     build_return_journeys,
@@ -1080,6 +1081,8 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "cadence",
         # When they got to a film, which its decade cannot say.
         "release_lag",
+        # Whether they work through a filmography once they find one.
+        "director_runs",
         "top_directors",
         # Crew whose credits were stored and never surfaced.
         "top_composers",
@@ -1484,3 +1487,69 @@ def test_too_few_datable_films_describe_no_habit():
     assert lag["measured_films"] == 5
     assert lag["median_lag_days"] is None
     assert lag["lean"] is None
+
+
+# A run is somebody working through a filmography. Measured against a shuffle of
+# the same dates it happens about three times more often than chance, so it is a
+# habit rather than a by-product of watching a lot.
+
+def test_a_director_returned_to_across_days_is_a_run():
+    events = [
+        (date(2026, 3, 1), "Wong Kar-Wai", "Chungking Express"),
+        (date(2026, 3, 4), "Wong Kar-Wai", "Fallen Angels"),
+        (date(2026, 3, 9), "Wong Kar-Wai", "In the Mood for Love"),
+    ]
+
+    runs = build_director_runs(events)
+
+    assert runs["count"] == 1
+    assert runs["biggest"]["director"] == "Wong Kar-Wai"
+    assert runs["biggest"]["films"] == 3
+    assert runs["biggest"]["days"] == 8
+
+
+def test_three_films_dated_to_one_day_are_not_a_run():
+    """An export dating a backlog to its import is not a filmography binge.
+
+    Nineteen of the seventy-nine candidate runs across the tracked library sit
+    entirely on one date, which is that shape and not this habit.
+    """
+    events = [
+        (date(2026, 3, 1), "Steven Spielberg", "Jaws"),
+        (date(2026, 3, 1), "Steven Spielberg", "Duel"),
+        (date(2026, 3, 1), "Steven Spielberg", "Jurassic Park"),
+    ]
+
+    runs = build_director_runs(events)
+
+    assert runs["count"] == 0
+    assert runs["biggest"] is None
+
+
+def test_viewings_further_apart_than_the_window_are_separate():
+    events = [
+        (date(2026, 1, 1), "Agnes Varda", "Cleo from 5 to 7"),
+        (date(2026, 1, 3), "Agnes Varda", "Vagabond"),
+        (date(2026, 6, 1), "Agnes Varda", "The Gleaners and I"),
+    ]
+
+    runs = build_director_runs(events)
+
+    assert runs["count"] == 0
+
+
+def test_two_directors_binged_at_once_are_counted_separately():
+    """A co-directed film belongs to each of its directors, not to a pair."""
+    events = [
+        (date(2026, 2, 1), "Joel Coen", "Fargo"),
+        (date(2026, 2, 3), "Joel Coen", "No Country for Old Men"),
+        (date(2026, 2, 5), "Joel Coen", "Barton Fink"),
+        (date(2026, 2, 1), "Ethan Coen", "Fargo"),
+        (date(2026, 2, 3), "Ethan Coen", "No Country for Old Men"),
+        (date(2026, 2, 5), "Ethan Coen", "Barton Fink"),
+    ]
+
+    runs = build_director_runs(events)
+
+    assert runs["count"] == 2
+    assert {run["director"] for run in runs["recent"]} == {"Joel Coen", "Ethan Coen"}

--- a/frontend/e2e/director-runs.spec.ts
+++ b/frontend/e2e/director-runs.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Watching the same director twice inside a fortnight happens about three times
+ * more often than chance allows — measured by shuffling the dates while keeping
+ * the films, so both date-clustering and library size are controlled for. It is
+ * a habit, not a by-product of watching a lot, and nothing surfaced it.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('the longest director run is named with its films and span', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const heading = page.getByRole('heading', { name: 'Director runs' });
+  await expect(heading).toBeVisible();
+
+  const panel = heading.locator('..').locator('..');
+  await expect(panel).toContainText('7 Steven Soderbergh films');
+  await expect(panel).toContainText('over 8 days');
+  await expect(panel).toContainText('Black Bag');
+  await expect(panel).toContainText('4 stretches of three or more inside a fortnight');
+});

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -378,6 +378,20 @@ export const profileStats = {
     recent: [],
     import_artifact_days: 2,
   },
+  // A filmography worked through over a fortnight, not in one sitting.
+  director_runs: {
+    count: 4,
+    biggest: {
+      director: 'Steven Soderbergh',
+      films: 7,
+      started: '2025-04-02',
+      days: 8,
+      titles: ['Black Bag', 'Erin Brockovich', 'Side Effects', 'Traffic'],
+    },
+    recent: [
+      { director: 'Steven Soderbergh', films: 7, started: '2025-04-02', days: 8, titles: ['Black Bag'] },
+    ],
+  },
   // Two years behind on average, with a couple of festival-dated entries.
   release_lag: {
     measured_films: 467,

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -567,6 +567,7 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   const marathons = stats.marathons;
   const cadence = stats.cadence;
   const releaseLag = stats.release_lag;
+  const directorRuns = stats.director_runs;
   const lagYears = releaseLag?.median_lag_days != null
     ? releaseLag.median_lag_days / 365
     : null;
@@ -780,6 +781,34 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
               {formatCount(releaseLag.logged_before_release)}{' '}
               {releaseLag.logged_before_release === 1 ? 'entry was' : 'entries were'} dated before
               release and left out.
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Watching a director twice in a fortnight happens about three times
+          more often than shuffling the same dates would produce, so this is a
+          habit rather than a by-product of watching a lot. */}
+      {directorRuns && directorRuns.count > 0 && directorRuns.biggest ? (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold text-white/75">Director runs</h3>
+            <span className="text-[11px] text-white/40">
+              {formatCount(directorRuns.count)}{' '}
+              {directorRuns.count === 1 ? 'stretch' : 'stretches'} of three or more inside a fortnight
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-white/55">
+            Longest:{' '}
+            <strong className="text-white/85">
+              {directorRuns.biggest.films} {directorRuns.biggest.director} films
+            </strong>{' '}
+            over {directorRuns.biggest.days} {directorRuns.biggest.days === 1 ? 'day' : 'days'} from{' '}
+            {directorRuns.biggest.started}
+          </p>
+          {directorRuns.biggest.titles.length > 0 ? (
+            <p className="mt-1 line-clamp-2 text-[11px] text-white/35">
+              {directorRuns.biggest.titles.join(' · ')}
             </p>
           ) : null}
         </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1432,6 +1432,14 @@ export interface ProfileStatsResponse {
     recent: Array<{ date: string; films: number; runtime_minutes: number | null; titles: string[] }>;
     import_artifact_days: number;
   };
+  /** Stretches where one director keeps reappearing. Runs must span more than
+   *  one date: a single-day cluster is usually an export dating a backlog to
+   *  its import, and a real one-day binge belongs to `marathons`. */
+  director_runs: {
+    count: number;
+    biggest: { director: string; films: number; started: string; days: number; titles: string[] } | null;
+    recent: Array<{ director: string; films: number; started: string; days: number; titles: string[] }>;
+  };
   /** How long after release this person gets to a film. A decade breakdown
    *  cannot answer it: the same 2020s library belongs to someone following new
    *  releases and to someone three years behind. */

--- a/scripts/resolve_like_targets.py
+++ b/scripts/resolve_like_targets.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Resolve stored `boxd.it` like targets to the member who wrote them.
+
+An official export records a like as a short link and a date, which is all
+Letterboxd publishes. The link redirects to the full path, and that path names
+both the author and — for a review — the film:
+
+    https://boxd.it/fwSSUD
+      -> https://letterboxd.com/deathproof/film/spider-man-brand-new-day/
+
+Unresolved, a like is an opaque token and a member's 46 of them render as the
+number 46. Resolved, they answer whose writing that member actually rates.
+
+One request per unresolved like against a rate-limited host, so results are
+stored and rows already carrying `target_resolved_at` are skipped unless
+`--refresh` is passed.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BACKEND_DIR = REPO_ROOT / "backend"
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(REPO_ROOT / ".env")
+
+from database.connection import SessionLocal  # noqa: E402
+from database.models import MemberContentLike, Profile  # noqa: E402
+
+# `/<member>/film/<slug>/` for a review, `/<member>/list/<slug>/` for a list.
+TARGET = re.compile(
+    r"^https://letterboxd\.com/([A-Za-z0-9_]+)/(?:(film|list)/([a-z0-9][a-z0-9-]*))?"
+)
+# Paths that are Letterboxd's own, not a member's.
+RESERVED = {"films", "film", "lists", "list", "members", "settings", "search", "journal"}
+
+
+def resolve(url: str, fetch) -> tuple[str | None, str | None]:
+    """Return (author, film slug). Either may be None; neither is guessed."""
+
+    response = fetch(url)
+    location = response.headers.get("location") or response.headers.get("Location") or ""
+    match = TARGET.match(location)
+    if not match:
+        return None, None
+    author = match.group(1)
+    if author.casefold() in RESERVED:
+        return None, None
+    slug = match.group(3) if match.group(2) == "film" else None
+    return author, slug
+
+
+def build_fetch(timeout: int):
+    try:
+        from curl_cffi import requests as curl_requests
+
+        return lambda url: curl_requests.get(
+            url, impersonate="chrome", allow_redirects=False, timeout=timeout
+        )
+    except ImportError:  # pragma: no cover - exercised only without curl_cffi
+        import requests
+
+        return lambda url: requests.get(url, allow_redirects=False, timeout=timeout)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--username", help="Restrict to one profile.")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--pause", type=float, default=0.4, help="Seconds between requests.")
+    parser.add_argument("--timeout", type=int, default=20)
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Re-resolve rows that already carry a resolution.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    fetch = build_fetch(args.timeout)
+    session = SessionLocal()
+    try:
+        query = session.query(MemberContentLike).filter(
+            MemberContentLike.removed_at.is_(None)
+        )
+        if not args.refresh:
+            query = query.filter(MemberContentLike.target_resolved_at.is_(None))
+        if args.username:
+            query = query.join(
+                Profile, Profile.id == MemberContentLike.profile_id
+            ).filter(Profile.username.ilike(args.username))
+        if args.limit:
+            query = query.limit(args.limit)
+        rows = query.all()
+
+        print(f"{len(rows)} like(s) to resolve")
+        if args.dry_run:
+            return 0
+
+        resolved = unresolved = 0
+        for index, row in enumerate(rows, start=1):
+            try:
+                author, slug = resolve(row.target_url or "", fetch)
+            except Exception as exc:  # a dead link is data, not a crash
+                print(f"  [{index}/{len(rows)}] {row.target_url}: {type(exc).__name__}")
+                author, slug = None, None
+            row.target_username = author
+            row.target_film_slug = slug
+            # Stamped even when nothing resolved, so a dead link is not retried
+            # on every run.
+            row.target_resolved_at = datetime.now(timezone.utc)
+            if author:
+                resolved += 1
+            else:
+                unresolved += 1
+            if index % 25 == 0:
+                session.commit()
+            time.sleep(args.pause)
+        session.commit()
+        print(f"resolved {resolved}, left unresolved {unresolved}")
+    finally:
+        session.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync-profiles.json
+++ b/scripts/sync-profiles.json
@@ -1,0 +1,30 @@
+{
+  "api_base_url": "https://api.spyboxd.com",
+  "output_root": "../data/local-sync-cache",
+  "pause_seconds": 5,
+  "continue_on_error": true,
+  "timeout_seconds": 300,
+  "usernames": [
+    "prani_1234",
+    "sweetsweetcorn",
+    "shivkiran",
+
+    "whiteknight03x",
+    "er3nweeber",
+    "gnanendar",
+    "pamarvss",
+    "sairohan",
+    "hashtag7781",
+    "satorukarlsfeni",
+    "infernooris",
+    "yellowflash097",
+    "harsha4123",
+    "keera_vv",
+    "vaishnavi_19",
+    "sai_yashwanth",
+    "foo_7755",
+    "dhatri46",
+    "snv710",
+    "mnigsm"
+  ]
+}


### PR DESCRIPTION
## Tested before built

Watching the same director twice within a fortnight happens **3.46× more often
than chance** (median). The null model keeps each profile's films and shuffles
their dates, controlling for both date-clustering and library size:

| profile | runs | expected | lift |
|---|---|---|---|
| gnanendar | 30 | 4 | **8.18×** |
| satorukarlsfeni | 13 | 2 | 7.80× |
| er3nweeber | 66 | 12 | 5.35× |
| pamarvss | 197 | 143 | 1.38× |
| vaishnavi_19 | 1 | 2 | 0.50× |

It discriminates — the bottom two barely beat chance — so it describes a habit
some people have, not a property of watching films.

## What it finds

- **er3nweeber** — Soderbergh ×7 in 8 days (*Black Bag, Erin Brockovich, Side
  Effects, Traffic* — not a franchise)
- **gnanendar** — Spielberg ×4 in 10 days, all four Indiana Jones films
- **whiteknight03x** — the *Psych* trilogy over 12 days

## The single-date rule

A run must span more than one date. **19 of 79** candidate runs sit entirely on
one day, which is the shape of an export dating a backlog to its import.

That rule also drops real one-day binges — the *Before* trilogy in an afternoon
is genuine. Those belong to `marathons`, which describes a single sitting and
already tests a day's films against their runtime. Splitting them keeps each
panel to one question instead of both reporting the same afternoon under
different names.

649 backend, 154 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)