### PR TITLE
Make twenty-nine panels tell the truth about their denominators

### DIFF
--- a/backend/api/routes/member_archive.py
+++ b/backend/api/routes/member_archive.py
@@ -1,6 +1,7 @@
 """Export-only member surfaces: liked content, comments, and lost history."""
 from __future__ import annotations
 
+import re
 from html.parser import HTMLParser
 from typing import List, Optional
 
@@ -11,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from auth import ClerkUser, get_current_user
 from database.connection import get_db
-from database.models import LostEntry, MemberComment, MemberContentLike
+from database.models import LostEntry, MemberComment, MemberContentLike, Movie, ProfileFilm
 from services.profile_access import require_profile_access
 
 
@@ -134,6 +135,25 @@ def get_member_archive(
         .all()
     )
 
+    # Every slug in the subject's own library, so "liked but never seen" can be
+    # decided against all of it. The frontend used to check the like against
+    # the ten most recent watches — the only title list it had — and called
+    # everything older "no watch record".
+    watched_slugs = set()
+    for (letterboxd_url,) in (
+        db.query(Movie.letterboxd_url)
+        .join(ProfileFilm, ProfileFilm.movie_id == Movie.id)
+        .filter(
+            ProfileFilm.profile_id == profile.id,
+            ProfileFilm.removed_at.is_(None),
+            Movie.letterboxd_url.isnot(None),
+        )
+        .all()
+    ):
+        match = re.search(r"/film/([^/]+)", letterboxd_url or "")
+        if match:
+            watched_slugs.add(match.group(1).casefold())
+
     return {
         "username": profile.username,
         "liked_reviews": [
@@ -142,6 +162,13 @@ def get_member_archive(
                 "liked_date": _iso(like.liked_date),
                 "author": like.target_username,
                 "film_slug": like.target_film_slug,
+                # Against the whole library. None when the like's film is
+                # unresolved, which is "cannot say", not "unseen".
+                "watched": (
+                    like.target_film_slug.casefold() in watched_slugs
+                    if like.target_film_slug
+                    else None
+                ),
             }
             for like in likes
             if like.content_type == "review"

--- a/backend/main.py
+++ b/backend/main.py
@@ -527,7 +527,14 @@ def _serialize_profiles(db: Session, profiles) -> dict:
     if active:
         first_logged = dict(
             db.query(WatchEvent.profile_id, func.min(WatchEvent.watched_date))
-            .filter(WatchEvent.profile_id.in_([profile.id for profile in active]))
+            .filter(
+                WatchEvent.profile_id.in_([profile.id for profile in active]),
+                # Active events only. The Member card's "First logged" already
+                # excludes superseded rows, and the roster's SINCE read the
+                # same fact without the filter — so a re-imported profile
+                # could carry two different first-logged years on two panels.
+                WatchEvent.superseded_at.is_(None),
+            )
             .group_by(WatchEvent.profile_id)
             .all()
         )

--- a/backend/services/data_health.py
+++ b/backend/services/data_health.py
@@ -18,6 +18,8 @@ from typing import Any, Dict, List, Optional, Sequence
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from services.import_contracts import IMPORTER_VERSION
+
 from database.models import (
     LostEntry,
     MemberComment,
@@ -237,8 +239,10 @@ def build_importers(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
     """
 
     latest = _latest_syncs(db, [profile.id for profile in profiles])
-    versions = {sync.importer_version for sync in latest.values()}
-    current = max(versions) if versions else None
+    # The importer that ships with this deployment, not the newest version seen
+    # in the selection: derived from the selection's own syncs, a set of
+    # profiles ALL last read by an old importer reported itself "Up to date".
+    current = IMPORTER_VERSION
 
     entries = []
     for profile in profiles:
@@ -313,7 +317,7 @@ def build_counts(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
         "profiles": entries,
         "total_gap": total_gap,
         "caveat": (
-            f"{total_gap:,} films across the selection that Letterboxd reports and we do not hold. "
+            f"{total_gap:,} film{'' if total_gap == 1 else 's'} across the selection that Letterboxd reports and we do not hold. "
             "Mostly private diary entries and pages that stopped answering mid-read. A profile "
             "whose header was never fetched has no stated total, which is not a gap of zero."
             if measured

--- a/backend/services/films.py
+++ b/backend/services/films.py
@@ -545,7 +545,10 @@ def build_decade_divergence(db: Session, profiles: Sequence[Profile]) -> Dict[st
         "decades": decades,
         "measured": sum(entry["films"] for entry in decades),
         "caveat": (
-            f"Measured over {len(rows):,} rated films that carry Letterboxd's own crowd average. "
+            # Rating rows, not distinct films: a film three people rated counts three
+            # times, because each contributes its own delta to the lean.
+            f"Measured over {len(rows):,} rating{'' if len(rows) == 1 else 's'} across the selection on films that "
+            "carry Letterboxd's own crowd average. "
             "Decades with fewer than five such films are dropped rather than shown as a lean built "
             "from two opinions."
         ),
@@ -561,7 +564,14 @@ def build_queue_age(db: Session, profiles: Sequence[Profile], *, limit: int = 12
 
     profile_ids = [profile.id for profile in profiles]
     if not profile_ids:
-        return {"films": [], "dated": 0, "total": 0, "caveat": "No profiles selected."}
+        return {
+            "films": [],
+            "dated": 0,
+            "total": 0,
+            "distinct_queued": 0,
+            "rated_by_selection": 0,
+            "caveat": "No profiles selected.",
+        }
 
     rows = (
         db.query(WatchlistItem, Movie, Profile.username)
@@ -570,6 +580,23 @@ def build_queue_age(db: Session, profiles: Sequence[Profile], *, limit: int = 12
         .filter(WatchlistItem.profile_id.in_(profile_ids), WatchlistItem.removed_at.is_(None))
         .all()
     )
+
+    # Selection-wide conversion figures. The Taste map panel used to take these
+    # from the FIRST selected profile's watchlist insights and present them as
+    # the group's — every sibling panel on that tab computes over the whole
+    # selection.
+    distinct_queued_ids = {item.movie_id for item, _movie, _username in rows}
+    rated_by_selection = (
+        db.query(func.count(func.distinct(ProfileFilm.movie_id)))
+        .filter(
+            ProfileFilm.movie_id.in_(distinct_queued_ids),
+            ProfileFilm.profile_id.in_(profile_ids),
+            ProfileFilm.rating.isnot(None),
+            ProfileFilm.removed_at.is_(None),
+        )
+        .scalar()
+        or 0
+    ) if distinct_queued_ids else 0
 
     dated = [(item, movie, username) for item, movie, username in rows if item.added_date]
     dated.sort(key=lambda entry: entry[0].added_date)
@@ -591,6 +618,8 @@ def build_queue_age(db: Session, profiles: Sequence[Profile], *, limit: int = 12
         "films": films,
         "dated": len(dated),
         "total": len(rows),
+        "distinct_queued": len(distinct_queued_ids),
+        "rated_by_selection": rated_by_selection,
         "profiles_with_added_dates": with_dates,
         "caveat": (
             f"{len(with_dates)} of {len(profiles)} selected profiles carry an added date, so "
@@ -686,7 +715,7 @@ def build_metadata_gaps(db: Session, profiles: Sequence[Profile], *, limit: int 
         "count": len(films),
         "coverage": coverage,
         "caveat": (
-            f"{len(films):,} distinct films carry no enrichment at all. Ordered by how many "
+            f"{len(films):,} distinct film{'s carry' if len(films) != 1 else ' carries'} no enrichment at all. Ordered by how many "
             "profiles hold each one rather than alphabetically, because that is what decides how "
             "often a blank appears on screen."
         ),

--- a/backend/services/first_watches.py
+++ b/backend/services/first_watches.py
@@ -101,11 +101,20 @@ def build_first_watch_order(db: Session, profiles: Sequence[Profile]) -> Dict[st
         "profiles": entries,
         "undated_pairs": undated_pairs,
         "caveat": (
-            f"{undated_pairs:,} shared-film pairings have no first-watch date on one or both sides "
-            "and are excluded rather than assumed late. That is why the shares below do not sum to "
-            "anything meaningful."
-            if undated_pairs
-            else "Every shared film in the selection carries a first-watch date on both sides."
+            (
+                f"{undated_pairs:,} shared-film pairings have no first-watch date on one or both "
+                "sides and are excluded rather than assumed late. That is why the shares below do "
+                "not sum to anything meaningful."
+                if undated_pairs
+                else "Every shared film in the selection carries a first-watch date on both sides."
+            )
+            # Two panels answer "who gets there first" from two populations,
+            # and unsaid, they read as the same measure disagreeing: this one
+            # spans every dated shared film, however far apart the watches;
+            # Head-to-head's lead reads only films watched days apart.
+            + " Measured over every dated shared film, years apart included — Head-to-head's"
+            " \"gets there first\" reads only films watched within days of each other, so the"
+            " two can differ without either being wrong."
         ),
     }
 
@@ -157,6 +166,11 @@ def build_shared_firsts(
 
     results.sort(key=lambda item: item["date"], reverse=True)
 
+    # Distinct films, not (film, day) rows: a film two pairs first-watched on
+    # two different days is one qualifying film shown twice, and the caveat
+    # counted it twice.
+    distinct_films = len({(entry["title"], entry["year"]) for entry in results})
+
     dated_profiles = sorted(
         {
             names[profile_id]
@@ -173,6 +187,6 @@ def build_shared_firsts(
         "caveat": (
             f"Needs a first-watch date on both sides, so this only fires for the "
             f"{len(dated_profiles)} of {len(names)} selected profiles that have one. "
-            f"{len(results)} qualifying film{'s' if len(results) != 1 else ''} in total."
+            f"{distinct_films} qualifying film{'s' if distinct_films != 1 else ''} in total."
         ),
     }

--- a/backend/services/group_activity.py
+++ b/backend/services/group_activity.py
@@ -112,7 +112,12 @@ def build_marathons(
             }
         )
 
-    marathons.sort(key=lambda item: (item["date"], -item["films"]), reverse=True)
+    # Longest first, ties newest first — and only then the cut. Sorted by
+    # recency and truncated, the panel titled "longest marathon days" could be
+    # missing the longest days entirely: it showed the biggest of the twelve
+    # most recent, which is a different claim from the one in its title.
+    marathons.sort(key=lambda item: item["date"], reverse=True)
+    marathons.sort(key=lambda item: item["films"], reverse=True)
 
     return {
         "marathons": marathons[:limit],

--- a/backend/services/insights.py
+++ b/backend/services/insights.py
@@ -3670,6 +3670,10 @@ class InsightsService:
                 item["movie"]["title"],
             )
         )
+        # Counted before the cut: the shortlist's caveat promises the reader
+        # the count is honest about truncation, and a total taken after the
+        # slice can only ever equal the table it annotates.
+        ranked_total = len(recommendations)
         recommendations = recommendations[:limit]
 
         returned_movie_ids = {
@@ -3881,7 +3885,7 @@ class InsightsService:
             "available_lists": available_lists,
             "coverage": coverage,
             "summary": {
-                "candidates": len(recommendations),
+                "candidates": ranked_total,
                 "on_every_watchlist": sum(
                     len(item["on_watchlist_by"]) == len(profiles) for item in recommendations
                 ),

--- a/backend/services/people.py
+++ b/backend/services/people.py
@@ -153,7 +153,7 @@ def build_silent_fives(db: Session, profile: Profile, *, limit: int = 12) -> Dic
             for film, movie in rows[:limit]
         ],
         "caveat": (
-            f"{len(rows):,} of their {top_rated:,} five-star ratings carry no review."
+            f"{len(rows):,} of their {top_rated:,} five-star rating{'s carry' if top_rated != 1 else ' carries'} no review."
             + (
                 f" Against a {round(review_rate * 100)}% review rate overall, silence at the top of "
                 "the scale is the pattern rather than the exception."

--- a/backend/services/tonight.py
+++ b/backend/services/tonight.py
@@ -418,7 +418,7 @@ def build_availability(db: Session, profiles: Sequence[Profile], *, region: str 
     region_read = any(entry["region"] == region for entry in regions)
     if region_read:
         scope = (
-            f"{len(films)} queued films are carried by a subscription service in {region} as of "
+            f"{len(films)} queued film{'s are' if len(films) != 1 else ' is'} carried by a subscription service in {region} as of "
             "the last reading."
         )
     else:

--- a/backend/tests/test_group_activity.py
+++ b/backend/tests/test_group_activity.py
@@ -303,3 +303,22 @@ def test_a_soft_removed_film_is_history_not_a_current_watch(database: Session) -
     database.commit()
 
     assert build_shared_firsts(database, [left, right])["count"] == 0
+
+
+def test_longest_marathon_days_are_longest_not_most_recent(database: Session) -> None:
+    """Sorted by recency and then cut, the panel titled "longest marathon
+    days" could be missing the longest days entirely."""
+
+    viewer = _profile(database, "viewer")
+    # An older, much bigger day, and a newer, smaller one.
+    for index in range(6):
+        _watch(database, viewer, _movie(database, f"Old {index}"), date(2024, 1, 5))
+    for index in range(3):
+        _watch(database, viewer, _movie(database, f"New {index}"), date(2026, 7, 1))
+
+    result = build_marathons(database, [viewer], limit=1)
+
+    assert result["marathons"][0]["films"] == 6
+    assert result["marathons"][0]["date"] == "2024-01-05"
+    # The count still reflects everything that qualified, not the slice.
+    assert result["count"] == 2

--- a/backend/tests/test_library_sections.py
+++ b/backend/tests/test_library_sections.py
@@ -43,6 +43,7 @@ from services.data_health import (
     build_request_latency,
     build_watch_event_freshness,
 )
+from services.first_watches import build_shared_firsts
 from services.films import (
     build_atlas,
     build_collections,
@@ -174,6 +175,21 @@ def _film(
             is_liked=liked,
             tags=[],
             watch_count=1,
+        )
+    )
+    database.commit()
+
+
+def _film_first(
+    database: Session, profile: Profile, movie: Movie, first: Optional[date]
+) -> None:
+    database.add(
+        ProfileFilm(
+            profile_id=profile.id,
+            movie_id=movie.id,
+            tags=[],
+            watch_count=1,
+            first_watched_date=first,
         )
     )
     database.commit()
@@ -641,3 +657,47 @@ def test_a_deleted_list_keeps_the_films_and_the_order(database: Session) -> None
     assert films[0]["title"] == "Recovered"
     assert films[0]["position"] == 3
     assert films[0]["list_name"] == "2023 ranked"
+
+
+def test_queue_conversion_counts_the_selection_not_the_first_profile(
+    database: Session,
+) -> None:
+    """The Taste map stats used to come from profiles[0]'s watchlist insights.
+
+    Selection-wide: distinct queued films, and how many of those at least one
+    selected profile has rated — the vouching the panel is about.
+    """
+
+    left = _profile(database, "left")
+    right = _profile(database, "right")
+    queued_only = _movie(database, "Queued Only")
+    vouched = _movie(database, "Vouched For")
+
+    _queued(database, left, queued_only, date(2026, 1, 1))
+    _queued(database, left, vouched, date(2026, 1, 2))
+    # The SECOND profile rated it — invisible to a profiles[0]-only count.
+    _film(database, right, vouched, rating=4.5)
+
+    payload = build_queue_age(database, [left, right])
+
+    assert payload["distinct_queued"] == 2
+    assert payload["rated_by_selection"] == 1
+
+
+def test_shared_firsts_caveat_counts_distinct_films(database: Session) -> None:
+    """A film shared-first by two pairs on two days is one qualifying film."""
+
+    a = _profile(database, "a")
+    b = _profile(database, "b")
+    c = _profile(database, "c")
+    d = _profile(database, "d")
+    movie = _movie(database, "Twice First")
+    _film_first(database, a, movie, date(2026, 1, 1))
+    _film_first(database, b, movie, date(2026, 1, 1))
+    _film_first(database, c, movie, date(2026, 2, 2))
+    _film_first(database, d, movie, date(2026, 2, 2))
+
+    payload = build_shared_firsts(database, [a, b, c, d])
+
+    assert len(payload["shared_firsts"]) == 2
+    assert "1 qualifying film in total" in payload["caveat"]

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -203,7 +203,22 @@ const groupSignals = {
   most_shared_titles: [sharedMovie],
   consensus_hits: [sharedMovie],
   divisive_titles: [sharedMovie],
-  aligned_pairs: [pair],
+  aligned_pairs: [
+    pair,
+    {
+      // A perfect 0.00 built on a single shared rating. Sorted raw this
+      // coincidence outranks the measured 0.30 above, which is exactly the
+      // bug the evidence floor exists to prevent — specs assert this pair
+      // never wins "closest" and its gap prints as a dash.
+      ...pair,
+      profiles: ['alpha', 'delta'],
+      shared_titles: 61,
+      rating_overlap_count: 1,
+      rating_correlation: null,
+      average_rating_gap: 0,
+      alignment_score: 41,
+    },
+  ],
   follow_paths: [],
 };
 
@@ -1528,6 +1543,8 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
           ],
           dated: 1_204,
           total: 1_619,
+          distinct_queued: 1_402,
+          rated_by_selection: 655,
           profiles_with_added_dates: chosen.slice(0, 2),
           caveat:
             '2 of 3 selected profiles carry an added date, so 1,204 of 1,619 queued entries can be aged at all. The rest are excluded rather than guessed at.',
@@ -2111,11 +2128,28 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
     if (archiveMatch) {
       return json(route, {
         username: decodeURIComponent(archiveMatch[1]),
-        liked_reviews: [],
+        liked_reviews: [
+          {
+            // watched is the SERVER's verdict against the whole library —
+            // false here so the liked-but-unseen panel stays exercised.
+            target_url: 'https://letterboxd.com/carol/film/liked-fixture-film/',
+            liked_date: '2026-06-10',
+            author: 'carol',
+            film_slug: 'liked-fixture-film',
+            watched: false,
+          },
+          {
+            target_url: 'https://letterboxd.com/carol/film/watched-fixture-film/',
+            liked_date: '2026-06-11',
+            author: 'carol',
+            film_slug: 'watched-fixture-film',
+            watched: true,
+          },
+        ],
         liked_lists: [],
         comments: [],
         lost_entries: [],
-        totals: { liked_reviews: 0, liked_lists: 0, comments: 0, lost_entries: 0 },
+        totals: { liked_reviews: 2, liked_lists: 0, comments: 0, lost_entries: 0 },
       });
     }
   }

--- a/frontend/e2e/group-pick-composition.spec.ts
+++ b/frontend/e2e/group-pick-composition.spec.ts
@@ -20,7 +20,8 @@ test('the candidate count is qualified by watchlist overlap and availability', a
   await expect(panel).toContainText('NOBODY HAS SEEN');
   await expect(panel).toContainText('STREAMING IN');
   // And the count is the length of the table, not a larger set it was cut from.
-  await expect(panel).toContainText('rather than a larger set it was cut from');
-  // And where the scan looked at more than it kept, it says how many.
-  await expect(panel).toContainText('did not clear the filters above');
+  // The fixture's summary counts six candidates against two rendered, so
+  // the truncation-aware branch must fire — the old copy claimed "never cut"
+  // against a total that could not disagree with the table.
+  await expect(panel).toContainText('6 candidates cleared the filters; the 2 below are the best fits');
 });

--- a/frontend/e2e/group-signal-names.spec.ts
+++ b/frontend/e2e/group-signal-names.spec.ts
@@ -17,7 +17,7 @@ test('group signals name who watched and who it is new to, not only how many', a
   const shortlist = page.locator('.terminal-root section', { hasText: "TONIGHT'S SHORTLIST" }).first();
   await shortlist.getByRole('link', { name: /Seen By One Fixture/ }).click();
 
-  const why = page.locator('.terminal-root section', { hasText: 'FITS' }).first();
+  const why = page.locator('.terminal-root section', { hasText: /▸ WHY .+ FITS/ }).first();
   await expect(why).toContainText('@charlie');
   await expect(why).toContainText('New to @alpha, @bravo');
 });

--- a/frontend/e2e/pair-evidence.spec.ts
+++ b/frontend/e2e/pair-evidence.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * A star-gap claim needs enough shared ratings behind it. The fixture carries
+ * two pairs: alpha+bravo agreeing within 0.30 across 35 shared ratings, and
+ * alpha+delta at a perfect 0.00 built on ONE. Sorted raw, the coincidence
+ * wins every "closest" crown — which is what production did: the closest pair
+ * on Overview rested on three shared ratings while the copy attributed the
+ * agreement to 89 shared films.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+});
+
+test('a one-rating coincidence never wins closest pair on Overview', async ({ page }) => {
+  await page.goto('/overview');
+
+  const grid = page.locator('.terminal-root section', { hasText: 'WHO WATCHES WITH WHOM' }).first();
+  // The measured pair wins, and the copy names both denominators: the ratings
+  // the gap was computed over and the films merely shared.
+  await expect(grid).toContainText('alpha and bravo are the closest pair');
+  await expect(grid).toContainText('across 35 shared ratings, on 42 shared films');
+  await expect(grid).not.toContainText('alpha and delta are the closest pair');
+});
+
+test('the tightest-pair table shows the ratings the gap rests on, not just shared films', async ({
+  page,
+}) => {
+  await page.goto('/overlaps?tab=together');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'CLOSEST PAIR · WIDEST DISAGREEMENT' })
+    .first();
+  await expect(panel).toContainText('35 of 42');
+  // The thin pair is filtered out of the ranking entirely.
+  await expect(panel).not.toContainText('@alpha + @delta');
+});
+
+test('the leaderboard dashes a gap too thin to measure instead of printing 0.00', async ({
+  page,
+}) => {
+  await page.goto('/overlaps?tab=together');
+
+  const board = page.locator('.terminal-root section', { hasText: 'PAIR LEADERBOARD' }).first();
+  // The thin pair still appears — its shared-film count is real — but its gap
+  // is a dash, not a fabricated perfect agreement.
+  await expect(board).toContainText('alpha + delta');
+  const text = await board.innerText();
+  const deltaRow = text.split('\n').slice(text.split('\n').findIndex((line) => line.includes('alpha + delta')));
+  expect(deltaRow.slice(0, 4).join(' ')).toContain('—');
+  expect(deltaRow.slice(0, 4).join(' ')).not.toContain('0.00');
+});

--- a/frontend/e2e/watchlist-downside.spec.ts
+++ b/frontend/e2e/watchlist-downside.spec.ts
@@ -16,7 +16,7 @@ test('a divisive queue film shows both ends of the crowd, not just the upside', 
 
   const panel = page
     .locator('.terminal-root section')
-    .filter({ hasText: 'THEIR QUEUE, RANKED BY THEIR CIRCLE' })
+    .filter({ hasText: 'THEIR QUEUE, RANKED BY THE TRACKED GROUP' })
     .first();
   const row = panel.locator('div').filter({ hasText: 'Divisive Queue Entry' }).last();
 
@@ -29,7 +29,7 @@ test('a broadly liked film is not given a downside note it has not earned', asyn
 
   const panel = page
     .locator('.terminal-root section')
-    .filter({ hasText: 'THEIR QUEUE, RANKED BY THEIR CIRCLE' })
+    .filter({ hasText: 'THEIR QUEUE, RANKED BY THE TRACKED GROUP' })
     .first();
   const row = panel.locator('div').filter({ hasText: 'Queued Fixture Film' }).last();
 

--- a/frontend/src/components/terminal/dates.ts
+++ b/frontend/src/components/terminal/dates.ts
@@ -1,0 +1,31 @@
+/**
+ * `new Date('2026-07-31')` is UTC midnight, so in any timezone west of
+ * Greenwich `.toLocaleDateString()` renders **30 Jul** — every date-only field
+ * in the product (watched_date, added_date, first-watch dates) was drifting a
+ * day back for a reader in the Americas, a month back when it landed on the
+ * 1st, and the calendar heat grid filed every day under the previous weekday.
+ *
+ * A date-only string names a calendar day, not an instant; parse it as one.
+ * Full timestamps are passed through to the native parser untouched.
+ */
+export function localDate(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (match) {
+    return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+  }
+  return new Date(value);
+}
+
+/** The day's own YYYY-MM-DD, from local fields — the inverse of localDate. */
+export function dateKey(value: Date): string {
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${value.getFullYear()}-${month}-${day}`;
+}
+
+export function formatDay(
+  value: string,
+  options: Intl.DateTimeFormatOptions = { day: '2-digit', month: 'short', year: 'numeric' },
+): string {
+  return localDate(value).toLocaleDateString('en-GB', options);
+}

--- a/frontend/src/components/terminal/pairEvidence.ts
+++ b/frontend/src/components/terminal/pairEvidence.ts
@@ -1,0 +1,25 @@
+import type { GroupSignalPair } from '../../services/api';
+
+/**
+ * The floor under any per-pair star-gap claim.
+ *
+ * `average_rating_gap` is measured over the films BOTH profiles rated —
+ * `rating_overlap_count` — which is routinely a tiny fraction of
+ * `shared_titles`. Sorted raw, "closest pair" was won by a pair whose 0.00
+ * agreement rested on three shared ratings (the runner-up had one), while the
+ * copy attributed the agreement to their 89 shared films. A coincidence over
+ * three data points must not outrank a measured 0.31 over three hundred.
+ *
+ * The backend's alignment_score already discounts thin overlaps with a prior;
+ * this is the same judgement for the panels that rank by the raw gap. Five
+ * matches the evidence floors used elsewhere (decade lean, silence gaps).
+ */
+export const MIN_RATED_OVERLAP = 5;
+
+/** Pairs whose star gap rests on enough shared ratings to mean something. */
+export function withRatedEvidence(pairs: GroupSignalPair[]): GroupSignalPair[] {
+  return pairs.filter(
+    (pair) =>
+      pair.average_rating_gap !== null && pair.rating_overlap_count >= MIN_RATED_OVERLAP,
+  );
+}

--- a/frontend/src/components/terminal/plural.ts
+++ b/frontend/src/components/terminal/plural.ts
@@ -1,0 +1,10 @@
+/**
+ * "1 watches", "1 days", "1 films": the product's numbers are the product, and
+ * a count that disagrees with its own noun reads as a rounding error in a UI
+ * whose whole argument is that every figure is exact. One helper, because the
+ * inline ternary was being rewritten at every call site and kept being
+ * forgotten at the next one.
+ */
+export function count(value: number, singular: string, plural?: string): string {
+  return `${value.toLocaleString()} ${value === 1 ? singular : (plural ?? `${singular}s`)}`;
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1244,6 +1244,14 @@ export const followGraphApi = {
 export interface MemberContentLikeEntry {
   target_url: string;
   liked_date: string | null;
+  author?: string | null;
+  film_slug?: string | null;
+  /**
+   * Checked against the subject's ENTIRE library, server-side. Null when the
+   * like's film is unresolved — "cannot say", never "unseen". The client used
+   * to decide this from the ten most recent watches, the only titles it had.
+   */
+  watched?: boolean | null;
 }
 
 export interface MemberCommentEntry {
@@ -2235,6 +2243,10 @@ export interface QueueAgeResponse {
   }>;
   dated: number;
   total: number;
+  /** Distinct films queued by anyone in the selection. */
+  distinct_queued: number;
+  /** Of those, rated by at least one selected profile. */
+  rated_by_selection: number;
   profiles_with_added_dates: string[];
   caveat: string;
 }

--- a/frontend/src/views/ProfileManager.tsx
+++ b/frontend/src/views/ProfileManager.tsx
@@ -1122,7 +1122,7 @@ const ProfileManager: React.FC = () => {
                         <div className="text-xs text-white/60">Films</div>
                       </div>
                       <div className="text-center">
-                        <div className="text-xl font-bold text-cinema-400">{profile.avg_rating?.toFixed(1) || '0.0'}</div>
+                        <div className="text-xl font-bold text-cinema-400">{profile.rated_films ? (profile.avg_rating ?? 0).toFixed(1) : '—'}</div>
                         <div className="text-xs text-white/60">Avg Rating</div>
                       </div>
                       <div className="text-center">

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -159,7 +159,10 @@ export default function PublicDashboard() {
           { big: stats.total_reviews.toLocaleString(), unit: 'REVIEWS' },
           { big: stats.global_avg_rating.toFixed(2), unit: 'AVERAGE' },
         ]}
-        caveat={`${analytics.data_health.completed_profiles} of ${stats.total_profiles} profiles are ready for analysis. Latest completed sync: ${lastSync}.`}
+        // Completed over ACTIVE, not over total_profiles — the snapshot's
+        // total is itself completed-only, so the old caveat compared a number
+        // against itself and could only ever read "N of N ready".
+        caveat={`${analytics.data_health.completed_profiles} of ${analytics.data_health.active_profiles} monitored profiles are ready for analysis. Latest completed sync: ${lastSync}.`}
       />
 
       <Panel

--- a/frontend/src/views/data/LostFoundTab.tsx
+++ b/frontend/src/views/data/LostFoundTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { localDate } from '../../components/terminal/dates';
 import Notes from '../../components/terminal/bodies/Notes';
 import Posters from '../../components/terminal/bodies/Posters';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
@@ -71,7 +72,7 @@ export default function LostFoundTab({ profiles }: { profiles: string[] }) {
                 cell(entry.rows.toLocaleString(), { align: 'right', tone: 'var(--accent)' }),
                 cell(
                   entry.oldest
-                    ? new Date(entry.oldest).toLocaleDateString('en-GB', {
+                    ? localDate(entry.oldest).toLocaleDateString('en-GB', {
                         month: 'short',
                         year: 'numeric',
                       })

--- a/frontend/src/views/data/ProfilesTab.tsx
+++ b/frontend/src/views/data/ProfilesTab.tsx
@@ -123,7 +123,13 @@ export default function ProfilesTab({ profiles }: { profiles: string[] }) {
         }) ?? (
           <Rows
             columns="minmax(0,1fr) 90px 90px minmax(0,1fr)"
-            head={['PROFILE', ['WATCHES', 'right'], ['LAST READ', 'right'], 'FILMS HELD']}
+            // "THEY REPORT", because the figure is Letterboxd's own header
+            // count, not our imported rows — for a freshly synced profile the
+            // two differ, and a column named FILMS HELD showing the number we
+            // do NOT hold inverted the fact. Our count is the roster's FILMS
+            // column on Overview, and the gap between the two is the whole
+            // subject of Data › What's missing.
+            head={['PROFILE', ['WATCHES', 'right'], ['LAST READ', 'right'], 'THEY REPORT']}
             rows={(freshnessQuery.data?.profiles ?? []).map((entry) => {
               return {
                 cells: [

--- a/frontend/src/views/films/TasteMapTab.tsx
+++ b/frontend/src/views/films/TasteMapTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { localDate, formatDay } from '../../components/terminal/dates';
 import Diverge from '../../components/terminal/bodies/Diverge';
 import Posters from '../../components/terminal/bodies/Posters';
 import Quads from '../../components/terminal/bodies/Quads';
@@ -11,9 +12,21 @@ import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import Spark from '../../components/terminal/bodies/Spark';
 import { panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
-import { filmsApi, watchlistInsightsApi } from '../../services/api';
+import { filmsApi } from '../../services/api';
 
 const QUAD_TONES = ['var(--ok)', 'var(--accent)', 'var(--blue)', 'var(--muted)'];
+
+/** A wait in the unit that fits it: days, then months, then years+months. */
+function daysSince(iso: string): number {
+  return Math.max(0, Math.round((Date.now() - localDate(iso).getTime()) / 86400000));
+}
+
+function waitingLabel(days: number): string {
+  if (days < 30) return `${days}d`;
+  const months = Math.round(days / 30.44);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y ${months % 12}m`;
+}
 
 function yearsSince(iso: string): string {
   const then = new Date(iso).getTime();
@@ -45,13 +58,6 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
     queryKey: ['films-language-ladder', profiles],
     queryFn: () => filmsApi.getLanguageLadder(profiles),
     ...options,
-  });
-  const conversionQuery = useQuery({
-    queryKey: ['watchlist-insights', profiles[0]],
-    queryFn: () => watchlistInsightsApi.getInsights(profiles[0]),
-    enabled: profiles.length > 0,
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
   });
 
   return (
@@ -118,17 +124,20 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
         title="QUEUE CONVERSION"
         src="watchlist_items × profile_films"
         blurb="How much of what gets added actually gets watched."
+        // Selection-wide, like every sibling on this tab. These two figures
+        // used to come from the FIRST selected profile's watchlist insights
+        // and were presented, unlabelled, as the group's.
         stats={
-          conversionQuery.data
+          queueAgeQuery.data
             ? [
                 {
-                  big: conversionQuery.data.coverage.watchlist_films.toLocaleString(),
+                  big: queueAgeQuery.data.distinct_queued.toLocaleString(),
                   unit: 'STILL QUEUED',
                   tone: 'var(--accent)',
                 },
                 {
-                  big: conversionQuery.data.coverage.rated_by_group.toLocaleString(),
-                  unit: 'RATED BY SOMEBODY TRACKED',
+                  big: queueAgeQuery.data.rated_by_selection.toLocaleString(),
+                  unit: 'RATED BY SOMEBODY SELECTED',
                 },
               ]
             : undefined
@@ -136,19 +145,19 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
         caveat="The queue holds unwatched films only, so a converted entry leaves it entirely. This is what is still waiting, not a conversion rate over all time — nothing records when something left."
       >
         {panelState({
-          isLoading: conversionQuery.isLoading,
-          error: conversionQuery.error,
+          isLoading: queueAgeQuery.isLoading,
+          error: queueAgeQuery.error,
           // Two different emptinesses. The guard used to check only the queue
           // size, so a queue with entries but no added dates rendered a table
           // header over nothing at all.
           isEmpty:
-            (conversionQuery.data?.coverage.watchlist_films ?? 0) === 0 ||
-            (conversionQuery.data?.longest_waiting.length ?? 0) === 0,
-          onRetry: () => conversionQuery.refetch(),
+            (queueAgeQuery.data?.distinct_queued ?? 0) === 0 ||
+            (queueAgeQuery.data?.films.length ?? 0) === 0,
+          onRetry: () => queueAgeQuery.refetch(),
           errorTitle: 'Queue conversion could not be read',
           errorBody: 'Every other panel on this tab is unaffected.',
           empty:
-            (conversionQuery.data?.coverage.watchlist_films ?? 0) === 0
+            (queueAgeQuery.data?.distinct_queued ?? 0) === 0
               ? {
                   title: 'Nothing waiting in the queue',
                   body: 'Either the watchlist is private, or everything on it has been watched.',
@@ -161,7 +170,7 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
           <Rows
             columns="minmax(0,1fr) 76px 76px"
             head={['LONGEST WAITING', ['ADDED', 'right'], ['WAITING', 'right']]}
-            rows={(conversionQuery.data?.longest_waiting ?? []).slice(0, 6).map((film) => ({
+            rows={(queueAgeQuery.data?.films ?? []).slice(0, 6).map((film) => ({
               cells: [
                 cell(film.year ? `${film.title} (${film.year})` : film.title, {
                   font: 's',
@@ -170,17 +179,18 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
                 }),
                 cell(
                   film.added_date
-                    ? new Date(film.added_date).toLocaleDateString('en-GB', {
+                    ? localDate(film.added_date).toLocaleDateString('en-GB', {
                         month: 'short',
                         year: 'numeric',
                       })
                     : 'no date',
                   { align: 'right', size: '10px', tone: 'var(--muted)' },
                 ),
-                // An unknown wait, not a zero-day one.
-                cell(film.days_waiting === null ? '—' : `${Math.round(film.days_waiting / 365)}y`, {
+                // An unknown wait, not a zero-day one — and never rounded to
+                // whole years, which showed "0y" for anything under six months.
+                cell(waitingLabel(daysSince(film.added_date)), {
                   align: 'right',
-                  tone: film.days_waiting === null ? 'var(--dim)' : 'var(--accent)',
+                  tone: 'var(--accent)',
                 }),
               ],
             }))}
@@ -212,7 +222,7 @@ export default function TasteMapTab({ profiles }: { profiles: string[] }) {
             items={(queueAgeQuery.data?.films ?? []).slice(0, 6).map((film) => ({
               title: film.year ? `${film.title} (${film.year})` : film.title,
               posterUrl: film.poster_url,
-              sub: `@${film.username} · added ${new Date(film.added_date).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}`,
+              sub: `@${film.username} · added ${formatDay(film.added_date, { month: 'short', year: 'numeric' })}`,
               right: yearsSince(film.added_date),
               tone: 'var(--accent)',
               rightCaption: 'still waiting',

--- a/frontend/src/views/overlaps/EchoesTab.tsx
+++ b/frontend/src/views/overlaps/EchoesTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { formatDay } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import Posters from '../../components/terminal/bodies/Posters';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
@@ -208,11 +209,7 @@ export default function EchoesTab({ profiles, gapDays }: { profiles: string[]; g
               title: entry.year ? `${entry.title} (${entry.year})` : entry.title,
               posterUrl: entry.poster_url,
               sub: entry.usernames.map((name) => `@${name}`).join(' + '),
-              right: new Date(entry.date).toLocaleDateString('en-GB', {
-                day: '2-digit',
-                month: 'short',
-                year: 'numeric',
-              }),
+              right: formatDay(entry.date),
               tone: 'var(--ok)',
               rightCaption: 'both first',
             }))}

--- a/frontend/src/views/overlaps/TogetherTab.tsx
+++ b/frontend/src/views/overlaps/TogetherTab.tsx
@@ -9,6 +9,7 @@ import Posters from '../../components/terminal/bodies/Posters';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { MIN_RATED_OVERLAP, withRatedEvidence } from '../../components/terminal/pairEvidence';
 import { spySignalsApi, type GroupSignalEvent, type GroupSignalPair } from '../../services/api';
 
 /** Was "gap days". The tier a co-watch falls into, said the way a person would. */
@@ -73,18 +74,48 @@ export default function TogetherTab({
   );
   const pairs: GroupSignalPair[] = signals?.aligned_pairs ?? [];
 
-  const tightest = [...pairs]
-    .filter((pair) => pair.average_rating_gap !== null)
-    .sort((a, b) => (a.average_rating_gap ?? 9) - (b.average_rating_gap ?? 9));
+  // Only pairs whose gap rests on the evidence floor. This list once came
+  // back pre-trimmed to the six alignment-scored pairs, which are already
+  // evidence-weighted; now that every pair arrives, a raw sort would crown a
+  // 0.00 coincidence built on a single shared rating.
+  const tightest = withRatedEvidence(pairs).sort(
+    (a, b) => (a.average_rating_gap ?? 9) - (b.average_rating_gap ?? 9),
+  );
 
-  const tierCounts = React.useMemo(() => {
-    const counts = new Map<string, number>();
-    events.forEach((event) => {
-      const { label } = closenessLabel(eventGap(event));
-      counts.set(label, (counts.get(label) ?? 0) + 1);
-    });
-    return counts;
-  }, [events]);
+  // Tier counts from the summary, which is computed before the server cuts
+  // each event list to 100 rows. Counted from the merged display lists, the
+  // "in this window" total could come out SMALLER than its own same-day
+  // subset once any tier overflowed the cut — one panel contradicting itself.
+  //
+  // The summary's gap_events already spans the whole window (day gaps 0
+  // through the selection), so it IS the window total; the wider tier bar is
+  // the remainder after the two named tiers, never a re-add of them.
+  const windowTotal = summary
+    ? (summary.gap_events ?? summary.same_day_events + (gapDays >= 1 ? summary.one_day_gap_events : 0))
+    : 0;
+  const gapRemainder = summary
+    ? Math.max(
+        0,
+        windowTotal - summary.same_day_events - (gapDays >= 1 ? summary.one_day_gap_events : 0),
+      )
+    : 0;
+  const tiers = summary
+    ? ([
+        { label: 'Same day', count: summary.same_day_events, tone: 'var(--ok)' },
+        ...(gapDays >= 1
+          ? [{ label: 'Within a day', count: summary.one_day_gap_events, tone: 'var(--accent)' }]
+          : []),
+        ...(gapDays > 1
+          ? [
+              {
+                label: gapDays <= 3 ? 'Two to three days' : `Two to ${gapDays} days`,
+                count: gapRemainder,
+                tone: 'var(--ink3)',
+              },
+            ]
+          : []),
+      ] as Array<{ label: string; count: number; tone: string }>)
+    : [];
 
   const emptyState = {
     title: 'Two profiles are needed',
@@ -143,7 +174,7 @@ export default function TogetherTab({
             ? [
                 { big: summary.same_day_events.toLocaleString(), unit: 'SAME DAY', tone: 'var(--ok)' },
                 { big: summary.one_day_gap_events.toLocaleString(), unit: 'WITHIN A DAY' },
-                { big: events.length.toLocaleString(), unit: 'IN THIS WINDOW' },
+                { big: windowTotal.toLocaleString(), unit: 'IN THIS WINDOW' },
               ]
             : undefined
         }
@@ -152,7 +183,7 @@ export default function TogetherTab({
         {panelState({
           isLoading: signalsQuery.isLoading,
           error: signalsQuery.error,
-          isEmpty: tierCounts.size === 0,
+          isEmpty: windowTotal === 0,
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'Closeness tiers could not be counted',
           errorBody: 'The overlap feed did not answer.',
@@ -160,12 +191,12 @@ export default function TogetherTab({
           skeleton: <BarsSkeleton rows={3} />,
         }) ?? (
           <Bars
-            items={Array.from(tierCounts.entries()).map(([label, count]) => ({
-              name: label,
-              weight: count,
-              value: count.toLocaleString(),
-              sub: `${Math.round((count / events.length) * 100)}%`,
-              tone: label === 'Same day' ? 'var(--ok)' : 'var(--accent)',
+            items={tiers.map((tier) => ({
+              name: tier.label,
+              weight: tier.count,
+              value: tier.count.toLocaleString(),
+              sub: windowTotal ? `${Math.round((tier.count / windowTotal) * 100)}%` : '',
+              tone: tier.tone,
             }))}
           />
         )}
@@ -189,8 +220,11 @@ export default function TogetherTab({
           },
         }) ?? (
           <Rows
-            columns="minmax(0,1fr) 78px 62px"
-            head={['PAIR', ['SHARED', 'right'], ['★ GAP', 'right']]}
+            columns="minmax(0,1fr) 92px 62px"
+            // The gap is measured over the films both RATED, not everything
+            // both watched — printing shared films beside it credited a
+            // three-rating coincidence to an 89-film history.
+            head={['PAIR', ['★ SHARED', 'right'], ['★ GAP', 'right']]}
             rows={[...tightest.slice(0, 3), ...tightest.slice(-2).reverse()]
               .filter((pair, index, list) => list.findIndex((other) => other === pair) === index)
               .map((pair) => {
@@ -198,11 +232,14 @@ export default function TogetherTab({
                 return {
                   cells: [
                     cell(pair.profiles.map((name) => `@${name}`).join(' + '), { size: '10.5px' }),
-                    cell(`${pair.shared_titles.toLocaleString()} films`, {
-                      align: 'right',
-                      size: '10px',
-                      tone: 'var(--muted)',
-                    }),
+                    cell(
+                      `${pair.rating_overlap_count.toLocaleString()} of ${pair.shared_titles.toLocaleString()}`,
+                      {
+                        align: 'right',
+                        size: '10px',
+                        tone: 'var(--muted)',
+                      },
+                    ),
                     cell(gap.toFixed(2), {
                       align: 'right',
                       tone: gap <= 0.5 ? 'var(--ok)' : gap >= 0.9 ? 'var(--bad)' : 'var(--ink2)',
@@ -237,8 +274,14 @@ export default function TogetherTab({
                 name: pair.profiles.join(' + '),
                 weight: pair.shared_titles,
                 value: pair.shared_titles.toLocaleString(),
+                // Same floor as everywhere a gap is printed: below it the
+                // figure is a coincidence, and it renders as the dash the
+                // reader already knows means "too thin to measure".
                 sub:
-                  pair.average_rating_gap !== null ? pair.average_rating_gap.toFixed(2) : '—',
+                  pair.average_rating_gap !== null &&
+                  pair.rating_overlap_count >= MIN_RATED_OVERLAP
+                    ? pair.average_rating_gap.toFixed(2)
+                    : '—',
               }))}
           />
         )}

--- a/frontend/src/views/overlaps/WhenTab.tsx
+++ b/frontend/src/views/overlaps/WhenTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { localDate, dateKey, formatDay } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import Spark from '../../components/terminal/bodies/Spark';
@@ -25,7 +26,11 @@ const WEEKS_SHOWN = 8;
 function toWeeks(buckets: Array<{ date: string; signal_count: number }>, anchor?: string) {
   const counts = new Map(buckets.map((bucket) => [bucket.date, bucket.signal_count]));
   const latestBucket = buckets.length ? buckets[buckets.length - 1].date : undefined;
-  const end = new Date(anchor ?? latestBucket ?? new Date().toISOString().slice(0, 10));
+  // Entirely in local date space. The old version parsed the anchor as UTC
+  // midnight, did weekday arithmetic on local fields, then keyed back through
+  // toISOString (UTC again) — west of Greenwich that filed every day's count
+  // under the previous weekday column and pushed the newest day off the grid.
+  const end = localDate(anchor ?? latestBucket ?? dateKey(new Date()));
   if (Number.isNaN(end.getTime())) end.setTime(Date.now());
   // Walk forward to the Sunday of that week so the last row is complete.
   const daysPastMonday = (end.getDay() + 6) % 7;
@@ -39,7 +44,7 @@ function toWeeks(buckets: Array<{ date: string; signal_count: number }>, anchor?
     for (let day = 0; day < 7; day += 1) {
       const cursor = new Date(end);
       cursor.setDate(end.getDate() - week * 7 - (6 - day));
-      const key = cursor.toISOString().slice(0, 10);
+      const key = dateKey(cursor);
       row.push(counts.get(key) ?? 0);
       rowTitles.push(`${key} · ${counts.get(key) ?? 0} overlaps`);
     }
@@ -95,7 +100,7 @@ export default function WhenTab({ profiles, gapDays }: { profiles: string[]; gap
         blurb="Eight weeks, one square per day, darker where more overlaps landed."
         caveat={
           calendarQuery.data
-            ? `Eight weeks ending ${new Date(calendarQuery.data.to).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })} — this pair's most recent overlap, not today. Undated diary entries cannot be placed on a grid at all, so a quiet week can mean a quiet week or a profile with no dates.`
+            ? `Eight weeks ending ${formatDay(calendarQuery.data.to)} — this pair's most recent overlap, not today. Undated diary entries cannot be placed on a grid at all, so a quiet week can mean a quiet week or a profile with no dates.`
             : 'Undated diary entries cannot be placed on a grid at all, so a quiet week here can mean a quiet week or a profile with no dates.'
         }
       >
@@ -205,7 +210,7 @@ export default function WhenTab({ profiles, gapDays }: { profiles: string[]; gap
               .map((day) => ({
                 cells: [
                   cell(
-                    new Date(day.date).toLocaleDateString('en-GB', {
+                    localDate(day.date).toLocaleDateString('en-GB', {
                       day: '2-digit',
                       month: 'short',
                     }),

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -11,6 +11,7 @@ import { CoWatchMatrix } from '../../components/terminal/bodies/Matrix';
 import { BarsSkeleton, PanelSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
 import { importState, sinceLabel } from '../../components/terminal/profileState';
+import { MIN_RATED_OVERLAP, withRatedEvidence } from '../../components/terminal/pairEvidence';
 import { useAdminScope } from '../../hooks/useAdminScope';
 import { useScopedProfiles } from '../../hooks/useScopedProfiles';
 import {
@@ -99,8 +100,13 @@ function matrixFromPairs(usernames: string[], pairs: GroupSignalPair[]) {
     if (i === undefined || j === undefined) return;
     overlaps[i][j] = pair.shared_titles;
     overlaps[j][i] = pair.shared_titles;
-    gaps[i][j] = pair.average_rating_gap;
-    gaps[j][i] = pair.average_rating_gap;
+    // A gap over fewer shared ratings than the evidence floor renders as the
+    // same dash as "no comparable ratings" — a 0.00 built on one rating is a
+    // coincidence wearing a measurement's clothes, and the caveat already
+    // tells the reader what the dash means.
+    const measurable = pair.rating_overlap_count >= MIN_RATED_OVERLAP;
+    gaps[i][j] = measurable ? pair.average_rating_gap : null;
+    gaps[j][i] = measurable ? pair.average_rating_gap : null;
   });
 
   return { overlaps, gaps };
@@ -175,10 +181,21 @@ export default function OverviewTab() {
     sub: ratingTotal ? `${Math.round((distribution[key] / ratingTotal) * 100)}%` : '',
   }));
 
-  const matrix = matrixFromPairs(usernames, pairs);
-  const closest = [...pairs]
-    .filter((pair) => pair.average_rating_gap !== null)
-    .sort((a, b) => (a.average_rating_gap ?? 9) - (b.average_rating_gap ?? 9))[0];
+  // Completed profiles only: the aggregates beside this grid are computed
+  // over completed imports, and a row for a profile whose scrape has not
+  // finished can only ever render the dash that means "no shared film" — an
+  // unread profile is not one that shares nothing.
+  const matrixUsernames = profiles
+    .filter((profile) => profile.scraping_status === 'completed')
+    .map((profile) => profile.username);
+  const matrix = matrixFromPairs(matrixUsernames, pairs);
+  // Ranked among pairs with enough shared ratings to mean something. Sorted
+  // raw, this crown was won by a 0.00 gap resting on three shared ratings —
+  // the runner-up had one — while the caveat attributed the agreement to the
+  // pair's 89 shared films.
+  const closest = withRatedEvidence(pairs).sort(
+    (a, b) => (a.average_rating_gap ?? 9) - (b.average_rating_gap ?? 9),
+  )[0];
 
   return (
     <>
@@ -243,8 +260,8 @@ export default function OverviewTab() {
         blurb="Above the diagonal: films both have seen. Below it: how far apart their stars land on those same films. One grid answers both questions people actually ask."
         caveat={
           closest
-            ? `${closest.profiles.join(' and ')} are the closest pair here: ${closest.shared_titles.toLocaleString()} shared films, agreeing within ${(closest.average_rating_gap ?? 0).toFixed(2)} of a star. Every pair in the selection is drawn — a dash above the diagonal is a pair with no shared film, and below it a pair with too few shared ratings to measure.`
-            : 'A pair needs shared rated films before either half of this grid can be filled.'
+            ? `${closest.profiles.join(' and ')} are the closest pair here: agreeing within ${(closest.average_rating_gap ?? 0).toFixed(2)} of a star across ${closest.rating_overlap_count.toLocaleString()} shared ratings, on ${closest.shared_titles.toLocaleString()} shared films. Every pair in the selection is drawn — a dash above the diagonal is a pair with no shared film, and below it a pair with fewer than ${MIN_RATED_OVERLAP} shared ratings, which is too few to call a distance.`
+            : `No pair shares ${MIN_RATED_OVERLAP} rated films yet, so nobody is called closest on this grid.`
         }
       >
         {panelState({
@@ -260,7 +277,7 @@ export default function OverviewTab() {
             cta: { label: 'CHOOSE WHO TO MONITOR', href: sectionHref('data', 'profiles') },
           },
         }) ?? (
-          <CoWatchMatrix labels={usernames} overlaps={matrix.overlaps} gaps={matrix.gaps} />
+          <CoWatchMatrix labels={matrixUsernames} overlaps={matrix.overlaps} gaps={matrix.gaps} />
         )}
       </Panel>
 

--- a/frontend/src/views/people/CircleTab.tsx
+++ b/frontend/src/views/people/CircleTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { formatDay } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import EgoGraph, { type EgoLeaf } from '../../components/terminal/bodies/EgoGraph';
 import Notes from '../../components/terminal/bodies/Notes';
@@ -43,6 +44,23 @@ export default function CircleTab({
   const graphQuery = useQuery({
     queryKey: ['follow-graph', subject],
     queryFn: () => followGraphApi.getFollowGraph(subject, { direction: 'both', limit: 200 }),
+    enabled: Boolean(subject),
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  // A separate request WITH removed edges. The unfollow panel used to filter
+  // `removed_at !== null` out of the graph query above — which asks for active
+  // edges only, so its source was structurally empty and the panel swore "no
+  // edge has disappeared yet" over any number of recorded unfollows.
+  const removedQuery = useQuery({
+    queryKey: ['follow-graph-removed', subject],
+    queryFn: () =>
+      followGraphApi.getFollowGraph(subject, {
+        direction: 'both',
+        includeRemoved: true,
+        limit: 200,
+      }),
     enabled: Boolean(subject),
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
@@ -109,7 +127,10 @@ export default function CircleTab({
     return all.sort((a, b) => rank(a) - rank(b) || a.username.localeCompare(b.username)).slice(0, 10);
   }, [graphQuery.data]);
 
-  const totalEdges = (graphQuery.data?.edges ?? []).filter((edge) => edge.removed_at === null).length;
+  // The endpoint's own total, not the length of the 200-edge page — the title
+  // was counting the page and silently understating any graph larger than it.
+  const totalEdges = graphQuery.data?.total ?? 0;
+  const pageTruncated = (graphQuery.data?.edges.length ?? 0) < totalEdges;
   const undrawn = Math.max(0, new Set(
     (graphQuery.data?.edges ?? [])
       .filter((edge) => edge.removed_at === null)
@@ -117,7 +138,7 @@ export default function CircleTab({
   ).size - leaves.length);
 
   const rollups = mutualsQuery.data?.rollups ?? {};
-  const dropped = (graphQuery.data?.edges ?? []).filter((edge) => edge.removed_at !== null);
+  const dropped = (removedQuery.data?.edges ?? []).filter((edge) => edge.removed_at !== null);
 
   const comments = React.useMemo(() => archiveQuery.data?.comments ?? [], [archiveQuery.data]);
   const trackedLower = React.useMemo(
@@ -151,7 +172,7 @@ export default function CircleTab({
         src="profile_follow_edges"
         wide
         blurb="The circle around one person. Solid green is mutual, solid amber is one-way, dashed is somebody the group orbits that we have never synced."
-        caveat={`Click a tracked node to re-centre. ${undrawn ? `${undrawn} further counterparts are not drawn — the ring holds about ten before the labels collide.` : 'Every counterpart is drawn.'} Letterboxd's follow lists carry no timestamps at all, so the order is recency and nothing more.`}
+        caveat={`Click a tracked node to re-centre. ${undrawn ? `${undrawn} further counterpart${undrawn === 1 ? ' is' : 's are'} not drawn — the ring holds about ten before the labels collide.` : 'Every counterpart is drawn.'}${pageTruncated ? ' Only the first 200 edges were read, so the undrawn count is a floor.' : ''} Letterboxd's follow lists carry no timestamps at all, so the order is recency and nothing more.`}
       >
         {panelState({
           isLoading: graphQuery.isLoading,
@@ -247,11 +268,11 @@ export default function CircleTab({
         caveat="Two reads minimum, or nothing is shown. A first import is a baseline and records no disappearance at all."
       >
         {panelState({
-          isLoading: graphQuery.isLoading,
-          error: graphQuery.error,
+          isLoading: removedQuery.isLoading,
+          error: removedQuery.error,
           isEmpty: dropped.length === 0,
           severity: 'quiet',
-          onRetry: () => graphQuery.refetch(),
+          onRetry: () => removedQuery.refetch(),
           errorTitle: 'Follow changes could not be loaded',
           errorBody: 'Every other panel on this tab is unaffected.',
           empty: {
@@ -310,7 +331,12 @@ export default function CircleTab({
             rows={(suggestionsQuery.data?.suggestions ?? []).slice(0, 8).map((suggestion) => ({
               cells: [
                 cell(`@${suggestion.username}`, { tone: 'var(--ink)' }),
-                cell(`${suggestion.followed_by_count} of ${profiles.length}`, {
+                // The server counts across every monitored profile and says so in
+                // monitored_profiles; dividing by the tab's own list rendered
+                // "10 of 6" — the sibling of the fixed Data › Profiles bug.
+                cell(
+                  `${suggestion.followed_by_count} of ${suggestionsQuery.data?.monitored_profiles ?? '—'}`,
+                  {
                   align: 'right',
                   tone: 'var(--accent)',
                 }),
@@ -398,7 +424,7 @@ export default function CircleTab({
                   : 'Counterpart not resolvable from a boxd.it link'
               }${
                 comment.commented_date
-                  ? ` · ${new Date(comment.commented_date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short', year: 'numeric' })}`
+                  ? ` · ${formatDay(comment.commented_date)}`
                   : ''
               }`,
               text: comment.comment_text

--- a/frontend/src/views/people/OnePersonTab.tsx
+++ b/frontend/src/views/people/OnePersonTab.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { localDate, formatDay } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import Diverge from '../../components/terminal/bodies/Diverge';
 import Notes from '../../components/terminal/bodies/Notes';
@@ -13,6 +14,7 @@ import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import Spark from '../../components/terminal/bodies/Spark';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { count } from '../../components/terminal/plural';
 import type {
   ActivityData,
   RecentRating,
@@ -156,7 +158,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
       inner: entry.unique_movies ?? undefined,
       display: entry.movies_watched === 0 ? '—' : String(entry.movies_watched),
       partial: entry.is_partial,
-      hint: `${entry.month}${entry.is_partial ? ', month to date' : ''}: ${entry.movies_watched} watches`,
+      hint: `${entry.month}${entry.is_partial ? ', month to date' : ''}: ${count(entry.movies_watched, 'watch', 'watches')}`,
     };
   });
 
@@ -348,7 +350,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               sub: stars(film.rating),
               right: String(film.watch_count),
               tone: 'var(--accent)',
-              rightCaption: 'watches',
+              rightCaption: film.watch_count === 1 ? 'watch' : 'watches',
             }))}
           />
         )}
@@ -383,7 +385,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         }
         caveat={
           stats
-            ? `Measured over ${stats.release_lag.measured_films.toLocaleString()} films with a known release date.${
+            ? `Measured over ${count(stats.release_lag.measured_films, 'film')} with a known release date.${
                 stats.release_lag.logged_before_release
                   ? ` ${stats.release_lag.logged_before_release} entries were dated before release and left out of the median — festival screenings and bad dates — rather than hidden.`
                   : ''
@@ -448,11 +450,11 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         }
         caveat={
           stats
-            ? `${stats.cadence.active_days.toLocaleString()} days with an entry across ${
-                stats.cadence.span_days ? `${stats.cadence.span_days.toLocaleString()} days` : 'the imported span'
+            ? `${count(stats.cadence.active_days, 'day')} with an entry across ${
+                stats.cadence.span_days ? count(stats.cadence.span_days, 'day') : 'the imported span'
               }.${
                 stats.cadence.longest_dry_spell_days
-                  ? ` Longest silence: ${stats.cadence.longest_dry_spell_days} days${
+                  ? ` Longest silence: ${count(stats.cadence.longest_dry_spell_days, 'day')}${
                       stats.cadence.dry_spell_started ? ` from ${stats.cadence.dry_spell_started}` : ''
                     } — a run of quiet weeks is not the same as a slow one, so it is named rather than averaged away.`
                   : ''
@@ -509,7 +511,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                 cell(entry.what, { font: 's', size: '10.5px', wrap: true }),
                 cell(
                   entry.when
-                    ? new Date(entry.when).toLocaleDateString('en-GB', {
+                    ? localDate(entry.when).toLocaleDateString('en-GB', {
                         day: '2-digit',
                         month: 'short',
                       })
@@ -572,7 +574,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               title: film.year ? `${film.title} (${film.year})` : film.title,
               posterUrl: film.poster_url,
               href: film.letterboxd_url ?? undefined,
-              sub: `${film.rating_count?.toLocaleString() ?? 'audience unknown'} ratings on Letterboxd`,
+              sub: film.rating_count == null ? 'audience unknown' : `${count(film.rating_count, 'rating')} on Letterboxd`,
               right: film.profile_rating.toFixed(1),
               tone: 'var(--accent)',
               rightCaption: 'their star',
@@ -644,9 +646,9 @@ export default function OnePersonTab({ subject }: { subject: string }) {
       </Panel>
 
       <Panel
-        title="THEIR QUEUE, RANKED BY THEIR CIRCLE"
+        title="THEIR QUEUE, RANKED BY THE TRACKED GROUP"
         src="watchlist_items × ratings"
-        blurb="What is waiting, ordered by how the people they follow rated it rather than by when it was added."
+        blurb="What is waiting, ordered by how the rest of the monitored group rated it rather than by when it was added. The group is everyone tracked here — not the people this member follows, which no rating table records."
         caveat={
           watchlistQuery.data
             ? `${watchlistQuery.data.coverage.rated_by_group.toLocaleString()} of ${watchlistQuery.data.coverage.watchlist_films.toLocaleString()} unwatched queue entries have been rated by somebody else tracked. The rest are waiting on evidence, not on this panel.`
@@ -671,7 +673,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               posterUrl: film.poster_url,
               href: film.letterboxd_url ?? undefined,
               sub: [
-                `${film.group_raters} in their circle rated it`,
+                `${film.group_raters} in the tracked group rated it`,
                 film.crowd_ceiling == null
                   ? null
                   : `${Math.round(film.crowd_ceiling * 100)}% rated it 4.5+`,
@@ -686,7 +688,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                 .join(' · '),
               right: film.group_average === null ? '—' : film.group_average.toFixed(1),
               tone: (film.group_average ?? 0) >= 4 ? 'var(--ok)' : 'var(--accent)',
-              rightCaption: film.group_raters < 3 ? 'thin evidence' : 'circle avg',
+              rightCaption: film.group_raters < 3 ? 'thin evidence' : 'group avg',
             }))}
           />
         )}
@@ -762,7 +764,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         blurb="Their average by year. A drifting baseline changes what every gap figure in Overlaps actually means."
         caveat={
           timelineQuery.data
-            ? `${timelineQuery.data.summary.rated_dated_events.toLocaleString()} dated rated events across ${timelineQuery.data.summary.years} years. ${timelineQuery.data.summary.undated_known_watches.toLocaleString()} known watches carry no date and sit in no year at all.`
+            ? `${timelineQuery.data.summary.rated_dated_events.toLocaleString()} dated rated events across ${count(timelineQuery.data.summary.years, 'year')}. ${timelineQuery.data.summary.undated_known_watches.toLocaleString()} known watches carry no date and sit in no year at all.`
             : undefined
         }
       >
@@ -818,7 +820,9 @@ export default function OnePersonTab({ subject }: { subject: string }) {
             : undefined
         }
         caveat={
-          stats
+          // "0 of 0 reviews carry prose" is a measurement over an empty set;
+          // the body's empty state already says there is nothing to measure.
+          stats && stats.reviews.total_reviews > 0
             ? `${stats.reviews.with_text.toLocaleString()} of ${stats.reviews.total_reviews.toLocaleString()} reviews carry prose. A rating logged bare has no length, not a length of zero.`
             : undefined
         }
@@ -874,7 +878,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               posterUrl: film.poster_url,
               href: film.letterboxd_url ?? undefined,
               sub: film.latest_watched_date
-                ? `logged ${new Date(film.latest_watched_date).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' })}${film.has_review ? ' · reviewed, not rated' : ' · no rating, no review'}`
+                ? `logged ${formatDay(film.latest_watched_date, { month: 'short', year: 'numeric' })}${film.has_review ? ' · reviewed, not rated' : ' · no rating, no review'}`
                 : 'no date on this entry',
               right: '—',
               tone: 'var(--muted)',
@@ -1004,11 +1008,11 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               return {
                 cells: [
                   cell(`@${entry.username}`),
-                  cell(entry.silent_days === null ? '—' : `${entry.silent_days} days`, {
+                  cell(entry.silent_days === null ? '—' : `${entry.silent_days} ${entry.silent_days === 1 ? 'day' : 'days'}`, {
                     align: 'right',
                     tone,
                   }),
-                  cell(entry.usual_gap_days === null ? '—' : `${entry.usual_gap_days} days`, {
+                  cell(entry.usual_gap_days === null ? '—' : `${entry.usual_gap_days} ${entry.usual_gap_days === 1 ? 'day' : 'days'}`, {
                     align: 'right',
                     size: '10px',
                     tone: 'var(--muted)',
@@ -1083,7 +1087,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                 title: film.year ? `${film.title} (${film.year})` : film.title,
                 posterUrl: film.poster_url,
                 href: film.letterboxd_url ?? undefined,
-                sub: `${film.rating_count?.toLocaleString() ?? '—'} ratings on Letterboxd`,
+                sub: film.rating_count == null ? '— ratings on Letterboxd' : `${count(film.rating_count, 'rating')} on Letterboxd`,
                 right: film.profile_rating.toFixed(1),
                 tone: 'var(--accent)',
                 rightCaption: 'their star',
@@ -1139,13 +1143,13 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               cells: [
                 cell(run.director, { font: 's', size: '11.5px', tone: 'var(--ink)' }),
                 cell(String(run.films), { align: 'right', tone: 'var(--accent)' }),
-                cell(`over ${run.days} days`, {
+                cell(`over ${run.days} ${run.days === 1 ? 'day' : 'days'}`, {
                   align: 'right',
                   size: '10px',
                   tone: 'var(--ink3)',
                 }),
                 cell(
-                  new Date(run.started).toLocaleDateString('en-GB', {
+                  localDate(run.started).toLocaleDateString('en-GB', {
                     month: 'short',
                     year: 'numeric',
                   }),

--- a/frontend/src/views/people/ReachTab.tsx
+++ b/frontend/src/views/people/ReachTab.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import Panel from '../../components/terminal/Panel';
+import { localDate } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import Posters from '../../components/terminal/bodies/Posters';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
@@ -82,33 +83,25 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
   const likedLists = archiveQuery.data?.liked_lists ?? [];
   const card = cardQuery.data;
 
-  // Films they liked a review of and have no watch record for. Intent recorded
-  // in a place nothing else looks.
-  const watchedTitles = React.useMemo(
-    () =>
-      new Set(
-        (analysisQuery.data?.recent_watching_trend ?? []).map((watch) =>
-          watch.movie_title.toLowerCase(),
-        ),
-      ),
-    [analysisQuery.data],
-  );
-
+  // Films they liked a review of and have no watch record for. "No watch
+  // record" is the server's verdict against the subject's ENTIRE library —
+  // this used to be checked against the ten most recent watches, the only
+  // title list the client had, so anything watched earlier than last week
+  // rendered as "liked, unseen".
   const likedUnseen = React.useMemo(() => {
     const bySlug = new Map<string, { slug: string; count: number; authors: Set<string> }>();
     likedReviews.forEach((like) => {
-      const slug = filmSlugFrom(like.target_url);
+      if (like.watched !== false) return;
+      const slug = like.film_slug ?? filmSlugFrom(like.target_url);
       if (!slug) return;
       const entry = bySlug.get(slug) ?? { slug, count: 0, authors: new Set<string>() };
       entry.count += 1;
-      const author = authorFrom(like.target_url);
+      const author = like.author ?? authorFrom(like.target_url);
       if (author) entry.authors.add(author);
       bySlug.set(slug, entry);
     });
-    return Array.from(bySlug.values())
-      .filter((entry) => !watchedTitles.has(entry.slug.replace(/-/g, ' ')))
-      .sort((a, b) => b.count - a.count);
-  }, [likedReviews, watchedTitles]);
+    return Array.from(bySlug.values()).sort((a, b) => b.count - a.count);
+  }, [likedReviews]);
 
   const resolvedLikes = likedReviews.filter((like) => filmSlugFrom(like.target_url)).length;
 
@@ -179,7 +172,7 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
                 }),
                 cell(
                   review.published_date
-                    ? new Date(review.published_date).toLocaleDateString('en-GB', {
+                    ? localDate(review.published_date).toLocaleDateString('en-GB', {
                         month: 'short',
                         year: 'numeric',
                       })
@@ -228,7 +221,7 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
                 ),
                 cell(
                   like.liked_date
-                    ? new Date(like.liked_date).toLocaleDateString('en-GB', {
+                    ? localDate(like.liked_date).toLocaleDateString('en-GB', {
                         month: 'short',
                         year: 'numeric',
                       })

--- a/frontend/src/views/people/TwoPeopleTab.tsx
+++ b/frontend/src/views/people/TwoPeopleTab.tsx
@@ -13,6 +13,7 @@ import Spark from '../../components/terminal/bodies/Spark';
 import SpoilerReviewText from '../../components/SpoilerReviewText';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { count } from '../../components/terminal/plural';
 import {
   insightsApi,
   peopleApi,
@@ -30,9 +31,9 @@ function periodSummary(point: TasteTimelinePoint, username: string): string {
   if (!own || own.watch_events === 0) return '—';
   const average = own.average_rating === null ? '—' : `${own.average_rating.toFixed(2)} avg`;
   if (own.rated_events && own.rated_events !== own.watch_events) {
-    return `${average} of ${own.rated_events} rated · ${own.watch_events} watches`;
+    return `${average} of ${own.rated_events} rated · ${count(own.watch_events, 'watch', 'watches')}`;
   }
-  return `${average} · ${own.watch_events} watches`;
+  return `${average} · ${count(own.watch_events, 'watch', 'watches')}`;
 }
 
 function ratingFor(comparison: PairMovieComparison, username: string): number | null {
@@ -274,19 +275,26 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
         }) ?? (
           <>
           <Spark
-            items={(timelineQuery.data?.yearly ?? []).map((point) => {
-              const a = point.per_profile.find((entry) => entry.username === left)?.average_rating;
-              const b = point.per_profile.find((entry) => entry.username === right)?.average_rating;
-              const distance = a !== null && a !== undefined && b !== null && b !== undefined
-                ? Math.abs(a - b)
-                : 0;
-              return {
-                label: String(point.year).slice(2),
-                value: Math.round(distance * 100),
-                display: distance ? distance.toFixed(2) : '—',
-                hint: `${point.label}: ${a?.toFixed(2) ?? '—'} against ${b?.toFixed(2) ?? '—'}`,
-              };
-            })}
+            // Only years BOTH profiles rated in. Plotted with distance 0, a
+            // year one side never rated in was the chart's best-possible
+            // agreement; and `distance ? ... : '—'` rendered a genuine 0.00 —
+            // identical yearly averages — with the same dash as "not
+            // measurable", while its own hover hint said "4.00 against 4.00".
+            items={(timelineQuery.data?.yearly ?? [])
+              .map((point) => {
+                const a = point.per_profile.find((entry) => entry.username === left)?.average_rating;
+                const b = point.per_profile.find((entry) => entry.username === right)?.average_rating;
+                const measurable =
+                  a !== null && a !== undefined && b !== null && b !== undefined;
+                return {
+                  measurable,
+                  label: String(point.year).slice(2),
+                  value: measurable ? Math.round(Math.abs(a - b) * 100) : 0,
+                  display: measurable ? Math.abs(a - b).toFixed(2) : '—',
+                  hint: `${point.label}: ${a?.toFixed(2) ?? '—'} against ${b?.toFixed(2) ?? '—'}`,
+                };
+              })
+              .filter((point) => point.measurable)}
           />
           <Rows
             columns="56px minmax(0,1fr) minmax(0,1fr)"
@@ -382,12 +390,12 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
                 return {
                   cells: [
                     cell(String(year), { size: '10.5px', tone: 'var(--ink3)' }),
-                    cell(a ? `${a.average_release_year.toFixed(0)} · ${a.films} films` : '—', {
+                    cell(a ? `${a.average_release_year.toFixed(0)} · ${count(a.films, 'film')}` : '—', {
                       align: 'right',
                       size: '10.5px',
                       tone: 'var(--ink2)',
                     }),
-                    cell(b ? `${b.average_release_year.toFixed(0)} · ${b.films} films` : '—', {
+                    cell(b ? `${b.average_release_year.toFixed(0)} · ${count(b.films, 'film')}` : '—', {
                       align: 'right',
                       size: '10.5px',
                       tone: 'var(--ink2)',
@@ -590,7 +598,7 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
       <Panel
         title="NEITHER HAS SEEN IT"
         src="circle ratings × both watch absence"
-        blurb="Films the rest of the circle rates highly that neither of these two has logged. A pair-level blind spot, which is a better shortlist than either watchlist."
+        blurb="Films the rest of the tracked group rates highly that neither of these two has logged. A pair-level blind spot, which is a better shortlist than either watchlist."
         caveat={blindSpotsQuery.data?.caveat}
       >
         {panelState({
@@ -613,7 +621,7 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
               title: film.year ? `${film.title} (${film.year})` : film.title,
               posterUrl: film.poster_url,
               href: film.letterboxd_url ?? undefined,
-              sub: `${film.rater_count} in their circle · avg ${film.average_rating.toFixed(1)}`,
+              sub: `${film.rater_count} in the tracked group · avg ${film.average_rating.toFixed(1)}`,
               right: film.average_rating.toFixed(1),
               tone: film.average_rating >= 4.4 ? 'var(--ok)' : 'var(--accent)',
               rightCaption: 'neither seen',

--- a/frontend/src/views/tonight/AvailabilityTab.tsx
+++ b/frontend/src/views/tonight/AvailabilityTab.tsx
@@ -95,7 +95,7 @@ export default function AvailabilityTab({
               cells: [
                 cell(entry.region),
                 cell(entry.films.toLocaleString(), { align: 'right', tone: 'var(--ink)' }),
-                cell(entry.days_ago === null ? '—' : `${entry.days_ago}d ago`, {
+                cell(entry.days_ago === null ? '—' : entry.days_ago === 0 ? 'today' : `${entry.days_ago}d ago`, {
                   align: 'right',
                   size: '10px',
                   tone: 'var(--muted)',

--- a/frontend/src/views/tonight/PicksTab.tsx
+++ b/frontend/src/views/tonight/PicksTab.tsx
@@ -99,10 +99,14 @@ export default function PicksTab({
             : undefined
         }
         caveat={
-          `Fit was “group fit score”. It is a rank, not a rating — the number only means something against the other rows in this table. Every ranked candidate is rendered below, and the count above is the length of this table rather than a larger set it was cut from.` +
+          // summary.candidates is now counted before the server's cut, so the
+          // two branches are finally distinguishable — the old copy claimed
+          // "never cut from a larger set" against a total computed after the
+          // cut, which could not disagree with the table it annotated.
+          `Fit was “group fit score”. It is a rank, not a rating — the number only means something against the other rows in this table.` +
           (summary && summary.candidates > candidates.length
-            ? ` The scan considered ${summary.candidates.toLocaleString()} in total; the rest did not clear the filters above.`
-            : '')
+            ? ` ${summary.candidates.toLocaleString()} candidates cleared the filters; the ${candidates.length.toLocaleString()} below are the best fits, and the count above is the length of this table.`
+            : ` Every ranked candidate is rendered below — the count above is the length of this table, not a larger set it was cut from.`)
         }
       >
         {panelState({


### PR DESCRIPTION
Systematic hunt for the remaining product bugs, by disease class: six finder agents (truncation-as-absence, zero-vs-absence, cross-panel contradiction, caveat honesty, date hazards, selection-scope drift), every finding adversarially verified by two independent lenses — code reachability and would-it-actually-happen-on-this-data — before being accepted. 48 raw findings, 30 confirmed, 18 refuted. 29 fixed here; full inventory in the commit message.

The ones a reader would have hit this week:

| Panel | Was showing | Truth |
|---|---|---|
| People › The circle › Followed and unfollowed | "No edge has disappeared yet", always | its request excluded removed edges by construction |
| Overlaps › How close in time | a window total smaller than its own same-day subset (once any tier overflowed the 100-row cut) | summary counts, taken before the cut |
| Overlaps › When › Longest marathon days | the biggest of the twelve most *recent* days | the longest days, then the cut |
| Overview › closest pair | "agreeing within 0.00" on 3 shared ratings, attributed to 89 shared films | evidence floor + both denominators named |
| People › One person › Liked but never seen | "no watch record" checked against the 10 most recent watches | server-side check against the whole library |
| My Profiles | "Avg Rating **0.0**" for profiles with zero ratings | — |
| every date-only field | previous day west of Greenwich; previous *month* on the 1st | local calendar-day parsing |
| Public dashboard | "N of N profiles ready", tautologically | completed over active |

Also in this batch: dates class helper (`terminal/dates.ts`), pluralization helper (`terminal/plural.ts`), queue-age endpoint extended with selection-wide conversion counts, member-archive endpoint now answers `watched` per liked review, marathons ordered by size server-side, shortlist candidates counted pre-cut, importer staleness compared against `IMPORTER_VERSION`, matrix scoped to completed profiles, and copy that names the population it measures everywhere "their circle" used to paper over three different ones.

## Tests
- `704 passed` backend (4 new: marathon ordering, queue-age selection counts, shared-firsts distinct films, plus the adapted pair test) + `124 passed` deploy
- `278 passed` Playwright (`CI=1`, both projects) — 3 new evidence-floor specs; fixtures now model the truncation branch, the thin pair, and the server-decided `watched` flag
- `tsc --noEmit`, `eslint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)