### PR TITLE
Cut filmographies from twelve seconds, and let the canary say what failed

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -433,6 +433,10 @@ jobs:
           guardian_started=1
 
           plan_ready=0
+          # Initialised before the loop: `set -u` is active and the loop body
+          # is the only other place this is assigned, so a guardian that fails
+          # on its first poll would otherwise trip an unbound variable.
+          guardian_status=running
           for _ in $(seq 1 60); do
             if deploy/production-ssh.sh run test -f "${remote_plan}"; then
               plan_ready=1
@@ -463,8 +467,18 @@ jobs:
                   node scripts/run-production-auth-canary.mjs --plan "${plan_file}"
               ) || browser_status=$?
             fi
+          elif [[ "${guardian_status}" == failed || "${guardian_status}" == cleanup_failed ]]; then
+            # The guardian did not go missing — it ran, failed its preflight and
+            # said why. Reporting "no plan appeared" threw that away and left
+            # the job undiagnosable. Its stderr stays closed on purpose, so the
+            # reason comes back through the status file it already writes.
+            guardian_reason="$(
+              deploy/production-ssh.sh run \
+                "${REMOTE_CANARY_PATH}" reason --lease-id "${lease_id}"
+            )" || guardian_reason=''
+            echo "The VPS guardian failed before publishing a plan (${guardian_status}): ${guardian_reason:-no reason recorded}" >&2
           else
-            echo 'The VPS guardian did not publish a canary plan.' >&2
+            echo 'The VPS guardian did not publish a canary plan before its deadline.' >&2
           fi
 
           if (( browser_status == 0 )); then

--- a/backend/services/films.py
+++ b/backend/services/films.py
@@ -12,7 +12,7 @@ from collections import Counter, defaultdict
 from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, Sequence
 
-from sqlalchemy import func
+from sqlalchemy import func, literal_column
 from sqlalchemy.orm import Session
 
 from database.models import (
@@ -23,6 +23,18 @@ from database.models import (
     WatchEvent,
     WatchlistItem,
 )
+
+
+# TMDB buries one or two directors in a crew list that routinely runs past two
+# hundred people. Selecting the crew and filtering it in Python shipped all of
+# them: /api/films/filmographies took twelve seconds on production against
+# well under one for every other panel in the section. Extracting just the
+# names by JSON path leaves the crew in the database.
+#
+# The constant is inlined rather than bound because PostgreSQL needs a
+# `jsonpath`-typed argument and a bound parameter arrives as text. It is a
+# literal in this file, never anything a caller supplies.
+_DIRECTOR_NAMES_JSONPATH = """'$[*] ? (@.job == "Director").name'::jsonpath"""
 
 
 def _library(db: Session, profile_ids: Sequence[int], *enrichment_columns):
@@ -57,6 +69,108 @@ def _library(db: Session, profile_ids: Sequence[int], *enrichment_columns):
         .filter(ProfileFilm.profile_id.in_(profile_ids), ProfileFilm.removed_at.is_(None))
         .all()
     )
+
+
+def _director_names_column(db: Session):
+    """Director names per film, extracted in the database where it can be.
+
+    PostgreSQL has `jsonb_path_query_array`, so production ships two strings
+    per film instead of a two-hundred-entry crew list. SQLite has no jsonpath,
+    so the tests fall back to the crew column and filter it here — the same
+    answer either way, and a fixture library is small enough not to care.
+
+    Returns the column and whether it is already reduced to names.
+    """
+
+    crew = MovieEnrichment.credits["crew"]
+    if db.get_bind().dialect.name == "postgresql":
+        return (
+            func.jsonb_path_query_array(crew, literal_column(_DIRECTOR_NAMES_JSONPATH)),
+            True,
+        )
+    return crew, False
+
+
+def _films_held(db: Session, profile_ids: Sequence[int], *enrichment_columns):
+    """One row per distinct film the selection holds, not one per holder.
+
+    Two queries rather than a join, because the interesting columns are large
+    JSON and a film held by six profiles was shipping its enrichment six times.
+    The rating is the selection's mean for the film: panels that group films
+    (by director, by collection) used to dedupe in Python and keep whichever
+    holder's rating the database happened to return first, which made the
+    average depend on row order.
+    """
+
+    if not profile_ids:
+        return []
+
+    holdings = (
+        db.query(
+            ProfileFilm.movie_id,
+            func.avg(ProfileFilm.rating).label("rating"),
+            func.count(ProfileFilm.movie_id).label("holders"),
+        )
+        .filter(ProfileFilm.profile_id.in_(profile_ids), ProfileFilm.removed_at.is_(None))
+        .group_by(ProfileFilm.movie_id)
+        .all()
+    )
+    if not holdings:
+        return []
+
+    by_movie = {row.movie_id: row for row in holdings}
+    films = (
+        db.query(
+            Movie.id.label("movie_id"),
+            Movie.title,
+            Movie.release_year,
+            Movie.poster_url,
+            Movie.tmdb_id,
+            MovieEnrichment.movie_id.label("enrichment_movie_id"),
+            *enrichment_columns,
+        )
+        .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
+        .filter(Movie.id.in_(list(by_movie)))
+        .all()
+    )
+
+    held = []
+    for film in films:
+        holding = by_movie.get(film.movie_id)
+        # An unrated film has no average, never an average of zero.
+        rating = None if holding is None or holding.rating is None else float(holding.rating)
+        held.append(_HeldFilm(film, rating, holding.holders if holding else 0))
+    return held
+
+
+class _HeldFilm:
+    """A film plus what the selection did with it, addressed like a row."""
+
+    __slots__ = ("_film", "rating", "holders")
+
+    def __init__(self, film, rating: Optional[float], holders: int) -> None:
+        self._film = film
+        self.rating = rating
+        self.holders = holders
+
+    def __getattr__(self, name: str):
+        return getattr(self._film, name)
+
+
+def _director_names(value: Any, already_names: bool) -> List[str]:
+    """Director names from either shape the column above can return."""
+
+    if not isinstance(value, list):
+        return []
+    if already_names:
+        return [name.strip() for name in value if isinstance(name, str) and name.strip()]
+    names = []
+    for member in value:
+        if isinstance(member, Mapping) and member.get("job") == "Director":
+            name = str(member.get("name") or "").strip()
+            if name:
+                names.append(name)
+    return names
 
 
 def _coverage(rows) -> Dict[str, Any]:
@@ -244,7 +358,7 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
     # TMDB nests this under `details`, which is where profile_stats has always
     # read it. Reading the top level found nothing, so the panel was empty for
     # every selection rather than wrong in a visible way.
-    rows = _library(
+    rows = _films_held(
         db,
         [profile.id for profile in profiles],
         MovieEnrichment.raw_payload["details"]["belongs_to_collection"].label(
@@ -254,11 +368,9 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
     coverage = _coverage(rows)
 
     grouped: Dict[str, Dict[str, Any]] = {}
-    seen: set[int] = set()
     for row in rows:
-        if row.enrichment_movie_id is None or row.movie_id in seen:
+        if row.enrichment_movie_id is None:
             continue
-        seen.add(row.movie_id)
         collection = row.belongs_to_collection
         if not isinstance(collection, Mapping):
             continue
@@ -283,7 +395,9 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
         # One film is not a franchise.
         if entry["films"] > 1
     ]
-    series.sort(key=lambda item: -item["films"])
+    # Name breaks the tie: without it the order among equal counts came from
+    # row order, so the panel reshuffled between two identical refreshes.
+    series.sort(key=lambda item: (-item["films"], item["name"].casefold()))
 
     return {
         "series": series[:limit],
@@ -299,28 +413,17 @@ def build_collections(db: Session, profiles: Sequence[Profile], *, limit: int = 
 def build_filmographies(db: Session, profiles: Sequence[Profile], *, limit: int = 12) -> Dict[str, Any]:
     """How much of one director's work the group holds."""
 
-    # Only the crew list, not the full credits document: the cast is by far the
-    # larger half and no panel here reads it.
-    rows = _library(
-        db,
-        [profile.id for profile in profiles],
-        MovieEnrichment.credits["crew"].label("crew"),
+    directors_column, already_names = _director_names_column(db)
+    rows = _films_held(
+        db, [profile.id for profile in profiles], directors_column.label("directors")
     )
     coverage = _coverage(rows)
 
     grouped: Dict[str, Dict[str, Any]] = {}
-    seen: set[int] = set()
     for row in rows:
-        if row.enrichment_movie_id is None or row.movie_id in seen:
+        if row.enrichment_movie_id is None:
             continue
-        seen.add(row.movie_id)
-        crew = row.crew if isinstance(row.crew, list) else []
-        for member in crew:
-            if not isinstance(member, Mapping) or member.get("job") != "Director":
-                continue
-            name = str(member.get("name") or "").strip()
-            if not name:
-                continue
+        for name in _director_names(row.directors, already_names):
             entry = grouped.setdefault(name, {"director": name, "films": 0, "ratings": [], "titles": []})
             entry["films"] += 1
             entry["titles"].append(row.title)
@@ -339,7 +442,8 @@ def build_filmographies(db: Session, profiles: Sequence[Profile], *, limit: int 
         for entry in grouped.values()
         if entry["films"] > 1
     ]
-    directors.sort(key=lambda item: -item["films"])
+    # Name breaks the tie, so two identical reads render in the same order.
+    directors.sort(key=lambda item: (-item["films"], item["director"].casefold()))
 
     return {
         "directors": directors[:limit],

--- a/backend/tests/test_films_postgres.py
+++ b/backend/tests/test_films_postgres.py
@@ -1,0 +1,232 @@
+"""The Films queries against real PostgreSQL, which is the only place they run.
+
+`test_library_sections.py` builds its fixtures on SQLite, so the two dialect
+branches in `services/films.py` — the `jsonb_path_query_array` extraction of
+director names, and the `->` JSON path into `raw_payload` — are never executed
+there. Both are the kind of thing that passes every local test and then fails
+in production, so they are exercised here against the database that actually
+serves them.
+
+Skipped without SPYBOXD_TEST_DATABASE_URL. CI sets it.
+"""
+from __future__ import annotations
+
+import os
+import unittest
+import uuid
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from database.models import (
+    Base,
+    Movie,
+    MovieEnrichment,
+    Profile,
+    ProfileFilm,
+)
+from services.films import build_collections, build_filmographies
+
+# This file creates and DROPs a schema, so it reuses the migration suite's
+# guard rather than trusting whatever SPYBOXD_TEST_DATABASE_URL points at:
+# loopback host, and a database whose name says it is a test database.
+from tests.test_additive_migrations import _validated_test_database_url
+
+
+def _crew(*directors: str):
+    """A TMDB-shaped crew: the directors buried among many other jobs."""
+
+    crew = [
+        {"job": "Director", "name": name, "department": "Directing", "id": index}
+        for index, name in enumerate(directors)
+    ]
+    crew.extend(
+        {"job": "Best Boy", "name": f"Someone {index}", "department": "Lighting", "id": 900 + index}
+        for index in range(40)
+    )
+    return crew
+
+
+@unittest.skipUnless(
+    os.getenv("SPYBOXD_TEST_DATABASE_URL"),
+    "Set SPYBOXD_TEST_DATABASE_URL to run the PostgreSQL Films queries.",
+)
+class FilmsPostgresTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.database_url = _validated_test_database_url(
+            os.environ["SPYBOXD_TEST_DATABASE_URL"]
+        )
+        cls.schema = f"spyboxd_films_test_{uuid.uuid4().hex[:16]}"
+        cls.engine = create_engine(
+            cls.database_url,
+            future=True,
+            pool_pre_ping=True,
+            connect_args={"options": f"-csearch_path={cls.schema}"},
+        )
+        with create_engine(cls.database_url, future=True).begin() as connection:
+            connection.execute(text(f'CREATE SCHEMA "{cls.schema}"'))
+        cls.addClassCleanup(cls._drop_schema)
+        # The whole schema: `movies` carries foreign keys into `profile_syncs`,
+        # so a hand-picked subset does not create cleanly.
+        Base.metadata.create_all(cls.engine)
+
+    @classmethod
+    def _drop_schema(cls) -> None:
+        cls.engine.dispose()
+        with create_engine(cls.database_url, future=True).begin() as connection:
+            connection.execute(text(f'DROP SCHEMA IF EXISTS "{cls.schema}" CASCADE'))
+
+    def setUp(self) -> None:
+        self.db = sessionmaker(bind=self.engine, expire_on_commit=False)()
+        self.addCleanup(self.db.close)
+
+    def _seed(self):
+        """Two profiles, both holding the same two films, rating them apart."""
+
+        left = Profile(username=f"left{uuid.uuid4().hex[:8]}", scraping_status="completed", is_active=True)
+        right = Profile(username=f"right{uuid.uuid4().hex[:8]}", scraping_status="completed", is_active=True)
+        self.db.add_all([left, right])
+        self.db.flush()
+
+        films = []
+        for index, (title, collection) in enumerate(
+            [("First", "A Series"), ("Second", "A Series")]
+        ):
+            movie = Movie(
+                canonical_key=f"letterboxd:{title}-{uuid.uuid4().hex[:8]}",
+                title=title,
+                normalized_title=title.casefold(),
+                release_year=2000 + index,
+            )
+            self.db.add(movie)
+            self.db.flush()
+            self.db.add(
+                MovieEnrichment(
+                    movie_id=movie.id,
+                    credits={"cast": [{"name": "An Actor"}], "crew": _crew("Akira Kurosawa")},
+                    raw_payload={"details": {"belongs_to_collection": {"name": collection}}},
+                )
+            )
+            films.append(movie)
+
+        # 5.0 and 3.0 on both films: the mean is 4.0, and neither holder's own
+        # rating is 4.0, so a result of 4.0 can only come from averaging.
+        for movie in films:
+            self.db.add(ProfileFilm(profile_id=left.id, movie_id=movie.id, rating=5.0, tags=[], watch_count=1))
+            self.db.add(ProfileFilm(profile_id=right.id, movie_id=movie.id, rating=3.0, tags=[], watch_count=1))
+        self.db.commit()
+        return [left, right]
+
+    def test_director_names_come_back_from_the_jsonpath_extraction(self):
+        """The crew list never leaves the database on PostgreSQL.
+
+        This is the branch SQLite cannot reach: `jsonb_path_query_array` needs
+        a jsonpath-typed argument, and getting that wrong raises
+        UndefinedFunction at query time rather than at import.
+        """
+
+        profiles = self._seed()
+
+        payload = build_filmographies(self.db, profiles)
+
+        self.assertEqual([entry["director"] for entry in payload["directors"]], ["Akira Kurosawa"])
+        self.assertEqual(payload["directors"][0]["films"], 2)
+        self.assertEqual(sorted(payload["directors"][0]["titles"]), ["First", "Second"])
+
+    def test_a_film_is_counted_once_however_many_people_hold_it(self):
+        """Two holders, two films — not four."""
+
+        profiles = self._seed()
+
+        payload = build_filmographies(self.db, profiles)
+
+        self.assertEqual(payload["directors"][0]["films"], 2)
+        self.assertEqual(payload["coverage"]["films"], 2)
+        self.assertEqual(payload["coverage"]["enriched"], 2)
+
+    def test_the_rating_is_the_selection_s_mean_not_whoever_came_back_first(self):
+        """5.0 and 3.0 average to 4.0; neither holder rated anything 4.0.
+
+        Deduping in Python and keeping the first row's rating made this depend
+        on the order the database happened to return.
+        """
+
+        profiles = self._seed()
+
+        directors = build_filmographies(self.db, profiles)["directors"]
+        series = build_collections(self.db, profiles)["series"]
+
+        self.assertEqual(directors[0]["average_rating"], 4.0)
+        self.assertEqual(series[0]["name"], "A Series")
+        self.assertEqual(series[0]["average_rating"], 4.0)
+
+    def test_the_collection_is_read_from_the_nested_tmdb_path(self):
+        """`raw_payload["details"]["belongs_to_collection"]`, not the top level."""
+
+        profiles = self._seed()
+
+        payload = build_collections(self.db, profiles)
+
+        self.assertEqual([entry["name"] for entry in payload["series"]], ["A Series"])
+        self.assertEqual(payload["series"][0]["films"], 2)
+
+    def test_the_crew_list_never_leaves_the_database(self):
+        """The whole point of the jsonpath: /api/films/filmographies took 12s.
+
+        Selecting `credits->'crew'` and filtering in Python shipped up to two
+        hundred crew members per film, once per holder. The bare column must
+        not reappear in a SELECT — only the path expression that reduces it to
+        names.
+        """
+
+        from sqlalchemy import event  # noqa: PLC0415
+
+        profiles = self._seed()
+        statements: list[str] = []
+
+        @event.listens_for(self.engine, "before_cursor_execute")
+        def _record(_conn, _cursor, statement, _params, _context, _executemany):
+            statements.append(statement)
+
+        build_filmographies(self.db, profiles)
+        event.remove(self.engine, "before_cursor_execute", _record)
+
+        selected_crew = [
+            statement
+            for statement in statements
+            if "credits -> " in statement and "jsonb_path_query_array" not in statement
+        ]
+        self.assertEqual(selected_crew, [], "the crew column was selected whole")
+        self.assertTrue(
+            any("jsonb_path_query_array" in statement for statement in statements),
+            "no jsonpath extraction ran — this guard has stopped guarding",
+        )
+
+    def test_an_unenriched_film_contributes_no_director(self):
+        """A null crew must not become an empty-string director."""
+
+        profiles = self._seed()
+        bare = Movie(
+            canonical_key=f"letterboxd:bare-{uuid.uuid4().hex[:8]}",
+            title="Unmatched",
+            normalized_title="unmatched",
+            release_year=1999,
+        )
+        self.db.add(bare)
+        self.db.flush()
+        self.db.add(
+            ProfileFilm(profile_id=profiles[0].id, movie_id=bare.id, rating=4.0, tags=[], watch_count=1)
+        )
+        self.db.commit()
+
+        payload = build_filmographies(self.db, profiles)
+
+        self.assertEqual([entry["director"] for entry in payload["directors"]], ["Akira Kurosawa"])
+        self.assertEqual(payload["coverage"]["films"], 3)
+        self.assertEqual(payload["coverage"]["enriched"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/run-production-auth-canary.py
+++ b/deploy/run-production-auth-canary.py
@@ -1491,9 +1491,22 @@ def run_guardian(
                     _write_private_json(state_path, state)
 
                 status = _guardian_result_status(primary_error, cleanup_error)
-                _write_private_json(
-                    lease_dir / STATUS_NAME, {"version": 1, "status": status}
-                )
+                status_payload: dict[str, Any] = {"version": 1, "status": status}
+                # Carry why it failed, not just that it did. The guardian's own
+                # stderr goes to /dev/null on purpose — a traceback can contain
+                # DATABASE_URL — so without this the workflow could only report
+                # "no plan appeared", which is not what happened and sent
+                # everybody looking in the wrong place for a fortnight.
+                reported = cleanup_error if cleanup_error is not None else primary_error
+                if reported is not None:
+                    status_payload["reason"] = (
+                        # Every AuthCanaryError message is a fixed string written
+                        # in this file. Anything else contributes its type only.
+                        str(reported)[:200]
+                        if isinstance(reported, AuthCanaryError)
+                        else type(reported).__name__
+                    )
+                _write_private_json(lease_dir / STATUS_NAME, status_payload)
             finally:
                 for signal_number, previous in previous_handlers.items():
                     signal.signal(signal_number, previous)
@@ -1556,6 +1569,23 @@ def signal_completion(
         raise AuthCanaryError(
             "authenticated canary completion could not be signalled"
         ) from exc
+
+
+def lease_failure_reason(*, lease_id: str, shared_dir: Path) -> str:
+    """The guardian's own account of why it failed, or an empty string.
+
+    Read separately from `lease_status` so the status contract is unchanged:
+    an older status file simply has no reason and yields "".
+    """
+
+    lease_dir = _lease_directory(shared_dir, lease_id)
+    status_path = lease_dir / STATUS_NAME
+    if not status_path.exists():
+        return ""
+    reason = _read_private_json(status_path).get("reason", "")
+    if not isinstance(reason, str):
+        return ""
+    return reason.replace("\n", " ").replace("\r", " ")[:200]
 
 
 def lease_status(*, lease_id: str, shared_dir: Path) -> str:
@@ -1625,6 +1655,10 @@ def main() -> int:
     status_command.add_argument("--lease-id", required=True)
     status_command.add_argument("--shared-dir", type=Path, default=DEFAULT_SHARED_DIR)
 
+    reason_command = commands.add_parser("reason")
+    reason_command.add_argument("--lease-id", required=True)
+    reason_command.add_argument("--shared-dir", type=Path, default=DEFAULT_SHARED_DIR)
+
     cleanup = commands.add_parser("cleanup")
     cleanup.add_argument("--lease-id", required=True)
     cleanup.add_argument(
@@ -1653,6 +1687,12 @@ def main() -> int:
             )
         elif args.command == "status":
             print(lease_status(lease_id=args.lease_id, shared_dir=args.shared_dir))
+        elif args.command == "reason":
+            print(
+                lease_failure_reason(
+                    lease_id=args.lease_id, shared_dir=args.shared_dir
+                )
+            )
         else:
             cleanup_lease(
                 lease_id=args.lease_id,

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -248,3 +248,43 @@ class WorkflowControlsTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class AuthCanaryDiagnosticsTests(unittest.TestCase):
+    """The guardian's reason has to reach the log, or the job is undiagnosable.
+
+    For a fortnight the job reported "The VPS guardian did not publish a canary
+    plan" while the guardian had in fact run, failed its preflight, and written
+    the reason to its status file. The workflow read that status, took the
+    branch for a timeout, and threw the diagnosis away.
+    """
+
+    def test_the_guardian_records_why_it_failed(self) -> None:
+        guardian = read_repo_file("deploy/run-production-auth-canary.py")
+
+        self.assertIn('status_payload["reason"]', guardian)
+        self.assertIn("def lease_failure_reason(", guardian)
+        self.assertIn('commands.add_parser("reason")', guardian)
+        # Only a message this file wrote: anything else contributes its type,
+        # because a traceback can carry DATABASE_URL.
+        self.assertIn("if isinstance(reported, AuthCanaryError)", guardian)
+        self.assertIn("type(reported).__name__", guardian)
+
+    def test_the_workflow_reports_a_failure_as_a_failure_not_as_a_timeout(self) -> None:
+        workflow = read_repo_file(".github/workflows/production-canary.yml")
+
+        self.assertIn("The VPS guardian failed before publishing a plan", workflow)
+        self.assertIn("did not publish a canary plan before its deadline", workflow)
+        self.assertIn('"${REMOTE_CANARY_PATH}" reason --lease-id', workflow)
+        # `set -u` is on and the loop may break on its first iteration.
+        self.assertLess(
+            workflow.index("guardian_status=running\n          for _ in $(seq 1 60)"),
+            workflow.index('"${REMOTE_CANARY_PATH}" reason --lease-id'),
+        )
+
+    def test_the_guardian_stderr_stays_closed(self) -> None:
+        """The reason travels through the status file, never through a traceback."""
+
+        workflow = read_repo_file(".github/workflows/production-canary.yml")
+
+        self.assertIn("2>/dev/null", workflow)


### PR DESCRIPTION
The two issues left open after the live audit.

## 1. `/api/films/filmographies` took 12 seconds

Every other Films panel answers in well under a second. TMDB buries one or two directors in a `credits.crew` list that routinely runs past two hundred people, and the query selected the whole list — **once per holder**, so a film six profiles hold shipped its crew six times.

Measured against a local PostgreSQL seeded to production's shape (3,705 profile-film rows over 2,163 films, 2,080 enriched, 20 MB of enrichment):

| | |
|---|---|
| whole crew, per profile-film (today) | **777 ms** |
| deduped to distinct films, whole crew | 395 ms |
| director names by JSON path in the DB | 100 ms |
| **both** | **57 ms** |

End to end through the builder: **868 ms → 61 ms**, back in line with its siblings (keywords 36, runtime 11, atlas 14, collections 18).

The answer is unchanged — identical membership and film counts across all 400 directors and 15 collections, verified by running the old and new implementations against the same database.

### Two bugs that fell out of it

- **The average rating was whichever holder came back first.** Both panels deduped by film in Python and kept the first row's rating, discarding the rest, so the number depended on row order. It is the selection's mean now. The new test pins it: two holders rate the same films 5.0 and 3.0, so a result of 4.0 can only come from averaging.
- **Ties were broken by row order**, so two identical refreshes could render the same panel in a different order. Name breaks the tie.

### Why there is a new PostgreSQL test file

`test_library_sections.py` builds its fixtures on SQLite, so neither dialect-specific expression in `services/films.py` is ever executed there. My first attempt at this jsonpath failed on a real server with `UndefinedFunction: jsonb_path_query_array(jsonb, character varying)` — the argument needs a `jsonpath` cast — while every local test passed. `test_films_postgres.py` runs the real queries against the database that serves them, and a guard fails if the bare crew column is ever selected again. It reuses the migration suite's loopback-and-name check, because it creates and drops a schema.

## 2. The authenticated canary reported the wrong failure

It printed `The VPS guardian did not publish a canary plan`. The guardian had in fact run, failed its preflight, and written the reason into the status file the workflow was already polling — the workflow took the timeout branch and discarded it.

The step lasted 6 seconds; a real timeout is ~2.5 minutes. That is why this job has been undiagnosable.

The guardian now records the reason and the workflow prints it. **Its stderr stays closed on purpose** — a traceback can carry `DATABASE_URL` — so only a fixed message written in that file is forwarded, and anything else contributes its exception type alone.

This does not repair the underlying condition, which is on the production side. It makes it possible to see what that condition is on the next run.

Also correcting the record: this broke on **2026-08-02**, at `803b7d2`, which is an ancestor of the pre-redesign tip `a0b873a`. Neither the workflow nor the guardian script has changed since 07-31. Not a redesign regression.

## Tests

Run the three commands CI runs, against a real PostgreSQL:

- `8 passed` migrations
- `706 passed` backend (including 6 new PostgreSQL Films tests)
- `118 passed` deploy (including 3 new canary-diagnostics tests)
- `824 passed` on the default SQLite path

🤖 Generated with [Claude Code](https://claude.com/claude-code)