### PR TITLE
Let the guardian's fast failures speak POSIX

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -428,7 +428,19 @@ jobs:
             exit 0
           fi
           status="$("${python_path}" "${canary_path}" status --lease-id "${lease_id}")"
-          [[ "${status}" == failed || "${status}" == cleanup_failed ]]
+          reason="$("${python_path}" "${canary_path}" reason --lease-id "${lease_id}" || true)"
+          echo "guardian exited within its startup window: status=${status} reason=${reason:-none recorded}" >&2
+          # POSIX sh, not bash: this heredoc runs under the VPS's /bin/sh, and
+          # the [[ ]] that used to sit here crashed with "[[: not found" (127)
+          # BEFORE reporting the status — replacing the guardian's own
+          # diagnosis at exactly the moment a diagnosis was needed. An orderly
+          # fast failure (status written) exits 0 so the workflow's reporting
+          # loop can read and print the reason; only a crash with no status
+          # fails the step outright.
+          case "${status}" in
+            failed|cleanup_failed) exit 0 ;;
+            *) exit 1 ;;
+          esac
           REMOTE
           guardian_started=1
 

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -288,3 +288,24 @@ class AuthCanaryDiagnosticsTests(unittest.TestCase):
         workflow = read_repo_file(".github/workflows/production-canary.yml")
 
         self.assertIn("2>/dev/null", workflow)
+
+    def test_the_remote_guardian_heredoc_is_posix_sh(self) -> None:
+        """The VPS runs these blocks under /bin/sh, where [[ is not found.
+
+        The fast-death diagnostic used [[ ]] and crashed with exit 127 before
+        reporting the guardian's status — replacing the diagnosis at exactly
+        the moment one was needed.
+        """
+
+        import re
+
+        workflow = read_repo_file(".github/workflows/production-canary.yml")
+        blocks = re.findall(r"sh -s --.*?<<'REMOTE'(.*?)\n\s*REMOTE", workflow, re.S)
+        self.assertTrue(blocks, "no remote sh heredoc found")
+        for block in blocks:
+            for line in block.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("#"):
+                    continue
+                self.assertNotIn("[[", stripped, f"bashism in sh heredoc: {stripped}")
+        self.assertIn("guardian exited within its startup window", workflow)


### PR DESCRIPTION
Follow-up to the canary A account replacement. The new identity resolved the Clerk 404, which moved the guardian's failure earlier — it now exits inside its two-second startup window, a path no run had ever taken. That path ran `[[ ... ]]` under the VPS's `/bin/sh` and died with `sh: 45: [[: not found` (exit 127), masking the guardian's recorded reason at exactly the moment it was needed.

- The fast-death branch is POSIX `case` now, and it prints `status=… reason=…` from the guardian's own status file before deciding anything.
- An orderly fast failure exits 0 so the downstream reporting loop (added in #134) presents the reason; only a reason-less crash fails the step outright.
- `test_the_remote_guardian_heredoc_is_posix_sh` sweeps every `sh -s` heredoc in the workflow for `[[` so the next bashism cannot hide.

`124 passed` deploy suite. Next canary run will finally name the real, current failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)