### PR TITLE
Point the deploy smoke at the route that is actually private

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1494,7 +1494,7 @@ jobs:
             curl --silent --show-error --output /dev/null \
               --write-out '%{http_code} %{redirect_url}\n' --max-time 10 \
               --header 'Cache-Control: no-cache' \
-              https://spyboxd.com/dashboard 2>/dev/null || true
+              https://spyboxd.com/overview 2>/dev/null || true
           )
           [[ "${private_status}" =~ ^30[1278]$ ]]
           [[ "${private_redirect}" == https://spyboxd.com/sign-in* ]]

--- a/deploy/run-production-canary.py
+++ b/deploy/run-production-canary.py
@@ -22,12 +22,16 @@ from typing import Any, Mapping
 
 MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
+# The redesigned sections. The pre-redesign paths (/dashboard, /spy-signals,
+# /analysis, /compare, /network) are permanent redirects now, so they answer
+# 308 to their new home rather than bouncing an anonymous caller to sign-in --
+# checking them would prove the redirect, not the protection.
 PRIVATE_UI_PATHS = (
-    "/dashboard",
+    "/overview",
+    "/overlaps",
     "/profiles",
-    "/compare",
     "/analysis",
-    "/spy-signals",
+    "/compare",
     "/watch-together",
     "/u/privacy-check",
 )
@@ -39,6 +43,9 @@ PRIVATE_API_PATHS = (
     "/public/profile/privacy-check",
     "/api/dashboard/analytics",
     "/api/spy-signals",
+    "/api/activity/marathons",
+    "/api/activity/weekday",
+    "/api/insights/shared-firsts",
     "/profiles/privacy-check/analysis",
     "/api/data-coverage",
     "/api/pair-dossier",

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -153,16 +153,16 @@ class ProductionCanaryTests(unittest.TestCase):
             client=FakeClient(_good_responses()),
         )
         self.assertEqual(result["revision"], REVISION)
-        self.assertEqual(result["private_ui_routes"], 7)
-        self.assertEqual(result["private_api_routes"], 20)
+        self.assertEqual(result["private_ui_routes"], len(public_canary.PRIVATE_UI_PATHS))
+        self.assertEqual(result["private_api_routes"], len(public_canary.PRIVATE_API_PATHS))
 
     def test_private_route_open_redirect_is_rejected(self):
         responses = _good_responses()
-        responses["https://spyboxd.com/dashboard"] = public_canary.Response(
+        responses["https://spyboxd.com/overview"] = public_canary.Response(
             307,
             {
                 **SECURITY_HEADERS,
-                "Location": "https://evil.example/sign-in?redirect_url=https://spyboxd.com/dashboard",
+                "Location": "https://evil.example/sign-in?redirect_url=https://spyboxd.com/overview",
             },
             b"",
         )


### PR DESCRIPTION
The post-merge deployment of #125 activated, failed its external smoke, and rolled production back. **The smoke was right to fail and the check was wrong.**

It proves an anonymous request to a private page bounces to `/sign-in`, and it used `/dashboard` to do it. `/dashboard` is now a permanent redirect to `/overview`, so it answers `308` to its new home rather than `307` to sign-in — the assertion was measuring the redirect, not the protection.

`/overview` is the route that is actually private now, so that is what both the deploy smoke and the production canary check.

The canary's private-route list gets the same treatment, plus the three new activity endpoints, so an anonymous caller reaching one of them fails the canary rather than passing unexamined. Both canary tests now count the lists rather than restating their length — adding a route can no longer leave the count silently stale.

Production is currently serving the pre-redesign release; this unblocks the redeploy.

- `python -m unittest deploy.test_production_canary` — 32 passed
- `pytest` — 667 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)