### PR TITLE
Rebuild the production tree from the lockfile instead of pruning past it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,31 @@ jobs:
         run: |
           npm ci --no-audit --no-fund
           npm run build
-          npm prune --omit=dev --no-audit --no-fund --package-lock=false
+
+          # A second `npm ci`, not `npm prune`: prune with --package-lock=false
+          # re-resolves every semver range against the registry, so the bundle
+          # silently shipped whatever Next had published that day rather than
+          # the version the lockfile pins and CI tested. Next 16.3.0 landed 14
+          # minutes after the last good bundle and broke every deploy for a
+          # day; nothing in this repository had changed. `npm ci --omit=dev`
+          # rebuilds node_modules exactly from the lock, production-only.
+          npm ci --omit=dev --no-audit --no-fund
+
+          # The runtime tree must be the tree the lockfile describes. This
+          # assertion exists so the next silent drift fails the build here,
+          # with a diff in hand, rather than failing health verification on
+          # the production host with nothing in the log.
+          node -e '
+            const path = require("node:path");
+            const locked = require(path.resolve("package-lock.json"))
+              .packages["node_modules/next"].version;
+            const installed = require(path.resolve("node_modules/next/package.json")).version;
+            if (locked !== installed) {
+              console.error(`next drifted from the lockfile: locked ${locked}, installed ${installed}`);
+              process.exit(1);
+            }
+            console.log(`next ${installed} matches the lockfile`);
+          '
           rm -rf -- .next/cache
 
           # Next.js owns this tracked type shim and may rewrite it while building.


### PR DESCRIPTION
Root cause of every failed deploy today, found by the diagnostics shipped in #137–#139.

## What the production host finally said

```
▲ Next.js 16.3.0
Failed to proxy http://localhost:3999/sign-in AggregateError: ECONNREFUSED
```

The repo pins **Next 16.2.12**. CI's Playwright suite tests 16.2.12. Local runs serve 16.2.12. The deployed bundle was running **16.3.0**, on which the Next proxy worker fails on the VPS — every request answers 500, health verification fails, and the deploy rolls back. Production has been safely pinned on `fd80731` by that rollback the whole time.

## How an unlocked Next got into a locked bundle

The bundle job ran:

```
npm ci                                     # installs the locked 16.2.12
npm run build                              # builds against it
npm prune --omit=dev --package-lock=false  # re-resolves ^16.2.12 → 16.3.0
```

`npm prune` with `--package-lock=false` is a full reify against the registry: it re-resolves every semver range fresh. **Next 16.3.0 published at 2026-08-03T20:34Z — fourteen minutes after the last good bundle built at 20:20Z.** Every bundle since shipped an untested Next. Nothing in this repository had changed, which is why no diff explained it.

Reproduced locally from a clean copy of `package.json` + `package-lock.json`:

```
after npm ci:    16.2.12
after npm prune: 16.3.0
```

## The fix

- The prune becomes a second **`npm ci --omit=dev`** — node_modules rebuilt exactly from the lock, production-only. (The runtime needs no devDependency: the VPS one-shot showed `next.config.ts` executing on the pruned tree.)
- An **assertion** that the installed Next equals the lockfile's, so the next silent drift fails the build in CI with a diff in hand instead of failing health verification on the production host with nothing in the log.

This also unblocks #135 (the coverage-panel fix) and #136 (error boundaries + client timeout), which have been merged but rolled back all day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)