### PR TITLE
Make the panel counts true, and let the canary see the endpoints it was missing

### DIFF
--- a/deploy/run-production-canary.py
+++ b/deploy/run-production-canary.py
@@ -42,6 +42,9 @@ PRIVATE_UI_PATHS = (
 # so the canary asserted /analysis sends anonymous traffic to /sign-in when it
 # now sends everybody to /people — and failed on a working deployment. They are
 # still worth checking, against what they actually do.
+# Deliberately not a route. See _validate_absent_api_route.
+ABSENT_API_PATH = "/api/films/this-endpoint-does-not-exist"
+
 LEGACY_UI_REDIRECTS = (
     ("/dashboard", "/overview"),
     ("/spy-signals", "/overlaps"),
@@ -58,10 +61,53 @@ PRIVATE_API_PATHS = (
     "/public/profile/privacy-check",
     "/api/dashboard/analytics",
     "/api/spy-signals",
+    "/profiles/privacy-check/analysis",
+    # Every endpoint the redesign added. Three of these were here and the other
+    # thirty-seven were not, so the sections that shipped last were the ones the
+    # canary could not see. On the API a missing route answers 404 and a guarded
+    # one answers 401, so listing them is a real existence check -- unlike the
+    # UI paths, where a route that does not exist redirects to sign-in exactly
+    # like one that does.
     "/api/activity/marathons",
     "/api/activity/weekday",
+    "/api/activity/season",
+    "/api/activity/logging-lag",
     "/api/insights/shared-firsts",
-    "/profiles/privacy-check/analysis",
+    "/api/insights/first-watch-order",
+    "/api/people/quiet",
+    "/api/people/reach",
+    "/api/people/reviews-per-watch",
+    "/api/people/tag-overlap",
+    "/api/people/decade-drift",
+    "/api/people/rename-resilience",
+    "/api/people/privacy-check/unrated",
+    "/api/people/privacy-check/silent-fives",
+    "/api/films/keywords",
+    "/api/films/runtime",
+    "/api/films/atlas",
+    "/api/films/collections",
+    "/api/films/filmographies",
+    "/api/films/liked-vs-rated",
+    "/api/films/decade-divergence",
+    "/api/films/queue-age",
+    "/api/films/language-ladder",
+    "/api/films/metadata-gaps",
+    "/api/films/match-rate",
+    "/api/tonight/blind-spot-favourites",
+    "/api/tonight/list-progress",
+    "/api/tonight/list-only-films",
+    "/api/tonight/list-cadence",
+    "/api/tonight/availability",
+    "/api/data-health/ledger",
+    "/api/data-health/feeds",
+    "/api/data-health/importers",
+    "/api/data-health/counts",
+    "/api/data-health/private",
+    "/api/data-health/removed",
+    "/api/data-health/request-latency",
+    "/api/data-health/freshness",
+    "/api/data-health/lost",
+    "/api/data-health/lost-lists",
     "/api/data-coverage",
     "/api/pair-dossier",
     "/api/signal-calendar",
@@ -218,6 +264,24 @@ def _load_health_validator(path: Path) -> ModuleType:
     return module
 
 
+def _validate_absent_api_route(response: Response) -> None:
+    """A route that does not exist must answer 404, not 401.
+
+    The list above proves the redesign's endpoints are deployed only because a
+    missing one would answer differently. If the API ever started answering 401
+    to everything — a catch-all guard, a proxy in front of it — the whole sweep
+    would pass while every endpoint was gone. This is the control that keeps
+    the sweep meaningful, and it is the check the UI paths cannot have: there,
+    a route that does not exist redirects to sign-in exactly like one that does.
+    """
+
+    if response.status != 404:
+        raise CanaryError(
+            "a fabricated API path answered "
+            f"{response.status} rather than 404, so a 401 no longer proves an endpoint exists"
+        )
+
+
 def _validate_legacy_redirect(
     web_base: str, path: str, destination: str, response: Response
 ) -> None:
@@ -346,6 +410,7 @@ def run_canary(
         )
     for path in PRIVATE_API_PATHS:
         _validate_anonymous_api(request_client.get(f"{api_base}{path}"))
+    _validate_absent_api_route(request_client.get(f"{api_base}{ABSENT_API_PATH}"))
 
     return {
         "revision": revision,

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -140,6 +140,9 @@ def _good_responses():
         responses[f"{web}{path}"] = public_canary.Response(
             308, {**SECURITY_HEADERS, "Location": f"{destination}?tab=one"}, b""
         )
+    responses[f"{api}{public_canary.ABSENT_API_PATH}"] = _json_response(
+        {"detail": "Not Found"}, status=404
+    )
     for path in public_canary.PRIVATE_API_PATHS:
         responses[f"{api}{path}"] = _json_response(
             {"detail": "Missing authorization token"},
@@ -1279,3 +1282,36 @@ class ProductionCanaryTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AbsentApiRouteControlTests(unittest.TestCase):
+    """The 401 sweep only proves an endpoint exists while 404 still means gone.
+
+    Forty redesign endpoints are asserted to answer 401. If the API ever
+    started answering 401 to everything, that whole sweep would pass while
+    every endpoint had disappeared.
+    """
+
+    def test_a_fabricated_path_answering_401_fails_the_canary(self):
+        responses = _good_responses()
+        responses[f"https://api.spyboxd.com{public_canary.ABSENT_API_PATH}"] = _json_response(
+            {"detail": "Missing authorization token"},
+            status=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+        with self.assertRaises(public_canary.CanaryError) as caught:
+            public_canary.run_canary(
+                web_base="https://spyboxd.com",
+                api_base="https://api.spyboxd.com",
+                validator_path=DEPLOY_DIR / "check-runtime-health.py",
+                client=FakeClient(responses),
+            )
+        self.assertIn("no longer proves an endpoint exists", str(caught.exception))
+
+    def test_every_redesign_endpoint_is_covered(self):
+        """Three of forty were listed; the rest shipped unwatched."""
+
+        for prefix in ("/api/films/", "/api/tonight/", "/api/data-health/", "/api/people/"):
+            covered = [p for p in public_canary.PRIVATE_API_PATHS if p.startswith(prefix)]
+            self.assertTrue(covered, f"no {prefix} endpoint is checked by the canary")
+        self.assertGreaterEqual(len(public_canary.PRIVATE_API_PATHS), 60)

--- a/frontend/e2e/panel-counts.spec.ts
+++ b/frontend/e2e/panel-counts.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+
+import { SECTIONS } from '../src/components/terminal/sections';
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Every tab publishes a panel count beside its label. Three of them were
+ * transcribed from the design handoff and then drifted as panels were added or
+ * cut: One person advertised 20 against 24 on screen, Two people 10 against 11,
+ * Profiles 7 against 5. Nobody noticed, because nothing counted.
+ *
+ * The whole argument of this product is that a number on screen is true, so a
+ * navigation badge is not allowed to be a rough estimate either. This walks
+ * every tab and holds the badge to what the page actually renders.
+ */
+test.beforeEach(async ({ page }) => {
+  // Non-admin: Data › Profiles renders an extra request-queue panel for admins,
+  // and the badge is what every reader gets rather than what one of them does.
+  await installApiMocks(page, { isAdmin: false });
+});
+
+for (const section of SECTIONS) {
+  for (const tab of section.tabs) {
+    test(`${section.name} › ${tab.label} renders the ${tab.panels} panels it advertises`, async ({
+      page,
+    }) => {
+      await page.goto(`/${section.id}?tab=${tab.id}`);
+
+      const panels = page.locator('.terminal-root section');
+      // Panels stream in as their queries settle, so wait for the count rather
+      // than sampling it the instant navigation resolves.
+      await expect(panels).toHaveCount(tab.panels);
+    });
+  }
+}
+
+test('the tab row prints the same number the section definition holds', async ({ page }) => {
+  await page.goto('/people?tab=one');
+
+  for (const tab of SECTIONS.find((entry) => entry.id === 'people')!.tabs) {
+    // Addressed by href rather than by accessible name: the badge renders as
+    // label and count run together ("ONE PERSON24"), and the name computation
+    // inserts a separator that the visible text does not have.
+    const link = page.locator(`a[href="/people?tab=${tab.id}"]`).first();
+    await expect(link).toHaveText(`${tab.label}${tab.panels}`);
+  }
+});

--- a/frontend/src/components/terminal/sections.ts
+++ b/frontend/src/components/terminal/sections.ts
@@ -11,7 +11,19 @@ export interface TabDef {
   /** URL value, e.g. `?tab=echoes`. */
   id: string;
   label: string;
-  /** How many panels the tab holds; shown beside the label in the tab row. */
+  /**
+   * How many panels the tab holds; shown beside the label in the tab row.
+   *
+   * Counted from what the page actually renders, not from what the handoff
+   * planned. Three of these were transcribed from the design document and then
+   * drifted as panels were added: One person said 20 against 24 on screen, Two
+   * people 10 against 11, Profiles 7 against 5. A badge in a product whose
+   * whole argument is that its numbers are true cannot be a rough estimate.
+   *
+   * Data › Profiles is the one tab whose panel count is not fixed: an admin
+   * sees an extra request-queue panel. The number here is what every reader
+   * gets; the admin panel is labelled as an addition.
+   */
   panels: number;
 }
 
@@ -69,8 +81,8 @@ export const SECTIONS: SectionDef[] = [
     blurb:
       'Merges Analysis, Compare and Network. Three doors into the same subject become one destination with four tabs.',
     tabs: [
-      { id: 'one', label: 'ONE PERSON', panels: 20 },
-      { id: 'two', label: 'TWO PEOPLE', panels: 10 },
+      { id: 'one', label: 'ONE PERSON', panels: 24 },
+      { id: 'two', label: 'TWO PEOPLE', panels: 11 },
       { id: 'circle', label: 'THE CIRCLE', panels: 7 },
       { id: 'reach', label: 'REACH', panels: 6 },
     ],
@@ -112,7 +124,7 @@ export const SECTIONS: SectionDef[] = [
     blurb:
       'Was My Profiles. Choosing who you follow sits next to the sync health that decides what you actually get, and next to the honest inventory of what we cannot read.',
     tabs: [
-      { id: 'profiles', label: 'PROFILES', panels: 7 },
+      { id: 'profiles', label: 'PROFILES', panels: 5 },
       { id: 'refreshes', label: 'REFRESHES', panels: 4 },
       { id: 'missing', label: "WHAT'S MISSING", panels: 4 },
       { id: 'lost', label: 'LOST & FOUND', panels: 3 },


### PR DESCRIPTION
Found by re-walking all six sections and nineteen tabs on the live site, plus an independent audit of the deployment.

## Three tab badges were lying

Every tab prints a panel count beside its label. Three were transcribed from the handoff and then drifted:

| Tab | Advertised | Actually renders |
|---|---|---|
| People › One person | 20 | 24 |
| People › Two people | 10 | 11 |
| Data › Profiles | 7 | 5 |

`e2e/panel-counts.spec.ts` now walks all nineteen tabs and asserts the badge equals the rendered count, so this cannot drift again. Data › Profiles is the one tab whose count varies — an admin sees an extra request-queue panel — so the badge is the number every reader gets and the admin panel is labelled as an addition.

## The canary was watching 3 of the 40 new endpoints

`PRIVATE_API_PATHS` held `/api/activity/marathons`, `/api/activity/weekday` and `/api/insights/shared-firsts`. Every `/api/films/*`, `/api/tonight/*`, `/api/people/*` and `/api/data-health/*` path was missing — so Films, Tonight and Data, the three sections that shipped last, were the ones nothing watched. Had the outage in #130 taken those routes out rather than merely hanging them, the canary would still have gone green.

All forty are listed now, and a **fabricated path is probed alongside them**. The 401 sweep only proves an endpoint exists for as long as a missing route answers 404; if the API ever answered 401 to everything, the sweep would pass while every endpoint was gone. That control is what the UI paths cannot have — there, a route that does not exist redirects to sign-in exactly like one that does, which is a real blind spot worth naming rather than papering over.

## Verification

Live production, before opening this:

```
production canary passed: revision=2c9616e6c83e672326efb637a10ad08acef34995 private_ui_routes=8 private_api_routes=60
```

- `272 passed` Playwright (`CI=1`, both projects) — up from 232, the 40 new ones being the per-tab count checks
- `821 passed` across `deploy/` and `backend/tests`
- `tsc --noEmit` and `eslint --max-warnings=0` clean

## Not fixed here

The canary's **authenticated** Clerk phase fails with "The VPS guardian did not publish a canary plan". That is a pre-existing infrastructure fault, not a redesign regression — it fails identically on `a0b873a`, the commit before any of this work merged. It needs access to the production VPS, so it is left alone here and flagged instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)