### PR TITLE
Check the pre-redesign paths against what they do, not against sign-in

### DIFF
--- a/deploy/run-production-canary.py
+++ b/deploy/run-production-canary.py
@@ -29,11 +29,26 @@ REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
 PRIVATE_UI_PATHS = (
     "/overview",
     "/overlaps",
+    "/people",
+    "/tonight",
+    "/films",
+    "/data",
     "/profiles",
-    "/analysis",
-    "/compare",
-    "/watch-together",
     "/u/privacy-check",
+)
+
+# The pre-redesign paths, which are permanent redirects rather than guarded
+# routes. They were left in PRIVATE_UI_PATHS after the sections were renamed,
+# so the canary asserted /analysis sends anonymous traffic to /sign-in when it
+# now sends everybody to /people — and failed on a working deployment. They are
+# still worth checking, against what they actually do.
+LEGACY_UI_REDIRECTS = (
+    ("/dashboard", "/overview"),
+    ("/spy-signals", "/overlaps"),
+    ("/analysis", "/people"),
+    ("/compare", "/people"),
+    ("/network", "/people"),
+    ("/watch-together", "/tonight"),
 )
 PRIVATE_API_PATHS = (
     "/api/me",
@@ -203,6 +218,35 @@ def _load_health_validator(path: Path) -> ModuleType:
     return module
 
 
+def _validate_legacy_redirect(
+    web_base: str, path: str, destination: str, response: Response
+) -> None:
+    """A pre-redesign path must land on its new home, not on sign-in.
+
+    Guarding it as a private route instead is what made a healthy deployment
+    look broken; asserting the destination is what actually protects the
+    inbound links people already hold.
+    """
+
+    label = f"legacy redirect {path}"
+    if response.status != 308:
+        raise CanaryError(f"{label} did not answer with a permanent redirect")
+    # Next serves these with a relative Location, so it is resolved against the
+    # request rather than compared raw -- and resolving keeps the cross-origin
+    # check meaningful for an absolute one.
+    location = _header(response, "Location")
+    parsed = urllib.parse.urlsplit(
+        urllib.parse.urljoin(f"{web_base}{path}", location)
+    )
+    expected_origin = urllib.parse.urlsplit(web_base)
+    if (
+        parsed.scheme != expected_origin.scheme
+        or parsed.netloc != expected_origin.netloc
+        or parsed.path.rstrip("/") != destination
+    ):
+        raise CanaryError(f"{label} no longer points at {destination}")
+
+
 def _validate_private_redirect(web_base: str, path: str, response: Response) -> None:
     label = "private application route"
     if response.status not in {301, 302, 303, 307, 308}:
@@ -296,6 +340,10 @@ def run_canary(
         _validate_private_redirect(
             web_base, path, request_client.get(f"{web_base}{path}")
         )
+    for path, destination in LEGACY_UI_REDIRECTS:
+        _validate_legacy_redirect(
+            web_base, path, destination, request_client.get(f"{web_base}{path}")
+        )
     for path in PRIVATE_API_PATHS:
         _validate_anonymous_api(request_client.get(f"{api_base}{path}"))
 
@@ -303,6 +351,7 @@ def run_canary(
         "revision": revision,
         "private_api_routes": len(PRIVATE_API_PATHS),
         "private_ui_routes": len(PRIVATE_UI_PATHS),
+        "legacy_ui_redirects": len(LEGACY_UI_REDIRECTS),
     }
 
 

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -133,6 +133,13 @@ def _good_responses():
             },
             b"",
         )
+    for path, destination in public_canary.LEGACY_UI_REDIRECTS:
+        # Relative, the way Next actually serves it. Comparing the raw header
+        # against an absolute origin is what made this check reject a working
+        # production deployment.
+        responses[f"{web}{path}"] = public_canary.Response(
+            308, {**SECURITY_HEADERS, "Location": f"{destination}?tab=one"}, b""
+        )
     for path in public_canary.PRIVATE_API_PATHS:
         responses[f"{api}{path}"] = _json_response(
             {"detail": "Missing authorization token"},
@@ -155,6 +162,60 @@ class ProductionCanaryTests(unittest.TestCase):
         self.assertEqual(result["revision"], REVISION)
         self.assertEqual(result["private_ui_routes"], len(public_canary.PRIVATE_UI_PATHS))
         self.assertEqual(result["private_api_routes"], len(public_canary.PRIVATE_API_PATHS))
+        self.assertEqual(
+            result["legacy_ui_redirects"], len(public_canary.LEGACY_UI_REDIRECTS)
+        )
+
+    def test_a_legacy_path_is_checked_against_its_new_home_not_sign_in(self):
+        """Guarding these as private routes failed a healthy deployment.
+
+        /analysis sends everybody to /people now, not anonymous traffic to
+        /sign-in, so asserting the latter broke the canary on a deploy that
+        was working exactly as designed.
+        """
+
+        responses = _good_responses()
+        responses["https://spyboxd.com/analysis"] = public_canary.Response(
+            307,
+            {**SECURITY_HEADERS, "Location": "https://spyboxd.com/sign-in"},
+            b"",
+        )
+        with self.assertRaises(public_canary.CanaryError) as caught:
+            public_canary.run_canary(
+                web_base="https://spyboxd.com",
+                api_base="https://api.spyboxd.com",
+                validator_path=DEPLOY_DIR / "check-runtime-health.py",
+                client=FakeClient(responses),
+            )
+        self.assertIn("permanent redirect", str(caught.exception))
+
+    def test_a_legacy_path_redirected_off_origin_is_rejected(self):
+        responses = _good_responses()
+        responses["https://spyboxd.com/watch-together"] = public_canary.Response(
+            308, {**SECURITY_HEADERS, "Location": "https://evil.example/tonight"}, b""
+        )
+        with self.assertRaises(public_canary.CanaryError) as caught:
+            public_canary.run_canary(
+                web_base="https://spyboxd.com",
+                api_base="https://api.spyboxd.com",
+                validator_path=DEPLOY_DIR / "check-runtime-health.py",
+                client=FakeClient(responses),
+            )
+        self.assertIn("/tonight", str(caught.exception))
+
+    def test_a_legacy_path_pointing_somewhere_new_is_rejected(self):
+        responses = _good_responses()
+        responses["https://spyboxd.com/watch-together"] = public_canary.Response(
+            308, {**SECURITY_HEADERS, "Location": "https://spyboxd.com/overview"}, b""
+        )
+        with self.assertRaises(public_canary.CanaryError) as caught:
+            public_canary.run_canary(
+                web_base="https://spyboxd.com",
+                api_base="https://api.spyboxd.com",
+                validator_path=DEPLOY_DIR / "check-runtime-health.py",
+                client=FakeClient(responses),
+            )
+        self.assertIn("/tonight", str(caught.exception))
 
     def test_private_route_open_redirect_is_rejected(self):
         responses = _good_responses()


### PR DESCRIPTION
The Production Canary workflow has been failing on healthy deployments. Latest run: `private application route redirected outside the production sign-in route`.

`PRIVATE_UI_PATHS` still listed `/analysis`, `/compare` and `/watch-together`. Those became permanent redirects in #127 and #128 — they answer `308` to `/people` and `/tonight`, not `307` to `/sign-in` — so the canary read a working redirect as a private route leaking. The comment directly above the list already explained that these are redirects; the list was never changed to match it. `/people`, `/tonight`, `/films` and `/data` were also missing, so four of the six new sections were never checked at all.

The redirects still deserve a check, so they get their own — against their real destination. That is what actually protects the links people already hold; asserting they bounce to sign-in never checked anything about where they land.

Two things only the live run could show:

- **Next serves these with a relative `Location`** (`/overview`, not `https://spyboxd.com/overview`) — `curl` resolves it for display, which is why it looked absolute. Comparing the raw header against an absolute origin rejected production. It is resolved against the request URL now, which keeps the cross-origin rejection meaningful for either form.
- **The fixture served an absolute `Location`**, so a test built on it would have passed while production failed. It now serves what Next serves.

## Verification

Run against live production before opening this:

```
production canary passed: revision=93d8788572620dcfde6ecaf0f3397720a9ad6ec8 private_ui_routes=8 private_api_routes=23
```

`819 passed` across `deploy/` and `backend/tests`, including three new canary cases: a legacy path answering `307`/sign-in is rejected, one pointing at the wrong section is rejected, and one redirected off-origin is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)