### PR TITLE
Give the failures outside a panel somewhere to land

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -24,3 +24,6 @@ yarn-error.log*
 
 # clerk configuration (can include secrets)
 /.clerk/
+
+# Clerk instance config dumps pulled while debugging the auth canary — never commit
+clerkenv.json

--- a/frontend/src/app/error.tsx
+++ b/frontend/src/app/error.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * The boundary above every route. Each panel already catches its own query
+ * errors and degrades alone — this exists for everything outside a panel: a
+ * throw in a layout, a shell component, a hook. Without it, that class of
+ * error unmounted the whole tree to a blank page, which is the failure mode
+ * this product is least allowed to have: a blank page carries no caveat.
+ */
+export default function RouteError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+        background: 'var(--bg, #101014)',
+        color: 'var(--ink, #e8e6e3)',
+        fontFamily: 'ui-monospace, monospace',
+        padding: '24px',
+      }}
+    >
+      <div style={{ maxWidth: '480px' }}>
+        <p style={{ margin: 0, fontSize: '11px', letterSpacing: '0.08em', opacity: 0.6 }}>
+          ▸ SOMETHING OUTSIDE A PANEL FAILED
+        </p>
+        <h1 style={{ margin: '8px 0 0', fontSize: '15px', fontWeight: 600 }}>
+          This section could not render
+        </h1>
+        <p style={{ margin: '10px 0 0', fontSize: '12.5px', lineHeight: 1.6, opacity: 0.8 }}>
+          A single panel failing degrades alone; this was something structural. Nothing about your
+          data changed — the store is append-only, and a render error writes nothing.
+          {error.digest ? ` Reference: ${error.digest}.` : ''}
+        </p>
+        <button
+          type="button"
+          onClick={reset}
+          style={{
+            marginTop: '16px',
+            padding: '7px 14px',
+            fontSize: '11px',
+            letterSpacing: '0.06em',
+            background: 'transparent',
+            color: 'inherit',
+            border: '1px solid currentColor',
+            cursor: 'pointer',
+          }}
+        >
+          TRY AGAIN
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/global-error.tsx
+++ b/frontend/src/app/global-error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * Last resort: a throw in the root layout itself, where error.tsx cannot
+ * mount. Must render its own <html> because nothing else survived.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          background: '#101014',
+          color: '#e8e6e3',
+          fontFamily: 'ui-monospace, monospace',
+        }}
+      >
+        <div style={{ maxWidth: '480px', padding: '24px' }}>
+          <h1 style={{ margin: 0, fontSize: '15px', fontWeight: 600 }}>Spyboxd could not start</h1>
+          <p style={{ margin: '10px 0 0', fontSize: '12.5px', lineHeight: 1.6, opacity: 0.8 }}>
+            The application shell itself failed to render. Nothing about your data changed.
+            {error.digest ? ` Reference: ${error.digest}.` : ''}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              marginTop: '16px',
+              padding: '7px 14px',
+              fontSize: '11px',
+              background: 'transparent',
+              color: 'inherit',
+              border: '1px solid currentColor',
+              cursor: 'pointer',
+            }}
+          >
+            RELOAD
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+
+/**
+ * Signed-out traffic never sees this — the middleware bounces unknown paths to
+ * sign-in with everything else. A signed-in user with a stale bookmark does,
+ * and "this page does not exist" is a different fact from "you cannot see
+ * this", so it is stated rather than left to a blank default.
+ */
+export default function NotFound() {
+  return (
+    <main
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+        background: 'var(--bg, #101014)',
+        color: 'var(--ink, #e8e6e3)',
+        fontFamily: 'ui-monospace, monospace',
+        padding: '24px',
+      }}
+    >
+      <div style={{ maxWidth: '480px' }}>
+        <p style={{ margin: 0, fontSize: '11px', letterSpacing: '0.08em', opacity: 0.6 }}>
+          ▸ 404
+        </p>
+        <h1 style={{ margin: '8px 0 0', fontSize: '15px', fontWeight: 600 }}>
+          No page lives at this address
+        </h1>
+        <p style={{ margin: '10px 0 0', fontSize: '12.5px', lineHeight: 1.6, opacity: 0.8 }}>
+          The six sections are Overview, Overlaps, People, Tonight, Films and Data. The
+          pre-redesign paths all redirect, so a link that lands here never existed.
+        </p>
+        <p style={{ marginTop: '16px' }}>
+          <Link href="/overview" style={{ color: 'inherit', fontSize: '11px', letterSpacing: '0.06em' }}>
+            GO TO OVERVIEW →
+          </Link>
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,6 +6,12 @@ const api = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  // A hung endpoint used to spin a panel's skeleton until nginx cut the
+  // connection at 60-120s — the one failure the per-panel error path could
+  // never reach, because nothing client-side ever gave up. 30s clears the
+  // slowest healthy endpoint we have measured by a wide margin; anything past
+  // it is an outage, and an outage should render as one.
+  timeout: 30_000,
 });
 
 type TokenProvider = () => Promise<string | null>;


### PR DESCRIPTION
From the end-to-end audit: the error path is complete inside a panel and absent everywhere else.

- **No error boundary of any kind existed** — zero `error.tsx`, `global-error.tsx`, `not-found.tsx`, zero `ErrorBoundary` in `src/`. Every panel degrades alone by design, but a throw in a layout, shell or hook unmounted the entire tree to a blank page. A blank page is the failure this product is least allowed to have: it carries no caveat. All three boundaries exist now, styled to the terminal, each stating that data was not touched (the store is append-only; a render error writes nothing).
- **The axios client had no timeout**, so a hung endpoint spun a panel skeleton until nginx cut the connection at 60–120s — the one failure the per-panel error path structurally could not reach, because nothing client-side ever gave up. `timeout: 30_000` turns a hang into the error state the panels already know how to render, with a wide margin over the slowest healthy endpoint measured (4.7s).
- **`frontend/clerkenv.json` is now gitignored** — a Clerk instance-config dump pulled while debugging the auth canary was sitting untracked and nothing prevented `git add -A` from committing it. (The file itself carries no secret values; this is hygiene.)

## Tests
- `272 passed` Playwright (`CI=1`, both projects)
- `tsc --noEmit` and `eslint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)