### PR TITLE
Draw every pair in the co-watch matrix, not the leaderboard's six

### DIFF
--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -39,7 +39,7 @@ CORRELATION_PRIOR_FILMS = 8
 
 RATING_MIN = 0.0
 RATING_MAX = 5.0
-DASHBOARD_SNAPSHOT_FORMAT_VERSION = 3
+DASHBOARD_SNAPSHOT_FORMAT_VERSION = 4
 DASHBOARD_ACTIVITY_MONTHS = 12
 
 
@@ -489,6 +489,7 @@ def _merge_event_source_timing(
     timing: Dict[str, Any],
     *,
     limit: int,
+    pair_limit: Optional[int] = None,
     gap_days: Optional[int],
 ) -> Dict[str, Any]:
     """Replace only timing fields while preserving legacy rating/title analysis."""
@@ -640,7 +641,7 @@ def _merge_event_source_timing(
     baseline["most_shared_titles"] = baseline.get("most_shared_titles", [])[:limit]
     baseline["consensus_hits"] = baseline.get("consensus_hits", [])[:limit]
     baseline["divisive_titles"] = baseline.get("divisive_titles", [])[:limit]
-    baseline["aligned_pairs"] = aligned_pairs[:limit]
+    baseline["aligned_pairs"] = aligned_pairs[:pair_limit] if pair_limit is not None else aligned_pairs
     baseline["follow_paths"] = follow_path_list[:limit]
     if gap_days is not None:
         baseline["gap_events"] = gap_events[:limit]
@@ -1476,8 +1477,18 @@ class AnalyticsRepository:
         limit: int = 8,
         gap_days: Optional[int] = None,
         event_source: str = "ratings",
+        pair_limit: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Build shared-profile correlation signals for dashboard and group analysis views."""
+        """Build shared-profile correlation signals for dashboard and group analysis views.
+
+        ``limit`` truncates the event and title leaderboards, which are top-N
+        lists by design. ``aligned_pairs`` is governed by ``pair_limit``
+        instead, and ``None`` means every pair: the Overview co-watch matrix
+        draws a cell for each pair in the selection, and when this list was cut
+        to the leaderboard's six, the other 184 cells rendered the dash that
+        means "no shared film" — for pairs sharing hundreds. A truncated list
+        and an empty cell must not be allowed to look alike.
+        """
         if gap_days is not None and not 0 <= gap_days <= 7:
             raise ValueError("gap_days must be between 0 and 7")
         if event_source not in {"ratings", "events"}:
@@ -1512,6 +1523,7 @@ class AnalyticsRepository:
                 baseline,
                 timing,
                 limit=limit,
+                pair_limit=pair_limit,
                 gap_days=gap_days,
             )
 
@@ -1917,7 +1929,7 @@ class AnalyticsRepository:
             "most_shared_titles": shared_titles[:limit],
             "consensus_hits": consensus_candidates[:limit],
             "divisive_titles": divisive_candidates[:limit],
-            "aligned_pairs": aligned_pairs[:limit],
+            "aligned_pairs": aligned_pairs[:pair_limit] if pair_limit is not None else aligned_pairs,
             "follow_paths": follow_path_list[:limit],
         }
         if gap_days is not None:

--- a/backend/tests/test_spy_signal_event_source.py
+++ b/backend/tests/test_spy_signal_event_source.py
@@ -354,6 +354,65 @@ class EventSourceMergeTests(unittest.TestCase):
         self.assertEqual(aligned_pair["same_day_count"], 1)
         self.assertNotIn("event_source", result)
 
+    def test_every_pair_survives_the_leaderboard_limit(self):
+        """`limit` is for top-N lists; `aligned_pairs` feeds a matrix.
+
+        The Overview co-watch grid draws one cell per pair in the selection.
+        When aligned_pairs was cut to the leaderboard's six, the other 184
+        cells of a twenty-profile grid rendered the dash that means "no shared
+        film" — for pairs sharing hundreds. Pair leaderboard and matrix then
+        contradicted each other about the same pair.
+        """
+
+        def pair(left: str, right: str, shared: int) -> dict:
+            return {
+                "profiles": [left, right],
+                "shared_titles": shared,
+                "rating_overlap_count": 2,
+                "rating_correlation": 0.5,
+                "average_rating_gap": 0.5,
+                "same_day_count": 0,
+                "one_day_gap_count": 0,
+                "tight_window_count": 0,
+                "alignment_score": 50.0,
+                "sample_titles": [],
+            }
+
+        baseline = {
+            "summary": {
+                "profiles_analyzed": 3,
+                "profiles_with_diary_dates": 3,
+                "shared_titles": 0,
+                "same_day_events": 0,
+                "one_day_gap_events": 0,
+                "same_day_pair_hits": 0,
+                "one_day_gap_pair_hits": 0,
+                "strongest_alignment_pair": None,
+            },
+            "same_day_events": [],
+            "one_day_gap_events": [],
+            "most_shared_titles": [{"title": f"t{i}"} for i in range(5)],
+            "consensus_hits": [],
+            "divisive_titles": [],
+            "aligned_pairs": [pair("a", "b", 400), pair("a", "c", 300), pair("b", "c", 200)],
+            "follow_paths": [],
+        }
+        timing = _calculate_event_source_timing([], gap_days=None)
+
+        result = _merge_event_source_timing(baseline, timing, limit=1, gap_days=None)
+
+        # The leaderboard lists honour the limit; the pair list does not.
+        self.assertEqual(len(result["most_shared_titles"]), 1)
+        self.assertEqual(
+            sorted(tuple(entry["profiles"]) for entry in result["aligned_pairs"]),
+            [("a", "b"), ("a", "c"), ("b", "c")],
+        )
+
+        capped = _merge_event_source_timing(
+            deepcopy(baseline), timing, limit=1, gap_days=None, pair_limit=2
+        )
+        self.assertEqual(len(capped["aligned_pairs"]), 2)
+
     def test_repository_rejects_unknown_event_source_before_querying(self):
         repository = AnalyticsRepository(db=None)
 

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -243,7 +243,7 @@ export default function OverviewTab() {
         blurb="Above the diagonal: films both have seen. Below it: how far apart their stars land on those same films. One grid answers both questions people actually ask."
         caveat={
           closest
-            ? `${closest.profiles.join(' and ')} are the closest pair here: ${closest.shared_titles.toLocaleString()} shared films, agreeing within ${(closest.average_rating_gap ?? 0).toFixed(2)} of a star.`
+            ? `${closest.profiles.join(' and ')} are the closest pair here: ${closest.shared_titles.toLocaleString()} shared films, agreeing within ${(closest.average_rating_gap ?? 0).toFixed(2)} of a star. Every pair in the selection is drawn — a dash above the diagonal is a pair with no shared film, and below it a pair with too few shared ratings to measure.`
             : 'A pair needs shared rated films before either half of this grid can be filled.'
         }
       >


### PR DESCRIPTION
Reported from the live site: the Overview "Who watches with whom" grid — 20×20, 190 pairs — rendered six filled cells and 184 dashes. A dash in that grid means *no shared film*, and it was being shown for pairs the Pair leaderboard credits with sharing 597 films. Two panels contradicting each other about the same pair, in the flagship panel.

**Cause:** `/api/dashboard/analytics` calls `get_group_correlation_metrics(limit=group_limit)` with `group_limit=6`, and `aligned_pairs` was truncated by the same `limit` that sizes the event/title leaderboards. The leaderboards are top-N lists by design; the matrix is not — a truncated list and an empty cell must not look alike.

**Fix:**
- `aligned_pairs` gets its own `pair_limit`, default `None` = every pair, threaded through both the legacy and event-source paths. The leaderboards keep their limit.
- `DASHBOARD_SNAPSHOT_FORMAT_VERSION` 3 → 4, so the cached global snapshot rebuilds with the full list on first request after deploy.
- The panel caveat now states what a dash means on each side of the diagonal (no shared film / too few shared ratings to measure), which with the full list is finally true.

Payload cost: ~190 pair entries for 20 profiles — a few tens of KB on an endpoint already carrying the activity series. Consumers of `aligned_pairs` (pair leaderboard, closest-pair rows) all slice client-side, verified.

## Tests
- New: `test_every_pair_survives_the_leaderboard_limit` — leaderboards honour `limit=1` while all three pairs survive, and an explicit `pair_limit` still caps.
- `701 passed` backend, `118 passed` deploy, `272 passed` Playwright (`CI=1`), `tsc`/`eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)