### PR TITLE
Let a residential resolution reach production

### DIFF
--- a/backend/api/routes/member_archive.py
+++ b/backend/api/routes/member_archive.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 from html.parser import HTMLParser
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 
 from auth import ClerkUser, get_current_user
@@ -186,4 +188,70 @@ def get_member_archive(
             "comments": len(comments),
             "lost_entries": len(lost),
         },
+    }
+
+
+@router.post("/profiles/{username}/archive/like-targets")
+def resolve_like_targets(
+    username: str,
+    payload: dict = Body(...),
+    db: Session = Depends(get_db),
+    user: ClerkUser = Depends(get_current_user),
+) -> dict:
+    """Attach resolved authors to this profile's stored likes.
+
+    A like is a `boxd.it` token until its redirect is followed, and Letterboxd
+    blocks the datacenter addresses this API runs on, so the redirect can only
+    be resolved from the residential machine that holds the export. This is the
+    counterpart to that constraint: the answer is computed there and posted
+    here, exactly as a scrape is.
+
+    Only the three resolution columns are written. Nothing is created, removed,
+    or soft-deleted, so a partial or repeated post cannot cost data -- unlike a
+    bundle upload, where a present authoritative file removes what it omits.
+    """
+
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Resolving like targets requires an admin.",
+        )
+    profile = require_profile_access(db, user, username)
+    resolutions = payload.get("resolutions")
+    if not isinstance(resolutions, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Send {'resolutions': {url: {'author': str, 'film_slug': str|null}}}.",
+        )
+
+    likes = (
+        db.query(MemberContentLike)
+        .filter(
+            MemberContentLike.profile_id == profile.id,
+            MemberContentLike.removed_at.is_(None),
+        )
+        .all()
+    )
+    now = datetime.now(timezone.utc)
+    updated = 0
+    for like in likes:
+        entry = resolutions.get(like.target_url)
+        if not isinstance(entry, dict):
+            continue
+        author = (entry.get("author") or "").strip()[:255]
+        if not author:
+            continue
+        like.target_username = author
+        slug = (entry.get("film_slug") or "").strip()[:250] or None
+        like.target_film_slug = slug
+        like.target_resolved_at = now
+        updated += 1
+    db.commit()
+    return {
+        "username": profile.username,
+        "likes": len(likes),
+        "resolved": updated,
+        # Stated rather than implied: a caller that sent fewer resolutions than
+        # there are likes should see that, not infer it from a smaller number.
+        "still_unresolved": sum(1 for like in likes if not like.target_username),
     }

--- a/backend/services/ingestion.py
+++ b/backend/services/ingestion.py
@@ -914,6 +914,7 @@ def _upsert_member_content_likes(
     frame_name: str,
     authoritative: bool,
     db: Session,
+    resolutions: Optional[Mapping[str, Mapping[str, Any]]] = None,
 ) -> int:
     """Reconcile the export-only liked-reviews/liked-lists surfaces.
 
@@ -951,6 +952,20 @@ def _upsert_member_content_likes(
         liked_date = parse_date(first_value(row, ("Date",)))
         if liked_date is not None:
             like.liked_date = liked_date
+        # A resolved target may ride along in the bundle. Letterboxd blocks the
+        # datacenter addresses production runs on, so the boxd.it redirect can
+        # only be followed from the same residential machine that scraped the
+        # export -- the resolution travels with the upload rather than being
+        # refetched here.
+        resolved = resolutions.get(target_url) if resolutions else None
+        if resolved:
+            author = clean_text(resolved.get("author"), max_length=255)
+            if author:
+                like.target_username = author
+                like.target_film_slug = clean_text(
+                    resolved.get("film_slug"), max_length=250
+                )
+                like.target_resolved_at = _utcnow()
         like.last_seen_profile_sync_id = sync.id
         like.removed_at = None
 
@@ -1987,6 +2002,7 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
             frame_name="liked_reviews",
             authoritative=liked_reviews_authoritative,
             db=db,
+            resolutions=getattr(analyzer_profile, "like_resolutions", None),
         )
         liked_lists_count = _upsert_member_content_likes(
             analyzer_profile=analyzer_profile,
@@ -1996,6 +2012,7 @@ def unified_data_loader(analyzer_profile, profile_id: int, db: Session):
             frame_name="liked_lists",
             authoritative=liked_lists_authoritative,
             db=db,
+            resolutions=getattr(analyzer_profile, "like_resolutions", None),
         )
         comment_count = _upsert_member_comments(
             analyzer_profile=analyzer_profile,

--- a/backend/services/profile_loader.py
+++ b/backend/services/profile_loader.py
@@ -5,7 +5,7 @@ import io
 import math
 import json
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -67,6 +67,11 @@ class LoadedProfileData:
     source_fingerprint: str
     source_files: Dict[str, Dict[str, Any]]
     manifest: Dict[str, Any]
+    # {boxd.it url: {"author": str, "film_slug": str | None}} produced by the
+    # residential resolver. Letterboxd blocks the datacenter addresses the API
+    # runs on, so the redirect can only be followed where the export was
+    # scraped; the answer travels in the bundle instead of being refetched.
+    like_resolutions: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
 
 def _safe_read_csv(path: str, label: str, *, strict: bool = False) -> pd.DataFrame:
@@ -186,6 +191,23 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
             source_files["manifest.json"] = _file_info(manifest_path, 0)
         except (OSError, ValueError, json.JSONDecodeError) as exc:
             raise ValueError(f"Invalid scrape manifest: {exc}") from exc
+
+    like_resolutions: Dict[str, Dict[str, Any]] = {}
+    resolved_path = resolved_profile_path / "likes_resolved.json"
+    if resolved_path.exists():
+        try:
+            with resolved_path.open("r", encoding="utf-8") as handle:
+                decoded_resolutions = json.load(handle)
+            if isinstance(decoded_resolutions, dict):
+                like_resolutions = {
+                    str(url): value
+                    for url, value in decoded_resolutions.items()
+                    if isinstance(value, dict) and value.get("author")
+                }
+            source_files["likes_resolved.json"] = _file_info(resolved_path, 0)
+        except (OSError, ValueError, json.JSONDecodeError):
+            # A malformed sidecar loses an enrichment, never the import.
+            like_resolutions = {}
 
     profile_csv = resolved_profile_path / "profile.csv"
     if profile_csv.exists():
@@ -423,6 +445,7 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
         source_fingerprint=source_fingerprint,
         source_files=source_files,
         manifest=manifest,
+        like_resolutions=like_resolutions,
     )
 
 

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -1591,3 +1591,39 @@ def test_no_resolved_likes_yield_no_authors_rather_than_an_empty_name():
         target_username = None
 
     assert _liked_authors([_Like(), _Like()]) == []
+
+
+def test_like_target_resolution_is_admin_only(database):
+    """Naming who a member likes is an identity surface, not a public one."""
+    from fastapi import HTTPException
+    from backend.api.routes.member_archive import resolve_like_targets
+
+    with pytest.raises(HTTPException) as raised:
+        resolve_like_targets(
+            username="alpha",
+            payload={"resolutions": {}},
+            db=database,
+            user=_user("ordinary"),
+        )
+
+    assert raised.value.status_code == 403
+
+
+def test_like_target_resolution_rejects_a_payload_it_cannot_read(database):
+    """Access is settled before the body is read, so the profile must exist."""
+    from fastapi import HTTPException
+    from backend.api.routes.member_archive import resolve_like_targets
+
+    database.add(_profile(1, "Alpha"))
+    database.commit()
+    admin = _legacy_user(database, "admin", admin=True)
+
+    with pytest.raises(HTTPException) as raised:
+        resolve_like_targets(
+            username="Alpha",
+            payload={"resolutions": ["not", "a", "mapping"]},
+            db=database,
+            user=admin,
+        )
+
+    assert raised.value.status_code == 400

--- a/backend/tests/test_route_access_matrix.py
+++ b/backend/tests/test_route_access_matrix.py
@@ -85,3 +85,8 @@ def test_existing_mutations_keep_admin_or_ingestion_auth():
         _route("POST", "/api/films/letterboxd-ratings")
     )
     assert "get_current_user" in _dependency_names(_route("POST", "/profiles/{profile_id}/tracking"))
+    # Writes an export-only surface that only an admin may touch; the handler
+    # also rejects non-admins, but the dependency must be there regardless.
+    assert "get_current_user" in _dependency_names(
+        _route("POST", "/api/profiles/{username}/archive/like-targets")
+    )

--- a/scripts/resolve_like_targets.py
+++ b/scripts/resolve_like_targets.py
@@ -84,6 +84,15 @@ def main() -> int:
         help="Re-resolve rows that already carry a resolution.",
     )
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--write-bundle",
+        help=(
+            "Directory of a scraped bundle; writes likes_resolved.json beside "
+            "the CSVs so the resolution uploads with the export. Production "
+            "cannot follow these redirects itself: Letterboxd blocks the "
+            "datacenter addresses it runs on."
+        ),
+    )
     args = parser.parse_args()
 
     fetch = build_fetch(args.timeout)
@@ -127,6 +136,33 @@ def main() -> int:
             time.sleep(args.pause)
         session.commit()
         print(f"resolved {resolved}, left unresolved {unresolved}")
+
+        if args.write_bundle:
+            import json
+
+            target_dir = Path(args.write_bundle).resolve()
+            target_dir.mkdir(parents=True, exist_ok=True)
+            # Everything resolved for this profile, not just this run's rows,
+            # so a re-upload carries the whole mapping.
+            export_query = session.query(MemberContentLike).filter(
+                MemberContentLike.removed_at.is_(None),
+                MemberContentLike.target_username.isnot(None),
+            )
+            if args.username:
+                export_query = export_query.join(
+                    Profile, Profile.id == MemberContentLike.profile_id
+                ).filter(Profile.username.ilike(args.username))
+            payload = {
+                row.target_url: {
+                    "author": row.target_username,
+                    "film_slug": row.target_film_slug,
+                }
+                for row in export_query.all()
+                if row.target_url
+            }
+            out = target_dir / "likes_resolved.json"
+            out.write_text(json.dumps(payload, indent=1), encoding="utf-8")
+            print(f"wrote {len(payload)} resolution(s) to {out}")
     finally:
         session.close()
     return 0


### PR DESCRIPTION
Follow-up to #112, which added resolution but left production unable to receive it.

## The constraint

`boxd.it/fwSSUD` → `letterboxd.com/deathproof/film/spider-man-brand-new-day/`
gives the author and the film. Production **cannot follow that redirect** —
Letterboxd blocks the datacenter addresses it runs on, which is exactly why
scraping already happens on a residential machine and uploads its result.

So resolution has to travel, not be recomputed.

## Two carriers

**`likes_resolved.json` in the bundle** — read by the loader, applied during
ingestion. The natural path for an official export.

**Admin-only `POST /api/profiles/{username}/archive/like-targets`** — for when
the export isn't at hand. It writes only the three resolution columns: nothing
is created, removed, or soft-deleted, so a partial or repeated call cannot cost
data. A bundle upload cannot promise that, since a present authoritative file
removes what it omits.

## Why both

Re-importing the residential bundle resolved **nothing**, which is how a real
distinction surfaced: a residential scrape's `likes.csv` is *liked films*.
Liked **reviews** live in `likes/reviews.csv` and come only from an official
export. Production already holds 46 of them from an earlier export upload —
there is no residential bundle that can carry their resolutions.

## Tests

- admin-only (403 for an ordinary user)
- malformed payload rejected, after access is settled
- route present in the access matrix

654 backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)