### PR TITLE
Name the surfaces the importer writes, and stop a table with no rows

### DIFF
--- a/backend/services/data_health.py
+++ b/backend/services/data_health.py
@@ -42,7 +42,11 @@ SURFACE_ORDER = [
     ("ratings", "Ratings"),
     ("watchlist", "Watchlist"),
     ("lists", "Lists"),
-    ("follows", "Follows"),
+    # The importer writes "following" and "followers"; it has never written a
+    # dataset called "follows". That row could therefore only ever report
+    # "never read", which the follow graph in People flatly contradicted.
+    ("following", "Following"),
+    ("followers", "Followers"),
     ("reviews", "Reviews"),
     ("likes", "Likes · comments"),
     ("comments", "Comments"),

--- a/backend/services/tonight.py
+++ b/backend/services/tonight.py
@@ -174,9 +174,9 @@ def build_list_progress(
         "lists": lists[:limit],
         "count": len(lists),
         "caveat": (
-            f"{len(lists)} public lists belong to this selection. A private list is not counted "
-            "at all — including one an account export brought in — so an absent list is not a "
-            "list nobody has started."
+            f"{len(lists)} public {'list belongs' if len(lists) == 1 else 'lists belong'} to this "
+            "selection. A private list is not counted at all — including one an account export "
+            "brought in — so an absent list is not a list nobody has started."
         ),
     }
 

--- a/backend/tests/test_library_sections.py
+++ b/backend/tests/test_library_sections.py
@@ -35,6 +35,7 @@ from database.models import (
     WatchlistItem,
 )
 from services.data_health import (
+    SURFACE_ORDER,
     build_counts,
     build_feeds,
     build_ledger,
@@ -517,7 +518,7 @@ def test_a_refresh_that_skips_a_surface_does_not_unread_it(database: Session) ->
     """
 
     viewer = _profile(database, "viewer")
-    _sync(database, viewer, datasets={"follows": 35})
+    _sync(database, viewer, datasets={"following": 35})
     later = _sync(database, viewer, datasets={"films": 500})
     later.completed_at = datetime(2026, 8, 3, 12, tzinfo=timezone.utc)
     database.commit()
@@ -525,10 +526,30 @@ def test_a_refresh_that_skips_a_surface_does_not_unread_it(database: Session) ->
     surfaces = {row["dataset"]: row for row in build_ledger(database, [viewer])["surfaces"]}
 
     assert surfaces["films"]["rows"] == 500
-    assert surfaces["follows"]["rows"] == 35
-    assert surfaces["follows"]["result"] != "Never read for any selected profile"
+    assert surfaces["following"]["rows"] == 35
+    assert surfaces["following"]["result"] != "Never read for any selected profile"
     # A surface genuinely never read still says so.
     assert surfaces["comments"]["result"] == "Never read for any selected profile"
+
+
+def test_every_ledger_surface_is_a_name_the_importer_actually_writes(
+    database: Session,
+) -> None:
+    """The ledger asked for a dataset called "follows".
+
+    The importer has only ever written "following" and "followers", so that row
+    could report nothing but "never read" for the life of the product — beside
+    a follow graph drawing 35 edges. A surface nobody can ever fill is worse
+    than a missing row: it reads as a finding.
+    """
+
+    from services.ingestion import _upsert_sync_datasets  # noqa: PLC0415
+
+    written = _upsert_sync_datasets.__code__.co_consts
+    names = {value for const in written if isinstance(const, tuple) for value in const}
+
+    for dataset, _label in SURFACE_ORDER:
+        assert dataset in names, f"the ledger reads {dataset!r}, which no importer writes"
 
 
 def test_a_header_never_read_holds_no_film_total_rather_than_zero(database: Session) -> None:

--- a/frontend/src/views/films/TasteMapTab.tsx
+++ b/frontend/src/views/films/TasteMapTab.tsx
@@ -138,14 +138,25 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
         {panelState({
           isLoading: conversionQuery.isLoading,
           error: conversionQuery.error,
-          isEmpty: (conversionQuery.data?.coverage.watchlist_films ?? 0) === 0,
+          // Two different emptinesses. The guard used to check only the queue
+          // size, so a queue with entries but no added dates rendered a table
+          // header over nothing at all.
+          isEmpty:
+            (conversionQuery.data?.coverage.watchlist_films ?? 0) === 0 ||
+            (conversionQuery.data?.longest_waiting.length ?? 0) === 0,
           onRetry: () => conversionQuery.refetch(),
           errorTitle: 'Queue conversion could not be read',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: {
-            title: 'Nothing waiting in the queue',
-            body: 'Either the watchlist is private, or everything on it has been watched.',
-          },
+          empty:
+            (conversionQuery.data?.coverage.watchlist_films ?? 0) === 0
+              ? {
+                  title: 'Nothing waiting in the queue',
+                  body: 'Either the watchlist is private, or everything on it has been watched.',
+                }
+              : {
+                  title: 'Nothing in the queue can be aged',
+                  body: 'A wait needs the date an entry was added, and that exists in an official export only. The counts above still hold; the ordering below them cannot be built.',
+                },
         }) ?? (
           <Rows
             columns="minmax(0,1fr) 76px 76px"


### PR DESCRIPTION
Follow-ups found by re-walking the live site after #130 deployed and confirming its fixes.

#130 made the refresh ledger report the most recent run that carried each surface, which corrected Watchlist, Lists and Comments. **Follows still read "never".** The cause was one layer down: `SURFACE_ORDER` names a dataset called `follows`, and `_upsert_sync_datasets` has only ever written `following` and `followers`. That row could not be filled by any import, ever — so it has been claiming a gap that does not exist since the ledger was written. Now split into the two real names, and `test_every_ledger_surface_is_a_name_the_importer_actually_writes` checks the two lists against each other so they cannot drift again.

**Films › Taste map › Queue conversion** drew `LONGEST WAITING / ADDED / WAITING` with no rows under it. The empty guard tested the queue size (24, so not empty), but the table is ordered by wait length and a wait needs `added_date`, which comes from an official export only. For a subject with no export the list is legitimately empty — that is now said, rather than drawn as an empty table. The two counts above it are real and still render in both cases.

Also: "1 public lists belong to this selection" → "1 public list belongs to this selection".

Checked visually as well as in text — the quadrant panel on the same tab reads `2687%` in extracted text but renders `268  7%` on screen, so it was left alone.

## Tests

- `706 passed` backend
- `232 passed` Playwright (`CI=1`, both projects)
- `tsc --noEmit` and `eslint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)