### PR TITLE
Read the franchises and crew TMDB already gave us

### DIFF
--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -82,6 +82,8 @@ class _FilmRow:
     editors: List[_Value]
     actors: List[_Value]
     studios: List[_Value]
+    extra_crew: Dict[str, List[_Value]]
+    collection: Optional[str]
 
     @property
     def decades(self) -> List[_Value]:
@@ -161,6 +163,18 @@ BELOW_THE_LINE_JOBS = {
     "editor": "Editor",
 }
 
+# The rest of the crew TMDB already credits. Letterboxd's own stats page lists
+# these beside the director; ours stored them and showed three. Each key is the
+# exact TMDB job string, because a near-miss silently yields an empty list.
+EXTRA_CREW_JOBS = {
+    "producer": "Producer",
+    "executive_producer": "Executive Producer",
+    "writer": "Screenplay",
+    "production_designer": "Production Design",
+    "costume_designer": "Costume Design",
+    "casting": "Casting",
+}
+
 
 def _crew_values(credits: Any, job: str) -> List[_Value]:
     """Names credited with one specific crew job."""
@@ -177,6 +191,19 @@ def _crew_values(credits: Any, job: str) -> List[_Value]:
             ]
         )
     )
+
+
+def _collection_name(payload: Any) -> Optional[str]:
+    """The franchise TMDB places a film in, if any.
+
+    Most films belong to none, which is why this is nullable rather than a
+    bucket: a standalone film is not a one-film franchise.
+    """
+
+    if not isinstance(payload, Mapping):
+        return None
+    name = str(payload.get("name") or "").strip()
+    return name or None
 
 
 def _director_genders(credits: Any) -> List[int]:
@@ -229,6 +256,9 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
 
     production_companies = MovieEnrichment.raw_payload["details"]["production_companies"]
     spoken_languages = MovieEnrichment.raw_payload["details"]["spoken_languages"]
+    # TMDB names the franchise a film belongs to; 1,143 of the 4,554 enriched
+    # films carry one and nothing had ever read it.
+    belongs_to_collection = MovieEnrichment.raw_payload["details"]["belongs_to_collection"]
     rows = (
         db.query(
             ProfileFilm.rating,
@@ -248,6 +278,7 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
             MovieEnrichment.production_countries,
             production_companies.label("production_companies"),
             spoken_languages.label("spoken_languages"),
+            belongs_to_collection.label("belongs_to_collection"),
         )
         .join(Movie, Movie.id == ProfileFilm.movie_id)
         .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
@@ -293,6 +324,11 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
                 editors=_crew_values(credits, BELOW_THE_LINE_JOBS["editor"]),
                 actors=_actor_values(credits),
                 studios=_plain_values(_as_string_list(row.production_companies)),
+                extra_crew={
+                    key: _crew_values(row.credits, job)
+                    for key, job in EXTRA_CREW_JOBS.items()
+                },
+                collection=_collection_name(row.belongs_to_collection),
             )
         )
     return films
@@ -1195,6 +1231,23 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
     editors = _collect(films, lambda film: film.editors)
     actors = _collect(films, lambda film: film.actors)
     studios = _collect(films, lambda film: film.studios)
+    extra_crew_buckets = {
+        key: _collect(films, lambda film, key=key: film.extra_crew.get(key, []))
+        for key in EXTRA_CREW_JOBS
+    }
+
+    # Franchise completion: how much of a series this profile has worked
+    # through. Counted over the films they hold, so it says "you have seen 8
+    # Harry Potter films", never "8 of 8" -- TMDB's collection size is not in
+    # the film payload and inventing a denominator would be a guess.
+    franchises: Dict[str, int] = defaultdict(int)
+    franchise_ratings: Dict[str, List[float]] = defaultdict(list)
+    for film in films:
+        if not film.collection:
+            continue
+        franchises[film.collection] += 1
+        if film.rating is not None:
+            franchise_ratings[film.collection].append(float(film.rating))
 
     return {
         "username": profile.username,
@@ -1247,6 +1300,32 @@ def build_profile_stats(db: Session, profile: Profile) -> Dict[str, Any]:
         "director_gender": _director_gender_split(films),
         "top_actors": _ranked(actors, label_key="name"),
         "top_studios": _ranked(studios, label_key="name"),
+        # The rest of the crew TMDB credits, which were stored and never shown.
+        "top_producers": _ranked(extra_crew_buckets["producer"], label_key="name"),
+        "top_executive_producers": _ranked(
+            extra_crew_buckets["executive_producer"], label_key="name"
+        ),
+        "top_writers": _ranked(extra_crew_buckets["writer"], label_key="name"),
+        "top_production_designers": _ranked(
+            extra_crew_buckets["production_designer"], label_key="name"
+        ),
+        "top_costume_designers": _ranked(
+            extra_crew_buckets["costume_designer"], label_key="name"
+        ),
+        "top_casting": _ranked(extra_crew_buckets["casting"], label_key="name"),
+        # Series worked through, most-watched first. A single film is not a
+        # franchise anybody is following, so two is the floor.
+        "franchises": [
+            {
+                "name": name,
+                "films": count,
+                "average_rating": _round(_average(franchise_ratings.get(name, [])), 2),
+            }
+            for name, count in sorted(
+                franchises.items(), key=lambda item: (-item[1], item[0])
+            )
+            if count >= 2
+        ][:MAX_LIST_ENTRIES],
         "genres": _ranked(genres),
         "countries": _ranked(countries, include_code=True),
         "languages": _ranked(languages),

--- a/backend/tests/test_profile_stats.py
+++ b/backend/tests/test_profile_stats.py
@@ -1083,6 +1083,14 @@ def test_route_serves_the_payload_for_a_tracked_profile(database: Session, clien
         "release_lag",
         # Whether they work through a filmography once they find one.
         "director_runs",
+        # The rest of the crew TMDB credits, and the series worked through.
+        "top_producers",
+        "top_executive_producers",
+        "top_writers",
+        "top_production_designers",
+        "top_costume_designers",
+        "top_casting",
+        "franchises",
         "top_directors",
         # Crew whose credits were stored and never surfaced.
         "top_composers",

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -378,6 +378,19 @@ export const profileStats = {
     recent: [],
     import_artifact_days: 2,
   },
+  // Series held, with one deliberately unrated so the null renders as blank
+  // rather than 0.0.
+  franchises: [
+    { name: 'Harry Potter Collection', films: 8, average_rating: 4.0 },
+    { name: 'The Fast and the Furious Collection', films: 11, average_rating: 2.25 },
+    { name: 'X-Men Collection', films: 7, average_rating: null },
+  ],
+  top_producers: [{ name: 'Kevin Feige', count: 30, rated_count: 28, average_rating: 3.1 }],
+  top_executive_producers: [{ name: 'Stan Lee', count: 41, rated_count: 39, average_rating: 2.9 }],
+  top_writers: [{ name: 'David Koepp', count: 9, rated_count: 9, average_rating: 3.3 }],
+  top_production_designers: [{ name: 'Stuart Craig', count: 12, rated_count: 12, average_rating: 3.9 }],
+  top_costume_designers: [{ name: 'Colleen Atwood', count: 17, rated_count: 15, average_rating: 3.4 }],
+  top_casting: [{ name: 'Sarah Halley Finn', count: 45, rated_count: 43, average_rating: 3.0 }],
   // A filmography worked through over a fortnight, not in one sitting.
   director_runs: {
     count: 4,

--- a/frontend/e2e/franchises-and-crew.spec.ts
+++ b/frontend/e2e/franchises-and-crew.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * TMDB names the franchise a film belongs to on 1,143 of the 4,554 enriched
+ * films, and credits 732 distinct crew jobs. Spyboxd stored both and surfaced
+ * neither the franchise nor any crew beyond composer, cinematographer and
+ * editor — while Letterboxd's own stats page lists every one of them.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('series are counted as films held, not as a completion score', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const panel = page.getByRole('heading', { name: 'Series worked through' }).locator('..').locator('..');
+  await expect(panel).toContainText('Harry Potter Collection');
+  await expect(panel).toContainText('11');
+  // TMDB does not give a collection's size in the film payload, so claiming
+  // "8 of 8" would be inventing the denominator.
+  await expect(panel).not.toContainText('of 8');
+  await expect(panel).toContainText('not a completion score');
+});
+
+test('an unrated series shows no average rather than zero', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const row = page.locator('li').filter({ hasText: 'X-Men Collection' }).first();
+  await expect(row).toBeVisible();
+  await expect(row).not.toContainText('0.0');
+});
+
+test('the crew beyond the big three is listed', async ({ page }) => {
+  await page.goto('/analysis');
+
+  const body = page.locator('body');
+  for (const name of ['Kevin Feige', 'Stan Lee', 'David Koepp', 'Sarah Halley Finn']) {
+    await expect(body).toContainText(name);
+  }
+});

--- a/frontend/src/components/insights/ProfileStatsPanel.tsx
+++ b/frontend/src/components/insights/ProfileStatsPanel.tsx
@@ -581,6 +581,15 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
   const topActors = stats.top_actors ?? [];
   const topStudios = stats.top_studios ?? [];
   const topComposers = stats.top_composers ?? [];
+  const franchises = stats.franchises ?? [];
+  const extraCrew: Array<[string, ProfileStatsPerson[]]> = [
+    ['Producers', stats.top_producers ?? []],
+    ['Executive producers', stats.top_executive_producers ?? []],
+    ['Writers', stats.top_writers ?? []],
+    ['Production design', stats.top_production_designers ?? []],
+    ['Costume design', stats.top_costume_designers ?? []],
+    ['Casting', stats.top_casting ?? []],
+  ];
   const topCinematographers = stats.top_cinematographers ?? [];
   const topEditors = stats.top_editors ?? [];
   const directorGender = stats.director_gender;
@@ -789,6 +798,38 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
       {/* Watching a director twice in a fortnight happens about three times
           more often than shuffling the same dates would produce, so this is a
           habit rather than a by-product of watching a lot. */}
+      {/* Series worked through. Counted over films held, never "8 of 8": TMDB
+          does not give a collection's size in the film payload, and inventing
+          a denominator would turn a count into a completion claim. */}
+      {franchises.length > 0 ? (
+        <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h3 className="text-sm font-semibold text-white/75">Series worked through</h3>
+            <span className="text-[11px] text-white/40">
+              films held from each, not a completion score
+            </span>
+          </div>
+          <ul className="mt-2 space-y-1.5">
+            {franchises.slice(0, 6).map((entry) => (
+              <li key={entry.name} className="flex items-center gap-2 text-xs">
+                <span className="min-w-0 flex-1 truncate text-white/75" title={entry.name}>
+                  {entry.name}
+                </span>
+                <span className="w-10 shrink-0 text-right tabular-nums text-white/55">
+                  {formatCount(entry.films)}
+                </span>
+                <span
+                  className="w-8 shrink-0 text-right tabular-nums text-white/35"
+                  title={entry.average_rating === null ? 'None of these are rated' : undefined}
+                >
+                  {entry.average_rating === null ? '' : entry.average_rating.toFixed(1)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
       {directorRuns && directorRuns.count > 0 && directorRuns.biggest ? (
         <div className="mt-6 rounded-xl border border-white/10 bg-black/20 px-4 py-3">
           <div className="flex flex-wrap items-baseline justify-between gap-2">
@@ -902,6 +943,12 @@ const ProfileStatsPanel: React.FC<{ username: string; delay?: number }> = ({
           <RankedList title="Top composers" subtitle="Scored what you watch" people={topComposers} />
           <RankedList title="Top cinematographers" subtitle="Shot what you watch" people={topCinematographers} />
           <RankedList title="Top editors" subtitle="Cut what you watch" people={topEditors} />
+          {/* The rest of the crew TMDB credits. Letterboxd's own stats page
+              lists every one of these beside the director; ours held the same
+              credits and showed three. */}
+          {extraCrew.map(([label, people]) => (
+            <RankedList key={label} title={label} subtitle={null} people={people} />
+          ))}
         </div>
       ) : null}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1468,6 +1468,18 @@ export interface ProfileStatsResponse {
   /** Crew whose credits TMDB stores on most enriched films and nothing read
    *  until now: the people shaping what you watch without being counted. */
   top_composers: ProfileStatsPerson[];
+  /** The rest of the crew TMDB credits — stored since enrichment began and
+   *  never surfaced, while Letterboxd's own stats page lists them all. */
+  top_producers: ProfileStatsPerson[];
+  top_executive_producers: ProfileStatsPerson[];
+  top_writers: ProfileStatsPerson[];
+  top_production_designers: ProfileStatsPerson[];
+  top_costume_designers: ProfileStatsPerson[];
+  top_casting: ProfileStatsPerson[];
+  /** Series worked through. Counted over films held, never "8 of 8": TMDB's
+   *  collection size is not in the film payload and a denominator would be a
+   *  guess. Singles are excluded — one film is not a franchise. */
+  franchises: Array<{ name: string; films: number; average_rating: number | null }>;
   top_cinematographers: ProfileStatsPerson[];
   top_editors: ProfileStatsPerson[];
   director_gender: {


### PR DESCRIPTION
Two fields stored since enrichment began and read by nothing — both of which
Letterboxd's own Patron stats page shows.

## Franchises

`belongs_to_collection` sits on **1,143 of 4,554** enriched films and was never
selected out of `raw_payload`:

| series | films held | average |
|---|---|---|
| The Fast and the Furious | 11 | **2.25** |
| Star Wars | 9 | 3.90 |
| Harry Potter | 8 | **4.00** |
| Jurassic Park | 7 | 2.50 |

The per-series average is the part a bare count cannot show — eleven Fast &
Furious films at 2.25 is a different story from eight Harry Potter at 4.0.

**Counted as films held, never "8 of 8".** TMDB does not return a collection's
size in the film payload, so the denominator would be invented — and a
completion score built on a guess is worse than a count. Singles are excluded;
one film is not a series anybody is working through.

## Crew

TMDB credits **732 distinct crew jobs**; three were surfaced. Now also:
producers, executive producers, writers, production design, costume design,
casting — all from the same stored `credits` blob.

Kevin Feige 30 · Stan Lee 41 · Sarah Halley Finn 45 · Colleen Atwood 17

## Tests

- a series shows films held and **not** a completion claim
- an unrated series renders blank, not `0.0`
- the new crew roles appear

657 backend, 160 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)