### PR TITLE
Redact secret values instead of dropping the lines that name them

### DIFF
--- a/deploy/release.sh
+++ b/deploy/release.sh
@@ -1156,9 +1156,17 @@ describe_health_failure() {
             sleep 1
             kill "${server_pid}" 2>/dev/null || true
         ) || true
-        log "DIAGNOSTIC one-shot frontend stderr follows" >&2
-        grep -aiv -e 'key' -e 'secret' -e 'token' "${oneshot_log}" 2>/dev/null \
-            | tail -n 40 | sed 's/^/[oneshot] /' >&2 || true
+        log "DIAGNOSTIC one-shot frontend output follows" >&2
+        # Redact secret VALUES but keep the lines: the first filter dropped any
+        # line containing "key", which is precisely the word a Clerk
+        # configuration error uses, so the diagnosis censored itself. Values
+        # have recognisable shapes; messages naming them are the evidence.
+        sed -E \
+            -e 's/(sk|pk)_(live|test)_[A-Za-z0-9+/=_-]+/\1_\2_REDACTED/g' \
+            -e 's/(Bearer )[A-Za-z0-9._~+/=-]+/\1REDACTED/g' \
+            "${oneshot_log}" 2>/dev/null \
+            | { head -n 30; echo '[...]'; tail -n 50; } \
+            | sed 's/^/[oneshot] /' >&2 || true
         rm -f "${oneshot_log}"
     fi
 }


### PR DESCRIPTION
Diagnostics v2 (#138) worked — it captured the failing frontend's stderr — but the sanitiser dropped every line containing "key", "secret" or "token", and a Clerk misconfiguration error contains the word "key" by definition. What survived was only a downstream `AggregateError: connect ECONNREFUSED localhost:<own port>`, which is a symptom (Next 16 failing to reach its own proxy worker), not the cause.

Values are now redacted by shape (`sk_live_…` → `sk_live_REDACTED`) and the lines naming them survive. Head of the log is captured too — a boot error precedes the request noise the tail catches.

`bash -n` clean; `118 passed` in `deploy/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)