### PR TITLE
Make the two panels that classify a profile read one field

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -842,7 +842,30 @@ const dataCoverage = {
       total_films: profile.total_films,
     },
     overall_score: 100,
-    surfaces: [],
+    // Real surfaces, so the three honesty tiers on Overlaps › How sure have
+    // something to classify. `status` is deliberately never "complete" here:
+    // it cannot be while any watch is undated, which is exactly why the tier
+    // must be read from the profile's own coverage rather than from this field.
+    surfaces: [
+      {
+        surface: 'watch_events',
+        status: 'partial',
+        captured: Math.round(profile.total_films * 0.8),
+        expected: profile.total_films,
+        ratio: 0.8,
+        last_updated: '2026-07-29T12:00:00Z',
+        warnings: [],
+      },
+      {
+        surface: 'ratings',
+        status: 'complete',
+        captured: profile.rated_films,
+        expected: profile.rated_films,
+        ratio: 1,
+        last_updated: '2026-07-29T12:00:00Z',
+        warnings: [],
+      },
+    ],
   })),
   feature_readiness: [
     'spy_signals',

--- a/frontend/e2e/tier-consistency.spec.ts
+++ b/frontend/e2e/tier-consistency.spec.ts
@@ -20,22 +20,23 @@ test.beforeEach(async ({ page }) => {
 test('a profile with a full diary is counted as one in both panels', async ({ page }) => {
   await page.goto('/overview');
 
+  // Both panels render a skeleton first, so every read here waits for the
+  // classified row to arrive. Counting whatever is on screen the instant
+  // navigation resolves measured the skeleton, not the tier.
   const roster = page.locator('.terminal-root section', { hasText: 'EVERYONE WE ARE WATCHING' }).first();
-  const rosterFull = await roster.getByText('Full diary imported').count();
-  expect(rosterFull).toBeGreaterThan(0);
+  await expect(roster.getByText('Full diary imported').first()).toBeVisible();
 
   await page.goto('/overlaps?tab=sure');
   const tiers = page.locator('.terminal-root section', { hasText: 'HOW SURE WE ARE' }).first();
-  await expect(tiers).toBeVisible();
+  await expect(tiers.getByText('One date per film only')).toBeVisible();
 
   // The top tier must carry events, not zero, whenever the roster says a
   // profile has a full diary.
-  const fullRow = tiers.locator('div').filter({ hasText: 'Full diary imported' }).last();
-  const text = await fullRow.innerText();
-  const share = Number(text.match(/(\d+)%/)?.[1] ?? '0');
-  const events = Number((text.match(/([\d,]+)/)?.[1] ?? '0').replace(/,/g, ''));
-  expect(events).toBeGreaterThan(0);
-  expect(share).toBeGreaterThan(0);
+  const text = await tiers.innerText();
+  const row = text.match(/Full diary imported\s+([\d,]+)\s+(\d+)%/);
+  expect(row, `no top-tier row in:\n${text}`).not.toBeNull();
+  expect(Number(row![1].replace(/,/g, ''))).toBeGreaterThan(0);
+  expect(Number(row![2])).toBeGreaterThan(0);
 });
 
 test('the bottom tier says what it actually mixes together', async ({ page }) => {

--- a/frontend/e2e/tier-consistency.spec.ts
+++ b/frontend/e2e/tier-consistency.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Overview's roster and Overlaps › How sure classify the same profiles into the
+ * same three tiers. They read one shared function so they cannot disagree —
+ * before that they did: How sure derived its tier from the coverage endpoint's
+ * `status`, which is never "complete" while any watch is undated, so it
+ * reported nobody with a full diary while the roster reported almost everybody.
+ *
+ * Two panels contradicting each other about the same profiles is worse than
+ * either being wrong on its own, so the agreement is pinned here rather than
+ * left to whoever edits one of them next.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+});
+
+test('a profile with a full diary is counted as one in both panels', async ({ page }) => {
+  await page.goto('/overview');
+
+  const roster = page.locator('.terminal-root section', { hasText: 'EVERYONE WE ARE WATCHING' }).first();
+  const rosterFull = await roster.getByText('Full diary imported').count();
+  expect(rosterFull).toBeGreaterThan(0);
+
+  await page.goto('/overlaps?tab=sure');
+  const tiers = page.locator('.terminal-root section', { hasText: 'HOW SURE WE ARE' }).first();
+  await expect(tiers).toBeVisible();
+
+  // The top tier must carry events, not zero, whenever the roster says a
+  // profile has a full diary.
+  const fullRow = tiers.locator('div').filter({ hasText: 'Full diary imported' }).last();
+  const text = await fullRow.innerText();
+  const share = Number(text.match(/(\d+)%/)?.[1] ?? '0');
+  const events = Number((text.match(/([\d,]+)/)?.[1] ?? '0').replace(/,/g, ''));
+  expect(events).toBeGreaterThan(0);
+  expect(share).toBeGreaterThan(0);
+});
+
+test('the bottom tier says what it actually mixes together', async ({ page }) => {
+  await page.goto('/overlaps?tab=sure');
+
+  const tiers = page.locator('.terminal-root section', { hasText: 'HOW SURE WE ARE' }).first();
+  // It is the difference between Letterboxd's stated total and our dated
+  // events, so calling it "no date at all" overstated what we know.
+  await expect(tiers).toContainText('No dated event');
+  await expect(tiers).toContainText('rows we never imported at all');
+});

--- a/frontend/src/components/terminal/profileState.ts
+++ b/frontend/src/components/terminal/profileState.ts
@@ -1,0 +1,51 @@
+import type { ProfileInfo } from '../../services/api';
+
+/**
+ * The three honesty tiers, in one place.
+ *
+ * Was "authoritative diary" / "legacy rating snapshot", which described our
+ * plumbing rather than what the reader gets. Overview's roster and Overlaps ›
+ * How sure both classify the same profiles, so they read the same field
+ * through the same function — the two panels disagreeing about whether a
+ * profile has a full diary is worse than either being wrong on its own.
+ */
+export type ImportTier = 'full' | 'partial' | 'none' | 'failed';
+
+export function importTier(profile: ProfileInfo): ImportTier {
+  const status = profile.scraping_status;
+  if (status === 'failed' || status === 'error') return 'failed';
+  const coverage = profile.data_coverage;
+  if (coverage?.is_partial === false) return 'full';
+  if (coverage?.is_partial === true) return 'partial';
+  return profile.total_films ? 'partial' : 'none';
+}
+
+export const TIER_LABEL: Record<ImportTier, { label: string; tone: string }> = {
+  full: { label: 'Full diary imported', tone: 'var(--ok)' },
+  partial: { label: 'Recent window only', tone: 'var(--accent)' },
+  none: { label: 'Nothing imported yet', tone: 'var(--muted)' },
+  failed: { label: 'Nothing since — feed backing off', tone: 'var(--bad)' },
+};
+
+export function importState(profile: ProfileInfo): { label: string; tone: string } {
+  return TIER_LABEL[importTier(profile)];
+}
+
+/**
+ * How far back we can see this profile.
+ *
+ * Letterboxd publishes no join date on a public profile page — it exists only
+ * in an account's own export — so a scraped profile used to read "Member since:
+ * unknown". The first diary entry answers the same question honestly and we
+ * hold it for everyone, so it is preferred and labelled for what it is.
+ */
+export function sinceLabel(profile: ProfileInfo): { label: string; tone: string } {
+  const logged = profile.first_logged_date;
+  if (logged) {
+    return { label: new Date(logged).getFullYear().toString(), tone: 'var(--muted)' };
+  }
+  if (profile.join_date) {
+    return { label: new Date(profile.join_date).getFullYear().toString(), tone: 'var(--muted)' };
+  }
+  return { label: 'no dates', tone: 'var(--dim)' };
+}

--- a/frontend/src/views/overlaps/HowSureTab.tsx
+++ b/frontend/src/views/overlaps/HowSureTab.tsx
@@ -7,6 +7,8 @@ import Panel from '../../components/terminal/Panel';
 import Bars from '../../components/terminal/bodies/Bars';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
+import { useScopedProfiles } from '../../hooks/useScopedProfiles';
+import { importTier } from '../../components/terminal/profileState';
 import { activityApi, insightsApi, type SurfaceCoverage } from '../../services/api';
 
 function surface(surfaces: SurfaceCoverage[], name: SurfaceCoverage['surface']) {
@@ -14,6 +16,13 @@ function surface(surfaces: SurfaceCoverage[], name: SurfaceCoverage['surface']) 
 }
 
 export default function HowSureTab({ profiles }: { profiles: string[] }) {
+  // The same source Overview's roster reads. Deriving the tier from the
+  // coverage endpoint's `status` instead put every profile in the middle tier,
+  // so this panel reported nobody with a full diary while the roster reported
+  // almost everybody -- two panels contradicting each other about the same
+  // profiles is worse than either being wrong alone.
+  const scopedQuery = useScopedProfiles();
+
   const coverageQuery = useQuery({
     queryKey: ['data-coverage', profiles],
     queryFn: () => insightsApi.getDataCoverage(profiles),
@@ -40,24 +49,28 @@ export default function HowSureTab({ profiles }: { profiles: string[] }) {
   // and the tier a reader cares about is the one behind the row they are
   // looking at.
   const tiers = React.useMemo(() => {
+    const byUsername = new Map(
+      (scopedQuery.data ?? []).map((profile) => [profile.username.toLowerCase(), profile]),
+    );
     let full = 0;
     let onePerFilm = 0;
-    let undated = 0;
+    let unaccounted = 0;
     perProfile.forEach((entry) => {
       const events = surface(entry.surfaces, 'watch_events');
       const captured = events?.captured ?? 0;
       const expected = events?.expected ?? null;
-      if (events?.status === 'complete') {
+      const profile = byUsername.get(entry.profile.username.toLowerCase());
+      if (profile && importTier(profile) === 'full') {
         full += captured;
       } else {
         onePerFilm += captured;
       }
-      if (expected !== null && expected > captured) undated += expected - captured;
+      if (expected !== null && expected > captured) unaccounted += expected - captured;
     });
-    return { full, onePerFilm, undated };
-  }, [perProfile]);
+    return { full, onePerFilm, unaccounted };
+  }, [perProfile, scopedQuery.data]);
 
-  const tierTotal = tiers.full + tiers.onePerFilm + tiers.undated;
+  const tierTotal = tiers.full + tiers.onePerFilm + tiers.unaccounted;
 
   const datedTotal = perProfile.reduce(
     (sum, entry) => sum + (surface(entry.surfaces, 'watch_events')?.captured ?? 0),
@@ -78,11 +91,11 @@ export default function HowSureTab({ profiles }: { profiles: string[] }) {
         title="HOW SURE WE ARE"
         src="profile_films.source · watch_events"
         blurb="Not every overlap is equally real. A diary row with a date is evidence; a rating snapshot with one inferred date is a guess, and it is labelled as one."
-        caveat="Overlaps built on the lower two tiers are shown with the tier named on the row. Nothing is hidden, and nothing is presented as firmer than it is."
+        caveat="Overlaps built on the lower two tiers are shown with the tier named on the row. The bottom tier is the difference between Letterboxd's own stated total and the dated events we hold, so it mixes rows that carry no date with rows we never imported at all — Data › What's missing separates those two."
       >
         {panelState({
-          isLoading: coverageQuery.isLoading,
-          error: coverageQuery.error,
+          isLoading: coverageQuery.isLoading || scopedQuery.isLoading,
+          error: coverageQuery.error ?? scopedQuery.error,
           isEmpty: tierTotal === 0,
           onRetry: () => coverageQuery.refetch(),
           errorTitle: 'Coverage could not be read',
@@ -110,10 +123,13 @@ export default function HowSureTab({ profiles }: { profiles: string[] }) {
                 tone: 'var(--accent)',
               },
               {
-                name: 'No date at all',
-                weight: tiers.undated,
-                value: tiers.undated.toLocaleString(),
-                sub: `${Math.round((tiers.undated / tierTotal) * 100)}%`,
+                // Not "no date at all": this is everything Letterboxd counts
+                // that we hold no dated event for, which is undated rows and
+                // unimported rows together.
+                name: 'No dated event',
+                weight: tiers.unaccounted,
+                value: tiers.unaccounted.toLocaleString(),
+                sub: `${Math.round((tiers.unaccounted / tierTotal) * 100)}%`,
                 tone: 'var(--barmuted)',
               },
             ]}

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -10,6 +10,7 @@ import Spark from '../../components/terminal/bodies/Spark';
 import { CoWatchMatrix } from '../../components/terminal/bodies/Matrix';
 import { BarsSkeleton, PanelSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { importState, sinceLabel } from '../../components/terminal/profileState';
 import { useAdminScope } from '../../hooks/useAdminScope';
 import { useScopedProfiles } from '../../hooks/useScopedProfiles';
 import {
@@ -46,48 +47,6 @@ function relativeDays(iso: string | null | undefined): string {
   if (hours < 1) return 'just now';
   if (hours < 48) return `${hours}h ago`;
   return `${Math.round(hours / 24)}d ago`;
-}
-
-/**
- * The three-tier honesty label used everywhere a profile's provenance matters.
- * Was "authoritative diary" / "legacy rating snapshot", which described our
- * plumbing rather than what the reader gets.
- */
-export function importState(profile: ProfileInfo): { label: string; tone: string } {
-  const status = profile.scraping_status;
-  if (status === 'failed' || status === 'error') {
-    return { label: 'Nothing since — feed backing off', tone: 'var(--bad)' };
-  }
-  const coverage = profile.data_coverage;
-  if (coverage?.is_partial === false) {
-    return { label: 'Full diary imported', tone: 'var(--ok)' };
-  }
-  if (coverage?.is_partial === true) {
-    return { label: 'Recent window only', tone: 'var(--accent)' };
-  }
-  if (profile.total_films) {
-    return { label: 'One date per film only', tone: 'var(--accent)' };
-  }
-  return { label: 'Nothing imported yet', tone: 'var(--muted)' };
-}
-
-/**
- * How far back we can see this profile.
- *
- * Letterboxd publishes no join date on a public profile page — it exists only
- * in an account's own export — so a scraped profile used to read "Member since:
- * unknown". The first diary entry answers the same question honestly and we
- * hold it for everyone, so it is preferred and labelled for what it is.
- */
-export function sinceLabel(profile: ProfileInfo): { label: string; tone: string } {
-  const logged = profile.first_logged_date;
-  if (logged) {
-    return { label: new Date(logged).getFullYear().toString(), tone: 'var(--muted)' };
-  }
-  if (profile.join_date) {
-    return { label: new Date(profile.join_date).getFullYear().toString(), tone: 'var(--muted)' };
-  }
-  return { label: 'no dates', tone: 'var(--dim)' };
 }
 
 /** Plain-English summary of one detected change, plus where it is explained. */


### PR DESCRIPTION
Found while verifying the redesign on production.

**Overview's roster reported almost every profile as "full diary imported" while Overlaps › How sure reported zero of them** — live, at the same moment, about the same profiles.

Both classify into the same three tiers. They disagreed because they read different things:

- **How sure** derived the tier from the data-coverage endpoint's per-surface `status`. That field is only `"complete"` when captured equals expected, and it cannot be while any watch is undated — so no profile ever reached the top tier and every one landed in the middle.
- **The roster** reads the profile's own `data_coverage.is_partial`, which is the actual provenance signal.

Both now call one `importTier` helper, and a test asserts they agree rather than leaving it to whoever edits one of them next.

## Also renamed the bottom tier

It is the difference between Letterboxd's stated total and the dated events we hold, so **"no date at all" overstated it** — that difference is undated rows *and* rows we never imported, together. It reads "no dated event" now, and the caveat points at Data › What's missing, which separates the two.

## Checks

- `tsc` clean, `eslint --max-warnings=0` clean, `next build` clean
- Playwright **230/230** against `next start` — 2 new specs
- pytest **699 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)