### PR TITLE
Restore the eight panels the redesign dropped without saying so

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -219,7 +219,14 @@ const groupSignals = {
       alignment_score: 41,
     },
   ],
-  follow_paths: [],
+  follow_paths: [
+    {
+      leader: 'alpha',
+      follower: 'bravo',
+      next_day_overlap_count: 4,
+      sample_titles: [{ title: 'Shared Fixture Film', year: 2024 }],
+    },
+  ],
 };
 
 const publicDashboard = {

--- a/frontend/e2e/restored-panels.spec.ts
+++ b/frontend/e2e/restored-panels.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Eight panels v3 rendered were silently dropped by the redesign handoff,
+ * despite its own "nothing in the current product is dropped" promise — the
+ * API computed and shipped every field the whole time. Restored, and pinned
+ * here so a future redesign cannot lose them silently again.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+});
+
+test('One person renders actors, studios, languages and review years again', async ({ page }) => {
+  await page.goto('/people?tab=one');
+
+  for (const title of [
+    'THE FACES THEY KEEP SEEING',
+    'THE STUDIOS BEHIND IT',
+    'WHAT LANGUAGE THE FILMS SPEAK',
+    'REVIEWS, YEAR BY YEAR',
+  ]) {
+    await expect(
+      page.locator('.terminal-root section', { hasText: title }).first(),
+    ).toBeVisible();
+  }
+  // Fixture data flows through: Ghibli is the top studio.
+  await expect(
+    page.locator('.terminal-root section', { hasText: 'THE STUDIOS BEHIND IT' }).first(),
+  ).toContainText('Studio Ghibli');
+});
+
+test('Together renders the three group lists again', async ({ page }) => {
+  await page.goto('/overlaps?tab=together');
+
+  for (const title of ["EVERYONE'S SEEN IT", 'AGREED ON, AND LIKED', 'SPLIT THE ROOM']) {
+    await expect(
+      page.locator('.terminal-root section', { hasText: title }).first(),
+    ).toBeVisible();
+  }
+});
+
+test('Echoes renders follow paths again, directional and caveated', async ({ page }) => {
+  await page.goto('/overlaps?tab=echoes');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'WHO FOLLOWS WHOSE LEAD' })
+    .first();
+  await expect(panel).toContainText('@alpha → @bravo');
+  // Correlation, never causation — the caveat says so in words.
+  await expect(panel).toContainText('A pattern is not a cause');
+});

--- a/frontend/src/components/terminal/sections.ts
+++ b/frontend/src/components/terminal/sections.ts
@@ -71,8 +71,8 @@ export const SECTIONS: SectionDef[] = [
     blurb:
       'Was Spy Signals. Same film, close in time — the core of the product, plus the honest account of how sure we are about each one.',
     tabs: [
-      { id: 'together', label: 'TOGETHER', panels: 4 },
-      { id: 'echoes', label: 'ECHOES', panels: 3 },
+      { id: 'together', label: 'TOGETHER', panels: 7 },
+      { id: 'echoes', label: 'ECHOES', panels: 4 },
       { id: 'when', label: 'WHEN', panels: 4 },
       { id: 'sure', label: 'HOW SURE', panels: 3 },
     ],
@@ -86,7 +86,7 @@ export const SECTIONS: SectionDef[] = [
     blurb:
       'Merges Analysis, Compare and Network. Three doors into the same subject become one destination with four tabs.',
     tabs: [
-      { id: 'one', label: 'ONE PERSON', panels: 25 },
+      { id: 'one', label: 'ONE PERSON', panels: 29 },
       { id: 'two', label: 'TWO PEOPLE', panels: 11 },
       { id: 'circle', label: 'THE CIRCLE', panels: 7 },
       { id: 'reach', label: 'REACH', panels: 6 },

--- a/frontend/src/views/overlaps/EchoesTab.tsx
+++ b/frontend/src/views/overlaps/EchoesTab.tsx
@@ -7,6 +7,7 @@ import Panel from '../../components/terminal/Panel';
 import { formatDay } from '../../components/terminal/dates';
 import Bars from '../../components/terminal/bodies/Bars';
 import Posters from '../../components/terminal/bodies/Posters';
+import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
 import {
@@ -78,6 +79,15 @@ export default function EchoesTab({ profiles, gapDays }: { profiles: string[]; g
     queryFn: () => firstWatchApi.getOrder(profiles),
     enabled: profiles.length >= 2,
     staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  // Same key TogetherTab uses, so this is a cache hit, not a second fetch.
+  const signalsQuery = useQuery({
+    queryKey: ['spy-signals', profiles, gapDays],
+    queryFn: () => spySignalsApi.getSignals(profiles, gapDays),
+    enabled: profiles.length >= 2,
+    staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
   });
 
@@ -212,6 +222,53 @@ export default function EchoesTab({ profiles, gapDays }: { profiles: string[]; g
               right: formatDay(entry.date),
               tone: 'var(--ok)',
               rightCaption: 'both first',
+            }))}
+          />
+        )}
+      </Panel>
+
+      {/* Restored from v3's dashboard (GroupSignalsPanel "Follow Paths"),
+          dropped by the redesign handoff without a stated reason. The endpoint
+          has shipped the list the whole time. */}
+      <Panel
+        title="WHO FOLLOWS WHOSE LEAD"
+        src="group_signals.follow_paths"
+        blurb="One person watches; the other watches the same film the next day, again and again. Directional, unlike everything else on this tab."
+        caveat="Counted per direction over next-day pairs only, and a path needs the earlier watch to be dated on both sides. A pattern is not a cause: they may share a feed, a household, or a release calendar."
+      >
+        {panelState({
+          isLoading: signalsQuery.isLoading,
+          error: signalsQuery.error,
+          isEmpty: (signalsQuery.data?.group_signals.follow_paths.length ?? 0) === 0,
+          onRetry: () => signalsQuery.refetch(),
+          errorTitle: 'Follow paths could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty:
+            profiles.length < 2
+              ? twoProfilesNeeded
+              : {
+                  title: 'No next-day pattern yet',
+                  body: 'Nobody in this selection has repeatedly watched a film the day after somebody else did.',
+                },
+        }) ?? (
+          <Rows
+            columns="minmax(0,1fr) 58px minmax(0,1.2fr)"
+            head={['WHO LEADS WHOM', ['TIMES', 'right'], 'FOR EXAMPLE']}
+            rows={(signalsQuery.data?.group_signals.follow_paths ?? []).slice(0, 8).map((path) => ({
+              cells: [
+                cell(`@${path.leader} → @${path.follower}`, { size: '10.5px' }),
+                cell(String(path.next_day_overlap_count), {
+                  align: 'right',
+                  tone: 'var(--accent)',
+                }),
+                cell(
+                  path.sample_titles
+                    .slice(0, 2)
+                    .map((entry) => entry.title)
+                    .join(', '),
+                  { font: 's', size: '10px', tone: 'var(--dim)', wrap: true },
+                ),
+              ],
             }))}
           />
         )}

--- a/frontend/src/views/overlaps/TogetherTab.tsx
+++ b/frontend/src/views/overlaps/TogetherTab.tsx
@@ -10,6 +10,7 @@ import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
 import { MIN_RATED_OVERLAP, withRatedEvidence } from '../../components/terminal/pairEvidence';
+import { count } from '../../components/terminal/plural';
 import { spySignalsApi, type GroupSignalEvent, type GroupSignalPair } from '../../services/api';
 
 /** Was "gap days". The tier a co-watch falls into, said the way a person would. */
@@ -283,6 +284,118 @@ export default function TogetherTab({
                     ? pair.average_rating_gap.toFixed(2)
                     : '—',
               }))}
+          />
+        )}
+      </Panel>
+
+      {/* The three panels below were on v3's dashboard (GroupSignalsPanel) and
+          were silently dropped by the redesign handoff despite its "nothing is
+          dropped" promise. The endpoint has shipped all three lists the whole
+          time. */}
+      <Panel
+        title="EVERYONE'S SEEN IT"
+        src="group_signals.most_shared_titles"
+        blurb="The films that travel furthest across the selection — held by the most people, whatever they thought of them."
+        caveat="A film needs two holders to appear at all; the count is people, not watches, so a rewatcher counts once."
+      >
+        {panelState({
+          isLoading: signalsQuery.isLoading,
+          error: signalsQuery.error,
+          isEmpty: (signals?.most_shared_titles.length ?? 0) === 0,
+          onRetry: () => signalsQuery.refetch(),
+          errorTitle: 'Most shared titles could not be loaded',
+          errorBody: 'The overlap feed did not answer.',
+          empty: emptyState,
+          skeleton: <BarsSkeleton rows={6} />,
+        }) ?? (
+          <Bars
+            items={(signals?.most_shared_titles ?? []).slice(0, 8).map((movie) => ({
+              name: movie.year ? `${movie.title} (${movie.year})` : movie.title,
+              weight: movie.profile_count,
+              value: count(movie.profile_count, 'person', 'people'),
+              sub: movie.average_rating === null ? '—' : movie.average_rating.toFixed(1),
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="AGREED ON, AND LIKED"
+        src="group_signals.consensus_hits"
+        blurb="Shared watches with a strong average and little disagreement. The safest common ground the selection has."
+        caveat="Needs two or more ratings on the same film — an average of one opinion is not a consensus. Ranked by average, then by how tightly the stars cluster."
+      >
+        {panelState({
+          isLoading: signalsQuery.isLoading,
+          error: signalsQuery.error,
+          isEmpty: (signals?.consensus_hits.length ?? 0) === 0,
+          onRetry: () => signalsQuery.refetch(),
+          errorTitle: 'Consensus hits could not be loaded',
+          errorBody: 'The overlap feed did not answer.',
+          empty: emptyState,
+        }) ?? (
+          <Rows
+            columns="minmax(0,1.4fr) 52px 62px 58px"
+            head={['FILM', ['AVG', 'right'], ['RATERS', 'right'], ['SPREAD', 'right']]}
+            rows={(signals?.consensus_hits ?? []).slice(0, 8).map((movie) => ({
+              cells: [
+                cell(movie.year ? `${movie.title} (${movie.year})` : movie.title, {
+                  font: 's',
+                  size: '10.5px',
+                  wrap: true,
+                }),
+                cell(movie.average_rating === null ? '—' : movie.average_rating.toFixed(1), {
+                  align: 'right',
+                  tone: 'var(--ok)',
+                }),
+                cell(String(movie.rating_count), { align: 'right', size: '10px', tone: 'var(--muted)' }),
+                cell(movie.rating_stddev === null ? '—' : movie.rating_stddev.toFixed(2), {
+                  align: 'right',
+                  size: '10px',
+                  tone: 'var(--muted)',
+                }),
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="SPLIT THE ROOM"
+        src="group_signals.divisive_titles"
+        blurb="Shared watches with the widest spread in stars — the whole selection against itself, not one pair. Head to head holds the pair version."
+        caveat="Spread is the standard deviation of the selection's own stars on the film, and it needs two or more raters to exist at all."
+      >
+        {panelState({
+          isLoading: signalsQuery.isLoading,
+          error: signalsQuery.error,
+          isEmpty: (signals?.divisive_titles.length ?? 0) === 0,
+          onRetry: () => signalsQuery.refetch(),
+          errorTitle: 'Divisive titles could not be loaded',
+          errorBody: 'The overlap feed did not answer.',
+          empty: emptyState,
+        }) ?? (
+          <Rows
+            columns="minmax(0,1.4fr) 52px 62px 58px"
+            head={['FILM', ['AVG', 'right'], ['RATERS', 'right'], ['SPREAD', 'right']]}
+            rows={(signals?.divisive_titles ?? []).slice(0, 8).map((movie) => ({
+              cells: [
+                cell(movie.year ? `${movie.title} (${movie.year})` : movie.title, {
+                  font: 's',
+                  size: '10.5px',
+                  wrap: true,
+                }),
+                cell(movie.average_rating === null ? '—' : movie.average_rating.toFixed(1), {
+                  align: 'right',
+                  tone: 'var(--ink2)',
+                }),
+                cell(String(movie.rating_count), { align: 'right', size: '10px', tone: 'var(--muted)' }),
+                cell(movie.rating_stddev === null ? '—' : movie.rating_stddev.toFixed(2), {
+                  align: 'right',
+                  tone: 'var(--bad)',
+                }),
+              ],
+            }))}
           />
         )}
       </Panel>

--- a/frontend/src/views/people/OnePersonTab.tsx
+++ b/frontend/src/views/people/OnePersonTab.tsx
@@ -1254,6 +1254,155 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         )}
       </Panel>
 
+      {/* The four panels below were rendered by v3's Analysis page and were
+          silently dropped by the redesign handoff despite its own "nothing is
+          dropped" promise. The API has computed and shipped every field the
+          whole time; they were fetched on every load and thrown away. */}
+      <Panel
+        title="THE FACES THEY KEEP SEEING"
+        src="movie_enrichments.credits · cast"
+        blurb="Actors, counted across the library. The billing order is TMDB's; the counting is ours."
+        caveat={
+          stats
+            ? `Only the casts TMDB records: ${Math.round(stats.coverage.enrichment_ratio * 100)}% of their films carry credits, and the rest contribute nobody rather than an unknown actor.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.top_actors.length ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Actors could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No cast credits enriched yet',
+            body: 'TMDB enrichment has not reached enough of this library.',
+            cta: { label: 'SEE THE MATCH RATE', href: sectionHref('films', 'gaps') },
+          },
+          skeleton: <BarsSkeleton rows={8} />,
+        }) ?? (
+          <Bars
+            items={(stats?.top_actors ?? []).slice(0, 8).map((person) => ({
+              name: person.name,
+              weight: person.count,
+              value: count(person.count, 'film'),
+              // The average's real denominator is rated_count, not count — an
+              // actor seen nine times with one rated film has an average of
+              // one opinion, and below three it is noise rather than a lean.
+              sub:
+                person.average_rating === null || person.rated_count < 3
+                  ? '—'
+                  : person.average_rating.toFixed(1),
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="THE STUDIOS BEHIND IT"
+        src="movie_enrichments.raw_payload · production_companies"
+        blurb="Production companies, counted across the library. A studio habit is taste nobody chose on purpose."
+        caveat={
+          stats
+            ? `Only what TMDB records, over the ${Math.round(stats.coverage.enrichment_ratio * 100)}% of films with metadata. Co-productions count once per named company, so these overlap.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.top_studios.length ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Studios could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No studio credits enriched yet',
+            body: 'TMDB enrichment has not reached enough of this library.',
+            cta: { label: 'SEE THE MATCH RATE', href: sectionHref('films', 'gaps') },
+          },
+          skeleton: <BarsSkeleton rows={8} />,
+        }) ?? (
+          <Bars
+            items={(stats?.top_studios ?? []).slice(0, 8).map((studio) => ({
+              name: studio.name,
+              weight: studio.count,
+              value: count(studio.count, 'film'),
+              sub:
+                studio.average_rating === null || studio.rated_count < 3
+                  ? '—'
+                  : studio.average_rating.toFixed(1),
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHAT LANGUAGE THE FILMS SPEAK"
+        src="enrichments.original_language · spoken_languages"
+        blurb="Original language, not subtitles: an English-language film shot abroad counts as English here and as its country in the atlas."
+        caveat={
+          stats
+            ? `Capped by enrichment: ${Math.round(stats.coverage.enrichment_ratio * 100)}% of their films carry a language, and the rest are excluded rather than counted as silent.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.languages.length ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Languages could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No language metadata enriched yet',
+            body: 'TMDB enrichment has not reached enough of this library.',
+            cta: { label: 'SEE THE MATCH RATE', href: sectionHref('films', 'gaps') },
+          },
+          skeleton: <BarsSkeleton rows={6} />,
+        }) ?? (
+          <Bars
+            items={(stats?.languages ?? []).slice(0, 8).map((bucket) => ({
+              name: bucket.label,
+              weight: bucket.count,
+              value: count(bucket.count, 'film'),
+              sub:
+                bucket.average_rating === null || bucket.rated_count < 3
+                  ? '—'
+                  : bucket.average_rating.toFixed(1),
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="REVIEWS, YEAR BY YEAR"
+        src="reviews.published_date"
+        blurb="When the writing happened. A review habit that started, stopped, or never existed — the volume says which."
+        caveat="Counts only reviews carrying a publication date. A review without one exists but sits in no year, so these bars can undercount the total above."
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.reviews.reviews_by_year.length ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Review years could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No dated reviews',
+            body: 'Either they have written none, or none of what they wrote carries a publication date.',
+          },
+        }) ?? (
+          <Spark
+            items={(stats?.reviews.reviews_by_year ?? []).map((entry) => ({
+              label: String(entry.year).slice(2),
+              value: entry.count,
+              display: entry.count === 0 ? '—' : String(entry.count),
+            }))}
+          />
+        )}
+      </Panel>
+
       {/* Always rendered. This used to disappear entirely when the import
           reported no limitation, which made a clean import indistinguishable
           from the panel not existing — and left the tab holding one more panel


### PR DESCRIPTION
Result of the v3 → main parity audit. The migration lost no commits, routes, migrations, specs or API functions — but the view rewrites dropped eight rendered surfaces that the design handoff's own mapping omitted, despite its "nothing in the current product is dropped" promise. Every field was still computed, tested and shipped in responses the pages already fetch; it was paid for and discarded at render time.

| Restored panel | Where | v3 ancestor |
|---|---|---|
| The faces they keep seeing | People › One person | Analysis › Top actors |
| The studios behind it | People › One person | Analysis › Top studios |
| What language the films speak | People › One person | Analysis › Languages |
| Reviews, year by year | People › One person | Analysis › Reviews by year |
| Everyone's seen it | Overlaps › Together | Dashboard › Most Shared Titles |
| Agreed on, and liked | Overlaps › Together | Dashboard › Consensus Hits |
| Split the room | Overlaps › Together | Dashboard › Divisive Titles |
| Who follows whose lead | Overlaps › Echoes | Dashboard › Follow Paths |

Zero backend changes — the data was always there. Each panel follows the terminal idiom: SRC line, evidence floors on averages (no lean printed under three rated films), honest empty states, and a directionality caveat on follow paths ("a pattern is not a cause"). Echoes reuses Together's exact query key, so the extra panel is a cache hit, not a second fetch.

Badges: One person 25→29, Together 4→7, Echoes 3→4 — `panel-counts.spec.ts` walks every tab and holds each badge to the rendered count, and the new `restored-panels.spec.ts` pins all eight so they cannot be silently lost twice.

## Tests
- `284 passed` Playwright (`CI=1`, both projects; 6 new)
- `705 passed` backend (untouched, run anyway)
- `tsc --noEmit`, `eslint --max-warnings=0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)