### PR TITLE
Stop the Films panels from taking the API down, and reconcile four counts

### DIFF
--- a/backend/api/routes/follow_graph.py
+++ b/backend/api/routes/follow_graph.py
@@ -263,7 +263,7 @@ def get_follow_graph_suggestions(
     )
     selected_normalized = [row.normalized for row in aggregate_rows]
     if not selected_normalized:
-        return {"suggestions": []}
+        return {"suggestions": [], "monitored_profiles": len(scoped_ids)}
 
     followed_by: Dict[str, List[str]] = {
         normalized: [] for normalized in selected_normalized
@@ -350,4 +350,7 @@ def get_follow_graph_suggestions(
                 "profile_id": linked_profile_id,
             }
         )
-    return {"suggestions": suggestions}
+    # The counts above are taken across every monitored profile, not across a
+    # tab's current selection. Without saying so, a caller that supplied its
+    # own denominator rendered "10 of 6".
+    return {"suggestions": suggestions, "monitored_profiles": len(scoped_ids)}

--- a/backend/services/data_health.py
+++ b/backend/services/data_health.py
@@ -82,19 +82,34 @@ def build_ledger(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
     """
 
     profile_ids = [profile.id for profile in profiles]
-    latest = _latest_syncs(db, profile_ids)
 
+    # Per profile *and surface*, not per profile. Scoped to the single latest
+    # sync, a surface an older run had read and a newer one did not touch was
+    # reported as "never read for any selected profile" — which the working
+    # follow graph in People flatly contradicted. Each surface now reports the
+    # most recent run that actually carried it.
     rows: List[Dict[str, Any]] = []
-    if latest:
+    if profile_ids:
         datasets = (
             db.query(SyncDataset, ProfileSync)
             .join(ProfileSync, ProfileSync.id == SyncDataset.profile_sync_id)
-            .filter(SyncDataset.profile_sync_id.in_([sync.id for sync in latest.values()]))
+            .filter(
+                ProfileSync.profile_id.in_(profile_ids),
+                ProfileSync.status == "completed",
+            )
             .all()
         )
-        by_surface: Dict[str, List[Any]] = defaultdict(list)
+        newest: Dict[tuple, Any] = {}
         for dataset, sync in datasets:
-            by_surface[dataset.dataset_name].append((dataset, sync))
+            key = (dataset.dataset_name, sync.profile_id)
+            when = _aware(sync.completed_at or sync.started_at)
+            current = newest.get(key)
+            if current is None or (when is not None and (current[2] is None or when > current[2])):
+                newest[key] = (dataset, sync, when)
+
+        by_surface: Dict[str, List[Any]] = defaultdict(list)
+        for (name, _profile_id), (dataset, sync, _when) in newest.items():
+            by_surface[name].append((dataset, sync))
 
         for name, label in SURFACE_ORDER:
             entries = by_surface.get(name, [])
@@ -116,7 +131,11 @@ def build_ledger(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
             imported = sum(dataset.imported_row_count for dataset, _ in entries)
             authoritative = sum(1 for dataset, _ in entries if dataset.is_authoritative)
             last_run = max(
-                (sync.completed_at or sync.started_at for _, sync in entries),
+                (
+                    when
+                    for when in (_aware(sync.completed_at or sync.started_at) for _, sync in entries)
+                    if when is not None
+                ),
                 default=None,
             )
             rows.append(
@@ -139,9 +158,10 @@ def build_ledger(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
     return {
         "surfaces": rows,
         "caveat": (
-            "Read from the latest completed sync per profile. A surface with no row was never "
-            "read for anybody in this selection — which is different from being read and coming "
-            "back empty, and the two must not look alike."
+            "Each surface reports the most recent completed run that carried it, which is not "
+            "always the profile's latest run — a refresh that skips a surface does not unread it. "
+            "A surface with no row was never read for anybody in this selection, which is "
+            "different from being read and coming back empty, and the two must not look alike."
         ),
     }
 
@@ -582,14 +602,27 @@ def build_watch_event_freshness(db: Session, profiles: Sequence[Profile]) -> Dic
                 "last_read_at": when.isoformat() if when else None,
                 "hours_ago": round((now - when).total_seconds() / 3600, 1) if when else None,
                 "watch_events": events,
+                # Letterboxd's own header figure, and null when the header has
+                # never been read. The panel used to source this from the
+                # tracked-profile list instead, which does not cover every
+                # profile on screen, so a profile missing from that list
+                # rendered a confident "0" beside its 299 watches.
+                "films_held": profile.reported_total_films,
             }
         )
 
     entries.sort(key=lambda item: (item["hours_ago"] is None, item["hours_ago"] or 0))
+    unread = sum(1 for entry in entries if entry["films_held"] is None)
     return {
         "profiles": entries,
         "caveat": (
             "Read time comes from the latest completed sync, falling back to the profile's own "
             "last-scraped stamp. A profile with neither has never been read at all."
+            + (
+                f" {unread} of these carry no film total: that figure comes from the profile "
+                "header, and a header nobody has read holds no number rather than a zero."
+                if unread
+                else ""
+            )
         ),
     }

--- a/backend/services/films.py
+++ b/backend/services/films.py
@@ -9,6 +9,7 @@ different claim from a country breakdown.
 from __future__ import annotations
 
 from collections import Counter, defaultdict
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Sequence
 
 from sqlalchemy import func
@@ -24,13 +25,33 @@ from database.models import (
 )
 
 
-def _library(db: Session, profile_ids: Sequence[int]):
-    """Active film rows for the selection, joined to whatever enrichment exists."""
+def _library(db: Session, profile_ids: Sequence[int], *enrichment_columns):
+    """Active film rows for the selection, joined to whatever enrichment exists.
+
+    Only the columns a panel actually reads are selected. Loading whole
+    ``MovieEnrichment`` entities pulled ``raw_payload`` — the entire TMDB
+    response, watch providers included — for every film in the selection, and
+    five Films panels ask at once on first paint. On a library this size that
+    was enough to stop the API answering anything at all, so the fragments
+    anybody needs out of a large JSON column are extracted by path in the
+    database rather than shipped whole. ``profile_stats`` already did this; this
+    module was written without it.
+    """
 
     if not profile_ids:
         return []
     return (
-        db.query(ProfileFilm, Movie, MovieEnrichment)
+        db.query(
+            ProfileFilm.rating,
+            ProfileFilm.is_liked,
+            Movie.id.label("movie_id"),
+            Movie.title,
+            Movie.release_year,
+            Movie.poster_url,
+            Movie.tmdb_id,
+            MovieEnrichment.movie_id.label("enrichment_movie_id"),
+            *enrichment_columns,
+        )
         .join(Movie, Movie.id == ProfileFilm.movie_id)
         .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
         .filter(ProfileFilm.profile_id.in_(profile_ids), ProfileFilm.removed_at.is_(None))
@@ -40,8 +61,9 @@ def _library(db: Session, profile_ids: Sequence[int]):
 
 def _coverage(rows) -> Dict[str, Any]:
     distinct: Dict[int, bool] = {}
-    for _film, movie, enrichment in rows:
-        distinct[movie.id] = distinct.get(movie.id, False) or enrichment is not None
+    for row in rows:
+        enriched = row.enrichment_movie_id is not None
+        distinct[row.movie_id] = distinct.get(row.movie_id, False) or enriched
     total = len(distinct)
     enriched = sum(1 for value in distinct.values() if value)
     return {
@@ -67,16 +89,16 @@ def build_keywords(db: Session, profiles: Sequence[Profile], *, limit: int = 12)
     Genre says drama. Keywords say grief, one location, unreliable narrator.
     """
 
-    rows = _library(db, [profile.id for profile in profiles])
+    rows = _library(db, [profile.id for profile in profiles], MovieEnrichment.keywords)
     coverage = _coverage(rows)
 
     counts: Counter[str] = Counter()
     seen: set[int] = set()
-    for _film, movie, enrichment in rows:
-        if enrichment is None or movie.id in seen:
+    for row in rows:
+        if row.enrichment_movie_id is None or row.movie_id in seen:
             continue
-        seen.add(movie.id)
-        for keyword in enrichment.keywords or []:
+        seen.add(row.movie_id)
+        for keyword in row.keywords or []:
             label = (keyword.get("name") if isinstance(keyword, dict) else str(keyword)) or ""
             label = label.strip().lower()
             if label:
@@ -113,17 +135,17 @@ def build_runtime(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
     """
 
     profile_ids = [profile.id for profile in profiles]
-    rows = _library(db, profile_ids)
+    rows = _library(db, profile_ids, MovieEnrichment.runtime_minutes)
     coverage = _coverage(rows)
 
     watched: Counter[str] = Counter()
     seen: set[int] = set()
-    for _film, movie, enrichment in rows:
-        if enrichment is None or enrichment.runtime_minutes is None or movie.id in seen:
+    for row in rows:
+        if row.enrichment_movie_id is None or row.runtime_minutes is None or row.movie_id in seen:
             continue
-        seen.add(movie.id)
+        seen.add(row.movie_id)
         for label, low, high in RUNTIME_BANDS:
-            if enrichment.runtime_minutes >= low and (high is None or enrichment.runtime_minutes <= high):
+            if row.runtime_minutes >= low and (high is None or row.runtime_minutes <= high):
                 watched[label] += 1
                 break
 
@@ -173,22 +195,27 @@ def build_runtime(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
 def build_atlas(db: Session, profiles: Sequence[Profile], *, limit: int = 12) -> Dict[str, Any]:
     """Countries, and how much of the library needs reading."""
 
-    rows = _library(db, [profile.id for profile in profiles])
+    rows = _library(
+        db,
+        [profile.id for profile in profiles],
+        MovieEnrichment.production_countries,
+        MovieEnrichment.original_language,
+    )
     coverage = _coverage(rows)
 
     countries: Counter[str] = Counter()
     languages: Counter[str] = Counter()
     seen: set[int] = set()
-    for _film, movie, enrichment in rows:
-        if enrichment is None or movie.id in seen:
+    for row in rows:
+        if row.enrichment_movie_id is None or row.movie_id in seen:
             continue
-        seen.add(movie.id)
-        for country in enrichment.production_countries or []:
+        seen.add(row.movie_id)
+        for country in row.production_countries or []:
             name = (country.get("name") if isinstance(country, dict) else str(country)) or ""
             if name.strip():
                 countries[name.strip()] += 1
-        if enrichment.original_language:
-            languages[enrichment.original_language] += 1
+        if row.original_language:
+            languages[row.original_language] += 1
 
     measured = sum(languages.values())
     non_english = measured - languages.get("en", 0)
@@ -214,25 +241,34 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
     denominator would be invented.
     """
 
-    rows = _library(db, [profile.id for profile in profiles])
+    # TMDB nests this under `details`, which is where profile_stats has always
+    # read it. Reading the top level found nothing, so the panel was empty for
+    # every selection rather than wrong in a visible way.
+    rows = _library(
+        db,
+        [profile.id for profile in profiles],
+        MovieEnrichment.raw_payload["details"]["belongs_to_collection"].label(
+            "belongs_to_collection"
+        ),
+    )
     coverage = _coverage(rows)
 
     grouped: Dict[str, Dict[str, Any]] = {}
     seen: set[int] = set()
-    for film, movie, enrichment in rows:
-        if enrichment is None or movie.id in seen:
+    for row in rows:
+        if row.enrichment_movie_id is None or row.movie_id in seen:
             continue
-        seen.add(movie.id)
-        collection = (enrichment.raw_payload or {}).get("belongs_to_collection")
-        if not isinstance(collection, dict):
+        seen.add(row.movie_id)
+        collection = row.belongs_to_collection
+        if not isinstance(collection, Mapping):
             continue
-        name = (collection.get("name") or "").strip()
+        name = str(collection.get("name") or "").strip()
         if not name:
             continue
         entry = grouped.setdefault(name, {"name": name, "films": 0, "ratings": []})
         entry["films"] += 1
-        if film.rating is not None:
-            entry["ratings"].append(film.rating)
+        if row.rating is not None:
+            entry["ratings"].append(row.rating)
 
     series = [
         {
@@ -263,27 +299,33 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
 def build_filmographies(db: Session, profiles: Sequence[Profile], *, limit: int = 12) -> Dict[str, Any]:
     """How much of one director's work the group holds."""
 
-    rows = _library(db, [profile.id for profile in profiles])
+    # Only the crew list, not the full credits document: the cast is by far the
+    # larger half and no panel here reads it.
+    rows = _library(
+        db,
+        [profile.id for profile in profiles],
+        MovieEnrichment.credits["crew"].label("crew"),
+    )
     coverage = _coverage(rows)
 
     grouped: Dict[str, Dict[str, Any]] = {}
     seen: set[int] = set()
-    for film, movie, enrichment in rows:
-        if enrichment is None or movie.id in seen:
+    for row in rows:
+        if row.enrichment_movie_id is None or row.movie_id in seen:
             continue
-        seen.add(movie.id)
-        crew = (enrichment.credits or {}).get("crew") or []
+        seen.add(row.movie_id)
+        crew = row.crew if isinstance(row.crew, list) else []
         for member in crew:
-            if not isinstance(member, dict) or member.get("job") != "Director":
+            if not isinstance(member, Mapping) or member.get("job") != "Director":
                 continue
-            name = (member.get("name") or "").strip()
+            name = str(member.get("name") or "").strip()
             if not name:
                 continue
             entry = grouped.setdefault(name, {"director": name, "films": 0, "ratings": [], "titles": []})
             entry["films"] += 1
-            entry["titles"].append(movie.title)
-            if film.rating is not None:
-                entry["ratings"].append(film.rating)
+            entry["titles"].append(row.title)
+            if row.rating is not None:
+                entry["ratings"].append(row.rating)
 
     directors = [
         {
@@ -323,9 +365,9 @@ def build_liked_vs_rated(db: Session, profiles: Sequence[Profile]) -> Dict[str, 
     liked_only = 0
     high_only = 0
     neither = 0
-    for film, _movie, _enrichment in rows:
-        liked = bool(film.is_liked)
-        high = film.rating is not None and film.rating >= 4.0
+    for row in rows:
+        liked = bool(row.is_liked)
+        high = row.rating is not None and row.rating >= 4.0
         if liked and high:
             high_and_liked += 1
         elif liked:
@@ -512,21 +554,21 @@ def build_metadata_gaps(db: Session, profiles: Sequence[Profile], *, limit: int 
     rows = _library(db, profile_ids)
 
     exposure: Dict[int, Dict[str, Any]] = {}
-    for _film, movie, enrichment in rows:
-        if enrichment is not None:
+    for row in rows:
+        if row.enrichment_movie_id is not None:
             continue
         entry = exposure.setdefault(
-            movie.id,
+            row.movie_id,
             {
-                "title": movie.title,
-                "year": movie.release_year,
-                "poster_url": movie.poster_url,
+                "title": row.title,
+                "year": row.release_year,
+                "poster_url": row.poster_url,
                 "profiles": 0,
                 "missing": [],
             },
         )
         entry["profiles"] += 1
-        if not movie.poster_url and "poster" not in entry["missing"]:
+        if not row.poster_url and "poster" not in entry["missing"]:
             entry["missing"].append("poster")
 
     films = sorted(exposure.values(), key=lambda item: -item["profiles"])
@@ -554,8 +596,8 @@ def build_match_rate(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]
     coverage = _coverage(rows)
 
     distinct: Dict[int, Optional[int]] = {}
-    for _film, movie, _enrichment in rows:
-        distinct[movie.id] = movie.tmdb_id
+    for row in rows:
+        distinct[row.movie_id] = row.tmdb_id
 
     with_id = sum(1 for value in distinct.values() if value)
 

--- a/backend/services/tonight.py
+++ b/backend/services/tonight.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
-from sqlalchemy import func
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session
 
 from database.models import (
@@ -121,10 +121,21 @@ def build_list_progress(
     ):
         watched_by[movie_id].add(profile_id)
 
+    # Scoped to the selection's own public lists, the same set "Work through a
+    # list" shows. Unscoped, this counted every list in the store -- including
+    # other people's, and including the private ones an account export brings
+    # in -- while its own caption claimed the lists were "readable for this
+    # selection". Three panels on this tab then reported three different
+    # totals for the same word.
     rows = (
         db.query(MovieList, MovieListItem.movie_id)
         .join(MovieListItem, MovieListItem.movie_list_id == MovieList.id)
-        .filter(MovieList.removed_at.is_(None), MovieListItem.removed_at.is_(None))
+        .filter(
+            MovieList.profile_id.in_(profile_ids),
+            MovieList.is_public.is_(True),
+            MovieList.removed_at.is_(None),
+            MovieListItem.removed_at.is_(None),
+        )
         .all()
     )
 
@@ -163,8 +174,9 @@ def build_list_progress(
         "lists": lists[:limit],
         "count": len(lists),
         "caveat": (
-            f"{len(lists)} lists are readable for this selection. A private list cannot be "
-            "counted at all, so an absent list is not a list nobody has started."
+            f"{len(lists)} public lists belong to this selection. A private list is not counted "
+            "at all — including one an account export brought in — so an absent list is not a "
+            "list nobody has started."
         ),
     }
 
@@ -198,7 +210,14 @@ def build_list_only_films(
         db.query(MovieListItem.movie_id, Movie, func.count(MovieListItem.id))
         .join(Movie, Movie.id == MovieListItem.movie_id)
         .join(MovieList, MovieList.id == MovieListItem.movie_list_id)
-        .filter(MovieListItem.removed_at.is_(None), MovieList.removed_at.is_(None))
+        .filter(
+            # Same scope as the panels above it: the selection's own public
+            # lists. A blind spot drawn from a stranger's list is not one.
+            MovieList.profile_id.in_(profile_ids),
+            MovieList.is_public.is_(True),
+            MovieListItem.removed_at.is_(None),
+            MovieList.removed_at.is_(None),
+        )
         .group_by(MovieListItem.movie_id, Movie.id)
         .all()
     )
@@ -221,8 +240,8 @@ def build_list_only_films(
         "films": films[:limit],
         "count": len(films),
         "caveat": (
-            f"On {min_lists} or more readable lists and logged by nobody in the selection. "
-            "A film on one list is not yet a canonical blind spot, so it is left out."
+            f"On {min_lists} or more of the selection's own public lists and logged by nobody in "
+            "it. A film on one list is not yet a canonical blind spot, so it is left out."
         ),
     }
 
@@ -239,10 +258,15 @@ def build_list_cadence(db: Session, profiles: Sequence[Profile]) -> Dict[str, An
     if not profile_ids:
         return {"profiles": [], "caveat": "No profiles selected."}
 
+    # Split by visibility rather than counted flat. Curating is curating
+    # whether or not the list is published, so a private list still belongs in
+    # this panel -- but every other list panel on the tab can only see the
+    # public ones, and a bare total here read as a contradiction of them.
     rows = (
         db.query(
             MovieList.profile_id,
             func.count(MovieList.id),
+            func.sum(case((MovieList.is_public.is_(True), 1), else_=0)),
             func.max(MovieList.updated_at),
         )
         .filter(MovieList.profile_id.in_(profile_ids), MovieList.removed_at.is_(None))
@@ -251,11 +275,16 @@ def build_list_cadence(db: Session, profiles: Sequence[Profile]) -> Dict[str, An
     )
 
     now = datetime.now(timezone.utc)
-    by_profile = {profile_id: (count, _aware(last)) for profile_id, count, last in rows}
+    by_profile = {
+        profile_id: (count, int(public or 0), _aware(last))
+        for profile_id, count, public, last in rows
+    }
 
     entries = []
+    private_total = 0
     for profile in profiles:
-        count, last = by_profile.get(profile.id, (0, None))
+        count, public, last = by_profile.get(profile.id, (0, 0, None))
+        private_total += count - public
         days = (now - last).days if last else None
         if count == 0:
             read = "Never made one"
@@ -271,6 +300,7 @@ def build_list_cadence(db: Session, profiles: Sequence[Profile]) -> Dict[str, An
             {
                 "username": names.get(profile.id, profile.username),
                 "lists": count,
+                "public_lists": public,
                 "last_edit_days": days,
                 "read": read,
             }
@@ -280,9 +310,16 @@ def build_list_cadence(db: Session, profiles: Sequence[Profile]) -> Dict[str, An
 
     return {
         "profiles": entries,
+        "private_lists": private_total,
         "caveat": (
             "Edit dates come from the list surface, which is read on its own schedule. A list we "
             "have never re-read looks stale here even if it changed yesterday."
+            + (
+                f" {private_total} of these are private and appear in no other panel on this tab: "
+                "an account export carries them, a public page never would."
+                if private_total
+                else ""
+            )
         ),
     }
 
@@ -374,13 +411,31 @@ def build_availability(db: Session, profiles: Sequence[Profile], *, region: str 
         )
     regions.sort(key=lambda item: (item["days_ago"] is None, item["days_ago"] or 0))
 
+    # A region nobody has ever fetched holds no rows, which is not the same
+    # fact as a region that was read and carries none of the queue. Reporting
+    # the first as the second is the one thing this section is not allowed to
+    # do, and the freshness panel beside it already says so in words.
+    region_read = any(entry["region"] == region for entry in regions)
+    if region_read:
+        scope = (
+            f"{len(films)} queued films are carried by a subscription service in {region} as of "
+            "the last reading."
+        )
+    else:
+        others = ", ".join(entry["region"] for entry in regions[:5])
+        scope = (
+            f"{region} has never been read, so this is empty for want of a fetch rather than for "
+            "want of availability."
+            + (f" The regions we do hold are {others}." if others else "")
+        )
+
     return {
         "films": films,
         "region": region,
+        "region_read": region_read,
         "regions": regions,
         "caveat": (
-            f"{len(films)} queued films are carried by a subscription service in {region} as of the "
-            "last reading. There is no countdown here on purpose: the provider feed publishes what "
+            f"{scope} There is no countdown here on purpose: the provider feed publishes what "
             "carries a film today and nothing about when that stops, so a \"days left\" figure "
             "would be invented rather than read."
         ),

--- a/backend/tests/test_follow_graph_api.py
+++ b/backend/tests/test_follow_graph_api.py
@@ -511,4 +511,6 @@ def test_suggestions_empty_for_user_with_no_tracked_profiles(database, client_fo
 
     payload = client_for(outsider).get("/api/follow-graph/suggestions").json()
 
-    assert payload == {"suggestions": []}
+    # The denominator travels with the counts: they are taken across every
+    # monitored profile, and a caller that supplied its own rendered "10 of 6".
+    assert payload == {"suggestions": [], "monitored_profiles": 0}

--- a/backend/tests/test_library_sections.py
+++ b/backend/tests/test_library_sections.py
@@ -40,11 +40,16 @@ from services.data_health import (
     build_ledger,
     build_lost_list_films,
     build_request_latency,
+    build_watch_event_freshness,
 )
 from services.films import (
+    build_atlas,
     build_collections,
+    build_filmographies,
+    build_keywords,
     build_liked_vs_rated,
     build_match_rate,
+    build_metadata_gaps,
     build_queue_age,
     build_runtime,
 )
@@ -138,7 +143,13 @@ def _movie(
     )
     database.add(movie)
     if enrich:
-        payload = {"belongs_to_collection": {"name": collection}} if collection else {}
+        # TMDB's response is nested under `details`, and this fixture used to
+        # put the collection at the top level instead. Both the fixture and the
+        # service agreed on a shape production never stores, so the panel was
+        # empty on real data while the test passed.
+        payload = (
+            {"details": {"belongs_to_collection": {"name": collection}}} if collection else {}
+        )
         database.add(
             MovieEnrichment(movie_id=movie_id, runtime_minutes=runtime, raw_payload=payload)
         )
@@ -228,6 +239,61 @@ def test_a_single_film_is_not_a_series(database: Session) -> None:
     assert series[0]["films"] == 2
 
 
+def test_no_films_panel_ships_the_whole_tmdb_payload(database: Session) -> None:
+    """`raw_payload` is the entire TMDB response, watch providers included.
+
+    Selecting it as a column pulled tens of megabytes per request, and the five
+    Films panels all fire on first paint, which was enough to stop the API
+    answering anything at all. The one fragment anybody needs out of it is
+    extracted by JSON path in the database, so the bare column must never
+    appear in a SELECT again.
+    """
+
+    viewer = _profile(database, "viewer")
+    for title in ("First", "Second"):
+        _film(database, viewer, _movie(database, title, runtime=100, collection="Series"))
+
+    statements: list[str] = []
+
+    @event.listens_for(database.get_bind(), "before_cursor_execute")
+    def _record(_conn, _cursor, statement, _params, _context, _executemany):
+        statements.append(statement)
+
+    for build in (
+        build_keywords,
+        build_runtime,
+        build_atlas,
+        build_collections,
+        build_filmographies,
+        build_metadata_gaps,
+        build_match_rate,
+        build_liked_vs_rated,
+    ):
+        build(database, [viewer])
+
+    event.remove(database.get_bind(), "before_cursor_execute", _record)
+
+    mentions = 0
+    for statement in statements:
+        for index in _offsets(statement, "movie_enrichments.raw_payload"):
+            mentions += 1
+            preceding = statement[:index]
+            assert preceding.rstrip().endswith("JSON_EXTRACT("), (
+                "raw_payload was selected whole rather than by path:\n" + statement
+            )
+
+    # Otherwise the loop above passes by never running, and stays passing after
+    # somebody drops the column back into a SELECT under a different name.
+    assert mentions, "no panel read raw_payload at all — this guard has stopped guarding"
+
+
+def _offsets(haystack: str, needle: str):
+    start = haystack.find(needle)
+    while start != -1:
+        yield start
+        start = haystack.find(needle, start + 1)
+
+
 def test_an_unrated_series_has_no_average(database: Session) -> None:
     viewer = _profile(database, "viewer")
     for title in ("One", "Two"):
@@ -302,12 +368,11 @@ def test_an_unrated_film_cannot_be_a_blind_spot_favourite(database: Session) -> 
 
 def test_list_only_films_need_more_than_one_list(database: Session) -> None:
     viewer = _profile(database, "viewer")
-    owner = _profile(database, "owner")
     once = _movie(database, "On One List")
     twice = _movie(database, "On Two Lists")
 
     for index, name in enumerate(("A", "B")):
-        movie_list = MovieList(profile_id=owner.id, name=name)
+        movie_list = MovieList(profile_id=viewer.id, name=name, is_public=True)
         database.add(movie_list)
         database.commit()
         database.add(MovieListItem(movie_list_id=movie_list.id, movie_id=twice.id, position=1))
@@ -318,6 +383,34 @@ def test_list_only_films_need_more_than_one_list(database: Session) -> None:
     films = build_list_only_films(database, [viewer])["films"]
 
     assert [film["title"] for film in films] == ["On Two Lists"]
+
+
+def test_a_blind_spot_is_drawn_from_the_selection_s_own_public_lists(database: Session) -> None:
+    """Three panels on this tab said "readable lists" and meant three things.
+
+    Unscoped, this counted every list in the store: other people's, and the
+    private ones an account export brings in. Both are now excluded, so the
+    word means the same thing everywhere on the tab.
+    """
+
+    viewer = _profile(database, "viewer")
+    stranger = _profile(database, "stranger")
+    theirs = _movie(database, "On A Stranger's Lists")
+    hidden = _movie(database, "On Private Lists")
+
+    for index in range(2):
+        outside = MovieList(profile_id=stranger.id, name=f"Stranger {index}", is_public=True)
+        private = MovieList(profile_id=viewer.id, name=f"Private {index}", is_public=False)
+        database.add_all([outside, private])
+        database.commit()
+        database.add(MovieListItem(movie_list_id=outside.id, movie_id=theirs.id, position=1))
+        database.add(MovieListItem(movie_list_id=private.id, movie_id=hidden.id, position=1))
+        database.commit()
+
+    payload = build_list_only_films(database, [viewer])
+
+    assert payload["films"] == []
+    assert "own public lists" in payload["caveat"]
 
 
 def test_a_profile_with_no_lists_is_named_rather_than_ranked_last(database: Session) -> None:
@@ -353,6 +446,108 @@ def test_availability_reports_staleness_and_claims_no_countdown(database: Sessio
     # The whole point of the panel: no expiry is claimed anywhere.
     assert "days left" in result["caveat"]
     assert "invented rather than read" in result["caveat"]
+
+
+def test_a_region_never_fetched_is_not_a_region_that_carries_nothing(database: Session) -> None:
+    """The shortlist read "Nothing queued is carried in IN".
+
+    Only DE had ever been fetched. Reporting a region we have never read as one
+    that carries none of the queue is the single thing this section is not
+    allowed to do, and the freshness panel beside it already said as much.
+    """
+
+    viewer = _profile(database, "viewer")
+    movie = _movie(database, "Streaming")
+    _queued(database, viewer, movie, date(2025, 1, 1))
+    database.add(
+        MovieWatchProvider(
+            movie_id=movie.id,
+            region="DE",
+            provider_id=8,
+            provider_name="Netflix",
+            provider_type="flatrate",
+            fetched_at=datetime.now(timezone.utc),
+        )
+    )
+    database.commit()
+
+    result = build_availability(database, [viewer], region="IN")
+
+    assert result["films"] == []
+    assert result["region_read"] is False
+    assert "never been read" in result["caveat"]
+    assert "DE" in result["caveat"]
+
+    read = build_availability(database, [viewer], region="DE")
+    assert read["region_read"] is True
+    assert "never been read" not in read["caveat"]
+
+
+def test_a_private_list_is_counted_for_its_owner_and_named_as_unshown(database: Session) -> None:
+    """Curating is curating, but the other panels on the tab cannot see it.
+
+    A bare list count here read as a flat contradiction of "Work through a
+    list", which only ever shows public ones.
+    """
+
+    viewer = _profile(database, "viewer")
+    database.add_all(
+        [
+            MovieList(profile_id=viewer.id, name="Shown", is_public=True),
+            MovieList(profile_id=viewer.id, name="Hidden", is_public=False),
+        ]
+    )
+    database.commit()
+
+    payload = build_list_cadence(database, [viewer])
+    entry = payload["profiles"][0]
+
+    assert entry["lists"] == 2
+    assert entry["public_lists"] == 1
+    assert payload["private_lists"] == 1
+    assert "appear in no other panel on this tab" in payload["caveat"]
+
+
+def test_a_refresh_that_skips_a_surface_does_not_unread_it(database: Session) -> None:
+    """The ledger said "Follows: never read" beside a rendered follow graph.
+
+    Scoped to each profile's single latest sync, a surface an older run had
+    read and a newer one did not touch fell out of the ledger entirely and was
+    reported as never read.
+    """
+
+    viewer = _profile(database, "viewer")
+    _sync(database, viewer, datasets={"follows": 35})
+    later = _sync(database, viewer, datasets={"films": 500})
+    later.completed_at = datetime(2026, 8, 3, 12, tzinfo=timezone.utc)
+    database.commit()
+
+    surfaces = {row["dataset"]: row for row in build_ledger(database, [viewer])["surfaces"]}
+
+    assert surfaces["films"]["rows"] == 500
+    assert surfaces["follows"]["rows"] == 35
+    assert surfaces["follows"]["result"] != "Never read for any selected profile"
+    # A surface genuinely never read still says so.
+    assert surfaces["comments"]["result"] == "Never read for any selected profile"
+
+
+def test_a_header_never_read_holds_no_film_total_rather_than_zero(database: Session) -> None:
+    """Data › Profiles showed "0" beside a profile's own 299 watches.
+
+    The count came from the tracked-profile list, which does not cover every
+    profile the panel renders, and a miss fell through to zero. It travels with
+    the row now, and stays null when the profile header has never been read.
+    """
+
+    read = _profile(database, "read", reported_total_films=564)
+    unread = _profile(database, "unread")
+
+    payload = build_watch_event_freshness(database, [read, unread])
+    by_name = {entry["username"]: entry for entry in payload["profiles"]}
+
+    assert by_name["read"]["films_held"] == 564
+    assert by_name["unread"]["films_held"] is None
+    assert "holds no number rather than a zero" in payload["caveat"]
 
 
 def test_a_surface_never_read_is_not_a_surface_that_came_back_empty(database: Session) -> None:

--- a/frontend/e2e/final-sections.spec.ts
+++ b/frontend/e2e/final-sections.spec.ts
@@ -95,6 +95,19 @@ test('Tonight refuses to invent a leaving countdown', async ({ page }) => {
   await expect(freshness).toContainText('Stale — shown greyed, not hidden');
 });
 
+test('Tonight reconciles the list counts its own panels disagreed about', async ({ page }) => {
+  await page.goto('/tonight?tab=lists');
+
+  // On production this tab reported 1, 49 and 17 for the same word: one panel
+  // read only public lists, one read every list in the store including other
+  // people's, and one counted the owner's private export lists flat. The
+  // cadence table now shows both numbers so the smaller ones read as a scope
+  // rather than a fault.
+  const cadence = page.locator('.terminal-root section', { hasText: 'WHO KEEPS THEIR LISTS ALIVE' }).first();
+  await expect(cadence).toContainText('SHOWN');
+  await expect(cadence).toContainText('appear in no other panel on this tab');
+});
+
 test('Data separates a surface never read from one that came back empty', async ({ page }) => {
   await page.goto('/data?tab=refreshes');
 

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -1598,14 +1598,21 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         });
       case '/api/tonight/list-cadence':
         return json(route, {
-          profiles: chosen.map((username, index) => ({
-            username,
-            lists: index === 2 ? 0 : Math.max(14 - index * 5, 1),
-            last_edit_days: index === 2 ? null : 3 + index * 120,
-            read: index === 2 ? 'Never made one' : index === 0 ? 'Actively curating' : 'Collector, not curator',
-          })),
+          profiles: chosen.map((username, index) => {
+            const lists = index === 2 ? 0 : Math.max(14 - index * 5, 1);
+            return {
+              username,
+              lists,
+              // The first profile holds private lists from an export, which is
+              // the case that made this panel contradict the three above it.
+              public_lists: index === 0 ? lists - 2 : lists,
+              last_edit_days: index === 2 ? null : 3 + index * 120,
+              read: index === 2 ? 'Never made one' : index === 0 ? 'Actively curating' : 'Collector, not curator',
+            };
+          }),
+          private_lists: 2,
           caveat:
-            'Edit dates come from the list surface, which is read on its own schedule. A list we have never re-read looks stale here even if it changed yesterday.',
+            'Edit dates come from the list surface, which is read on its own schedule. A list we have never re-read looks stale here even if it changed yesterday. 2 of these are private and appear in no other panel on this tab: an account export carries them, a public page never would.',
         });
       case '/api/tonight/availability':
         return json(route, {
@@ -1617,6 +1624,7 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
             },
           ],
           region: url.searchParams.get('region') ?? 'IN',
+          region_read: true,
           regions: [
             { region: 'IN', films: 800, checked_at: '2026-08-03T12:00:00Z', days_ago: 0, stale: false },
             { region: 'GB', films: 90, checked_at: '2026-07-15T12:00:00Z', days_ago: 19, stale: true },
@@ -1632,7 +1640,7 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
             { surface: 'Likes · comments', dataset: 'likes', profiles_covered: 0, profiles_selected: 3, rows: 0, authoritative_profiles: 0, last_run: null, result: 'Never read for any selected profile' },
           ],
           caveat:
-            'Read from the latest completed sync per profile. A surface with no row was never read for anybody in this selection — which is different from being read and coming back empty, and the two must not look alike.',
+            'Each surface reports the most recent completed run that carried it, which is not always the profile’s latest run — a refresh that skips a surface does not unread it. A surface with no row was never read for anybody in this selection, which is different from being read and coming back empty, and the two must not look alike.',
         });
       case '/api/data-health/feeds':
         return json(route, {
@@ -1699,9 +1707,12 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
             last_read_at: '2026-08-03T08:00:00Z',
             hours_ago: 6 + index * 30,
             watch_events: 2_184 - index * 300,
+            // One profile whose header has never been read: the panel used to
+            // print a confident 0 for it, beside its own watch count.
+            films_held: index === 1 ? null : 1_200 - index * 37,
           })),
           caveat:
-            "Read time comes from the latest completed sync, falling back to the profile's own last-scraped stamp. A profile with neither has never been read at all.",
+            "Read time comes from the latest completed sync, falling back to the profile's own last-scraped stamp. A profile with neither has never been read at all. 1 of these carry no film total: that figure comes from the profile header, and a header nobody has read holds no number rather than a zero.",
         });
       case '/api/data-health/lost':
         return json(route, {
@@ -2053,7 +2064,9 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   // renders "no follow connections" and leaves every node, the ego view and the
   // deep-dive hand-off untestable, which is how a blank-on-back regression
   // reached production unnoticed.
-  if (path === '/api/follow-graph/suggestions') return json(route, { suggestions: [] });
+  if (path === '/api/follow-graph/suggestions') {
+    return json(route, { suggestions: [], monitored_profiles: profiles.length });
+  }
   if (path === '/api/follow-graph/mutuals') {
     return json(route, followMutuals);
   }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1193,6 +1193,8 @@ export interface FollowSuggestion {
 
 export interface FollowSuggestionsResponse {
   suggestions: FollowSuggestion[];
+  /** `followed_by_count` is out of this, not out of any tab's current selection. */
+  monitored_profiles: number;
 }
 
 export const followGraphApi = {
@@ -2326,9 +2328,12 @@ export interface ListCadenceResponse {
   profiles: Array<{
     username: string;
     lists: number;
+    /** Every other list panel on this tab can only see these. */
+    public_lists: number;
     last_edit_days: number | null;
     read: string;
   }>;
+  private_lists: number;
   caveat: string;
 }
 
@@ -2344,6 +2349,8 @@ export interface AvailabilityResponse {
     checked_at: string | null;
   }>;
   region: string;
+  /** False when this region has never been fetched, which is not the same as carrying nothing. */
+  region_read: boolean;
   regions: Array<{
     region: string;
     films: number;
@@ -2447,6 +2454,8 @@ export interface FreshnessResponse {
     last_read_at: string | null;
     hours_ago: number | null;
     watch_events: number;
+    /** Letterboxd's own header figure. Null when the header has never been read. */
+    films_held: number | null;
   }>;
   caveat: string;
 }

--- a/frontend/src/views/data/ProfilesTab.tsx
+++ b/frontend/src/views/data/ProfilesTab.tsx
@@ -62,13 +62,6 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
   const { isAdmin, userReady } = useAdminScope();
   const enabled = profiles.length > 0;
 
-  const trackedQuery = useQuery({
-    queryKey: ['profiles-tracked'],
-    queryFn: () => profileApi.getTrackedProfiles(),
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-  });
-
   const freshnessQuery = useQuery({
     queryKey: ['data-freshness', profiles],
     queryFn: () => dataHealthApi.getFreshness(profiles),
@@ -107,8 +100,6 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
     refetchOnWindowFocus: false,
   });
 
-  const tracked = trackedQuery.data ?? [];
-
   return (
     <>
       <Panel
@@ -118,8 +109,8 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
         caveat={freshnessQuery.data?.caveat}
       >
         {panelState({
-          isLoading: freshnessQuery.isLoading || trackedQuery.isLoading,
-          error: freshnessQuery.error ?? trackedQuery.error,
+          isLoading: freshnessQuery.isLoading,
+          error: freshnessQuery.error,
           isEmpty: (freshnessQuery.data?.profiles.length ?? 0) === 0,
           severity: 'fatal',
           onRetry: () => freshnessQuery.refetch(),
@@ -134,9 +125,6 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
             columns="minmax(0,1fr) 90px 90px minmax(0,1fr)"
             head={['PROFILE', ['WATCHES', 'right'], ['LAST READ', 'right'], 'FILMS HELD']}
             rows={(freshnessQuery.data?.profiles ?? []).map((entry) => {
-              const profile = tracked.find(
-                (candidate) => candidate.username.toLowerCase() === entry.username.toLowerCase(),
-              );
               return {
                 cells: [
                   cell(`@${entry.username}`),
@@ -156,11 +144,18 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
                             ? 'var(--accent)'
                             : 'var(--ok)',
                   }),
-                  cell((profile?.total_films ?? 0).toLocaleString(), {
-                    align: 'right',
-                    size: '10px',
-                    tone: 'var(--muted)',
-                  }),
+                  // A header nobody has read holds no number. This used to
+                  // read the tracked-profile list, which does not cover every
+                  // profile on screen, and rendered a confident 0 for the ones
+                  // it missed — beside their own non-zero watch count.
+                  cell(
+                    entry.films_held === null ? 'never read' : entry.films_held.toLocaleString(),
+                    {
+                      align: 'right',
+                      size: '10px',
+                      tone: entry.films_held === null ? 'var(--dim)' : 'var(--muted)',
+                    },
+                  ),
                 ],
               };
             })}
@@ -221,7 +216,10 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
             items={(suggestionsQuery.data?.suggestions ?? []).map((suggestion) => ({
               name: `@${suggestion.username}`,
               weight: suggestion.followed_by_count,
-              value: `${suggestion.followed_by_count} of ${profiles.length}`,
+              // Counted across every monitored profile, which is what the
+              // server measured. Dividing by the tab's current selection
+              // produced "10 of 6".
+              value: `${suggestion.followed_by_count} of ${suggestionsQuery.data?.monitored_profiles ?? '—'}`,
               sub: suggestion.already_imported ? 'synced' : 'new',
             }))}
           />

--- a/frontend/src/views/tonight/AvailabilityTab.tsx
+++ b/frontend/src/views/tonight/AvailabilityTab.tsx
@@ -40,10 +40,19 @@ export default function AvailabilityTab({
           onRetry: () => availabilityQuery.refetch(),
           errorTitle: 'Availability could not be read',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: {
-            title: `Nothing queued is carried in ${region}`,
-            body: 'That is a fact about this region at the last reading, not about the films. Another region may carry them.',
-          },
+          // "Nothing is carried here" and "we have never looked here" are
+          // opposite facts, and the panel below already refuses to conflate
+          // them. Availability said the first while meaning the second.
+          empty:
+            availabilityQuery.data && !availabilityQuery.data.region_read
+              ? {
+                  title: `${region} has never been read`,
+                  body: 'No provider reading exists for this region, so this is empty for want of a fetch rather than for want of availability. The panel below names the regions we do hold.',
+                }
+              : {
+                  title: `Nothing queued is carried in ${region}`,
+                  body: 'That is a fact about this region at the last reading, not about the films. Another region may carry them.',
+                },
         }) ?? (
           <Posters
             items={(availabilityQuery.data?.films ?? []).slice(0, 10).map((film) => ({

--- a/frontend/src/views/tonight/ListsTab.tsx
+++ b/frontend/src/views/tonight/ListsTab.tsx
@@ -43,7 +43,7 @@ export default function ListsTab({ profiles }: { profiles: string[] }) {
         blurb="Was “list mission”. Every public list the group can see, with how much of it is imported."
         caveat={
           listsQuery.data
-            ? `${listsQuery.data.summary.available_lists.toLocaleString()} readable lists holding ${listsQuery.data.summary.total_movie_items.toLocaleString()} entries. A private list cannot be counted at all, so an absence here is not a list nobody started.`
+            ? `${listsQuery.data.summary.available_lists.toLocaleString()} public ${listsQuery.data.summary.available_lists === 1 ? 'list holds' : 'lists hold'} ${listsQuery.data.summary.total_movie_items.toLocaleString()} entries. A private list cannot be counted at all, so an absence here is not a list nobody started.`
             : undefined
         }
       >
@@ -120,7 +120,12 @@ export default function ListsTab({ profiles }: { profiles: string[] }) {
           errorBody: 'Every other panel on this tab is unaffected.',
           empty: {
             title: 'No canonical blind spot',
-            body: 'Everything on two or more readable lists has been watched by somebody in the selection.',
+            // Two different absences, and the old copy asserted the second
+            // whichever one was true.
+            body:
+              (listsQuery.data?.summary.available_lists ?? 0) < 2
+                ? 'A canonical blind spot needs a film on two of the selection’s own public lists, and there are fewer than two to cross. Nothing has been watched or missed here yet.'
+                : 'Everything on two or more of those lists has been watched by somebody in the selection.',
           },
         }) ?? (
           <Posters
@@ -153,8 +158,11 @@ export default function ListsTab({ profiles }: { profiles: string[] }) {
           empty: { title: 'No profiles selected', body: 'Choose at least one profile above.' },
         }) ?? (
           <Rows
-            columns="minmax(0,1fr) 52px 80px minmax(0,1fr)"
-            head={['PROFILE', ['LISTS', 'right'], ['LAST EDIT', 'right'], 'READ']}
+            columns="minmax(0,1fr) 52px 62px 80px minmax(0,1fr)"
+            // SHOWN is the count the other three panels on this tab work from.
+            // Without it a profile reading "16 lists" here beside "1 readable
+            // list" above looks like one of the two is broken.
+            head={['PROFILE', ['LISTS', 'right'], ['SHOWN', 'right'], ['LAST EDIT', 'right'], 'READ']}
             rows={(cadenceQuery.data?.profiles ?? []).map((entry) => {
               const tone =
                 entry.lists === 0
@@ -170,6 +178,11 @@ export default function ListsTab({ profiles }: { profiles: string[] }) {
                 cells: [
                   cell(`@${entry.username}`),
                   cell(String(entry.lists), { align: 'right', tone: 'var(--ink)' }),
+                  cell(String(entry.public_lists), {
+                    align: 'right',
+                    size: '10px',
+                    tone: entry.public_lists < entry.lists ? 'var(--accent)' : 'var(--muted)',
+                  }),
                   cell(
                     entry.last_edit_days === null ? '—' : `${entry.last_edit_days}d ago`,
                     { align: 'right', size: '10px', tone: 'var(--muted)' },


### PR DESCRIPTION
Found by walking all six sections and nineteen tabs on the live site after #128 and #129 deployed.

## The outage

`/api/films/*` never answered. `_library` queried whole `MovieEnrichment` entities, which pulls `raw_payload` — the entire TMDB response, watch providers included — for every film in the selection. All five Films › Library panels fire on first paint, and on a 4,745-film library that was enough to make `api.spyboxd.com` return 502 to unrelated callers for about a minute. It recovered on its own once the requests timed out.

Each builder now selects only the columns it reads, and fragments from large JSON columns are extracted by path in the database (`raw_payload["details"]["belongs_to_collection"]`, `credits["crew"]`). `services/profile_stats.py` has done exactly this since it was written; `services/films.py` was written without it. `test_no_films_panel_ships_the_whole_tmdb_payload` records every statement the eight Films builders emit and fails if the bare column is ever selected again.

## Wrong claims, in the order the walk found them

| Panel | Said | Truth |
|---|---|---|
| Films › Series worked through | nothing, for every selection | read the top-level key; TMDB nests it under `details` |
| Tonight › Lists | 1, 49 and 17 "readable lists" on one tab | two panels ignored both the selection and `is_public` |
| Tonight › Availability | "Nothing queued is carried in IN" | IN has never been fetched; DE is the only region held |
| Data › Profiles | `FILMS HELD 0` beside 299 watches | sourced from a list that does not cover every row |
| Data › Profiles | "10 of 6" | count is across all monitored profiles, not the selection |
| Data › Refreshes | "Follows: never read" | read only each profile's latest sync |

Every one of these is the rule the redesign is built on — a zero must never stand in for an absence — broken in a different place.

## Tests

- `705 passed` backend, including six new cases pinning each fix
- `232 passed` Playwright (`CI=1`, both projects)
- `tsc --noEmit` and `eslint --max-warnings=0` clean

One existing test changed meaning rather than being deleted: `test_list_only_films_need_more_than_one_list` built its lists under a profile outside the selection, which is the case this PR excludes. It now builds them under the selection, and a new test covers the exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)