### PR TITLE
Add a dispatch-only canary reset that dry-runs before it deletes

### DIFF
--- a/.github/workflows/canary-reset.yml
+++ b/.github/workflows/canary-reset.yml
@@ -1,0 +1,159 @@
+name: Canary Reset
+
+# Maintenance, dispatch-only: reset the authenticated canary's identities to
+# the guardian's bootstrap state after a Clerk account was replaced. Deletes
+# ONLY canary app_users rows (plus their tracked-profile and request rows);
+# profiles and imported history are never touched. Dry run unless `execute`
+# is checked, and the script refuses administrators outright either way.
+
+on:
+  workflow_dispatch:
+    inputs:
+      execute:
+        description: Actually delete (unchecked = dry run that changes nothing)
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read # checkout the exact reset script
+
+jobs:
+  canary_reset:
+    name: Reset canary identities to bootstrap
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    concurrency:
+      # Shares the auth canary's group so a reset can never race a live
+      # guardian run against the same rows.
+      group: spyboxd-production-auth-canary
+      cancel-in-progress: false
+    environment:
+      name: production
+      url: https://spyboxd.com
+
+    steps:
+      - name: Monitor runner file and network activity
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check out the exact reset script and SSH helpers
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Establish one pinned IPv4 production SSH connection
+        env:
+          SSH_FINGERPRINT: ${{ secrets.VPS_HOST_FINGERPRINT }}
+          SSH_HOST: ${{ secrets.VPS_HOST }}
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: deploy/production-ssh.sh open
+
+      - name: Allocate private remote paths
+        id: remote
+        run: |
+          set -Eeuo pipefail
+          script_path="$(deploy/production-ssh.sh run mktemp /tmp/spyboxd-canary-reset.XXXXXX)"
+          [[ "${script_path}" =~ ^/tmp/spyboxd-canary-reset\.[A-Za-z0-9]{6}$ ]]
+          env_path="$(deploy/production-ssh.sh run mktemp /tmp/spyboxd-canary-reset-env.XXXXXX)"
+          [[ "${env_path}" =~ ^/tmp/spyboxd-canary-reset-env\.[A-Za-z0-9]{6}$ ]]
+          printf 'script_path=%s\n' "${script_path}" >>"${GITHUB_OUTPUT}"
+          printf 'env_path=%s\n' "${env_path}" >>"${GITHUB_OUTPUT}"
+
+      - name: Install the exact remote reset script
+        env:
+          REMOTE_SCRIPT_PATH: ${{ steps.remote.outputs.script_path }}
+        run: |
+          set -Eeuo pipefail
+          [[ "${REMOTE_SCRIPT_PATH}" =~ ^/tmp/spyboxd-canary-reset\.[A-Za-z0-9]{6}$ ]]
+          expected_hash="$(sha256sum deploy/run-canary-reset.py | awk '{print $1}')"
+          [[ "${expected_hash}" =~ ^[0-9a-f]{64}$ ]]
+          deploy/production-ssh.sh copy \
+            deploy/run-canary-reset.py \
+            "spyboxd-production:${REMOTE_SCRIPT_PATH}"
+          deploy/production-ssh.sh run sh -s -- \
+            "${REMOTE_SCRIPT_PATH}" "${expected_hash}" <<'REMOTE'
+          set -eu
+          script_path="$1"
+          expected_hash="$2"
+          actual_hash="$(sha256sum "${script_path}" | awk '{print $1}')"
+          [ "${actual_hash}" = "${expected_hash}" ]
+          chmod 0600 "${script_path}"
+          REMOTE
+
+      - name: Stage the private canary identity configuration
+        env:
+          REMOTE_ENV_PATH: ${{ steps.remote.outputs.env_path }}
+          SPYBOXD_CANARY_PROFILE_A: ${{ secrets.SPYBOXD_CANARY_PROFILE_A }}
+          SPYBOXD_CANARY_PROFILE_B: ${{ secrets.SPYBOXD_CANARY_PROFILE_B }}
+          SPYBOXD_CANARY_USER_A_ID: ${{ secrets.SPYBOXD_CANARY_USER_A_ID }}
+          SPYBOXD_CANARY_USER_B_ID: ${{ secrets.SPYBOXD_CANARY_USER_B_ID }}
+        run: |
+          set -Eeuo pipefail
+          local_env="${RUNNER_TEMP}/spyboxd-canary-reset.env"
+          [[ "${REMOTE_ENV_PATH}" =~ ^/tmp/spyboxd-canary-reset-env\.[A-Za-z0-9]{6}$ ]]
+          [[ "${SPYBOXD_CANARY_USER_A_ID}" =~ ^user_[A-Za-z0-9]+$ ]]
+          [[ "${SPYBOXD_CANARY_USER_B_ID}" =~ ^user_[A-Za-z0-9]+$ ]]
+          [[ "${SPYBOXD_CANARY_PROFILE_A}" =~ ^[A-Za-z0-9_]{2,15}$ ]]
+          [[ "${SPYBOXD_CANARY_PROFILE_B}" =~ ^[A-Za-z0-9_]{2,15}$ ]]
+          umask 077
+          {
+            printf 'SPYBOXD_CANARY_USER_A_ID=%s\n' "${SPYBOXD_CANARY_USER_A_ID}"
+            printf 'SPYBOXD_CANARY_PROFILE_A=%s\n' "${SPYBOXD_CANARY_PROFILE_A}"
+            printf 'SPYBOXD_CANARY_USER_B_ID=%s\n' "${SPYBOXD_CANARY_USER_B_ID}"
+            printf 'SPYBOXD_CANARY_PROFILE_B=%s\n' "${SPYBOXD_CANARY_PROFILE_B}"
+          } >"${local_env}"
+          chmod 0600 "${local_env}"
+          deploy/production-ssh.sh copy \
+            "${local_env}" \
+            "spyboxd-production:${REMOTE_ENV_PATH}"
+          rm -f -- "${local_env}"
+
+      - name: Run the reset (dry run unless execute was checked)
+        env:
+          REMOTE_SCRIPT_PATH: ${{ steps.remote.outputs.script_path }}
+          REMOTE_ENV_PATH: ${{ steps.remote.outputs.env_path }}
+          EXECUTE: ${{ inputs.execute && '1' || '' }}
+        run: |
+          set -Eeuo pipefail
+          deploy/production-ssh.sh run sh -s -- \
+            "${REMOTE_SCRIPT_PATH}" "${REMOTE_ENV_PATH}" "${EXECUTE}" <<'REMOTE'
+          set -eu
+          script_path="$1"
+          env_path="$2"
+          execute="$3"
+          current_link=/opt/spyboxd/current
+          python_path="${current_link}/.venv/bin/python"
+          [ -L "${current_link}" ] && [ -x "${python_path}" ]
+          chmod 0600 "${env_path}"
+          if [ -n "${execute}" ]; then
+            "${python_path}" "${script_path}" --env-file "${env_path}" --execute
+          else
+            "${python_path}" "${script_path}" --env-file "${env_path}"
+          fi
+          REMOTE
+
+      - name: Securely remove remote one-run material
+        if: always()
+        env:
+          REMOTE_SCRIPT_PATH: ${{ steps.remote.outputs.script_path }}
+          REMOTE_ENV_PATH: ${{ steps.remote.outputs.env_path }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "${REMOTE_ENV_PATH}" =~ ^/tmp/spyboxd-canary-reset-env\.[A-Za-z0-9]{6}$ ]]; then
+            deploy/production-ssh.sh run rm -f -- "${REMOTE_ENV_PATH}" || true
+          fi
+          if [[ "${REMOTE_SCRIPT_PATH}" =~ ^/tmp/spyboxd-canary-reset\.[A-Za-z0-9]{6}$ ]]; then
+            deploy/production-ssh.sh run rm -f -- "${REMOTE_SCRIPT_PATH}" || true
+          fi
+
+      - name: Close production SSH and securely remove local key material
+        if: always()
+        run: |
+          if [[ -x deploy/production-ssh.sh ]]; then
+            deploy/production-ssh.sh close || true
+          fi

--- a/deploy/run-canary-reset.py
+++ b/deploy/run-canary-reset.py
@@ -1,0 +1,201 @@
+"""Reset the canary identities to the guardian's bootstrap state, on the VPS.
+
+The authenticated canary accepts exactly two starting states: both canary
+identities absent from ``app_users`` (bootstrap — the browser flow provisions
+them itself), or both fully provisioned. Replacing a deleted Clerk account
+leaves a third state the guardian rightly refuses: the survivor still
+provisioned, the newcomer absent, and an orphaned row from the dead account
+still claiming a canary profile.
+
+This script deletes exactly the canary rows and nothing else:
+
+- ``app_users`` rows whose ``clerk_user_id`` is one of the two configured
+  canary IDs, or whose ``letterboxd_username`` is one of the two configured
+  canary profiles (that second clause is what catches the orphan)
+- their ``user_tracked_profiles`` rows
+- their ``profile_access_requests`` rows (a mis-onboarded canary files a
+  request for a profile that does not exist, which otherwise sits in the
+  admin queue forever)
+
+Profiles and imported history are never touched: untracking and unclaiming
+delete nothing from the append-only store.
+
+DRY RUN BY DEFAULT. Without ``--execute`` it reports what it would delete and
+changes nothing. It refuses outright if any matched row belongs to a
+configured administrator, whatever flags are set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import stat
+import sys
+from pathlib import Path
+
+
+USER_ID_PATTERN = re.compile(r"^user_[A-Za-z0-9]+$")
+PROFILE_PATTERN = re.compile(r"^[A-Za-z0-9_]{2,15}$")
+DATABASE_CONNECT_TIMEOUT_SECONDS = 10
+
+
+class CanaryResetError(RuntimeError):
+    pass
+
+
+def _read_secure_env(path: Path) -> dict[str, str]:
+    """The guardian's reader, byte for byte in behaviour: regular file, not
+    world-accessible, KEY=VALUE lines."""
+
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise CanaryResetError("a required VPS configuration file is unavailable") from exc
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise CanaryResetError("VPS configuration must use regular files")
+    if metadata.st_mode & 0o007:
+        raise CanaryResetError("VPS configuration must not be world-accessible")
+
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        raise CanaryResetError("a required VPS configuration file could not be read") from exc
+    values: dict[str, str] = {}
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _mask(value: str) -> str:
+    """Enough to recognise, not enough to reuse."""
+
+    if len(value) <= 6:
+        return "…"
+    return f"{value[:5]}…{value[-3:]}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--env-file", type=Path, required=True,
+                        help="staged file carrying the four SPYBOXD_CANARY_* values")
+    parser.add_argument("--api-env", type=Path, default=Path("/etc/spyboxd/api.env"))
+    parser.add_argument("--execute", action="store_true",
+                        help="actually delete; the default is a dry run that changes nothing")
+    args = parser.parse_args()
+
+    staged = _read_secure_env(args.env_file)
+    user_ids = []
+    profiles = []
+    for label in ("A", "B"):
+        user_id = staged.get(f"SPYBOXD_CANARY_USER_{label}_ID", "")
+        profile = staged.get(f"SPYBOXD_CANARY_PROFILE_{label}", "")
+        if not USER_ID_PATTERN.fullmatch(user_id):
+            raise CanaryResetError(f"canary user id {label} is malformed")
+        if not PROFILE_PATTERN.fullmatch(profile):
+            raise CanaryResetError(f"canary profile {label} is malformed")
+        user_ids.append(user_id)
+        profiles.append(profile.casefold())
+    if len(set(user_ids)) != 2 or len(set(profiles)) != 2:
+        raise CanaryResetError("canary identities must be two distinct users and profiles")
+
+    api_values = _read_secure_env(args.api_env)
+    database_url = api_values.get("DATABASE_URL", "")
+    if not database_url:
+        raise CanaryResetError("the production database URL is unavailable")
+    admin_ids = {
+        value.strip()
+        for value in api_values.get("CLERK_ADMIN_USER_IDS", "").split(",")
+        if value.strip()
+    }
+    if set(user_ids) & admin_ids:
+        raise CanaryResetError("a configured canary identity is an administrator; refusing")
+
+    try:
+        from sqlalchemy import create_engine, text
+    except ImportError as exc:
+        raise CanaryResetError("the backend environment cannot reach the database") from exc
+
+    engine = create_engine(
+        database_url,
+        pool_pre_ping=True,
+        connect_args={"connect_timeout": DATABASE_CONNECT_TIMEOUT_SECONDS},
+    )
+    try:
+        with engine.connect() as connection:
+            transaction = connection.begin()
+            rows = connection.execute(
+                text(
+                    """
+                    SELECT id, clerk_user_id, letterboxd_username
+                    FROM app_users
+                    WHERE clerk_user_id = ANY(:user_ids)
+                       OR lower(coalesce(letterboxd_username, '')) = ANY(:profiles)
+                    """
+                ),
+                {"user_ids": user_ids, "profiles": profiles},
+            ).fetchall()
+
+            for row in rows:
+                if row.clerk_user_id in admin_ids:
+                    raise CanaryResetError(
+                        "a matched row belongs to an administrator; refusing to touch anything"
+                    )
+
+            if not rows:
+                print("canary reset: nothing matched — state is already bootstrap")
+                return 0
+
+            ids = [row.id for row in rows]
+            tracked = connection.execute(
+                text("SELECT count(*) FROM user_tracked_profiles WHERE user_id = ANY(:ids)"),
+                {"ids": ids},
+            ).scalar_one()
+            requests = connection.execute(
+                text("SELECT count(*) FROM profile_access_requests WHERE user_id = ANY(:ids)"),
+                {"ids": ids},
+            ).scalar_one()
+
+            for row in rows:
+                origin = "configured id" if row.clerk_user_id in user_ids else "orphan claiming a canary profile"
+                print(
+                    f"canary reset: matched app_user {_mask(row.clerk_user_id)} "
+                    f"bound to {row.letterboxd_username or '(no profile)'} — {origin}"
+                )
+            print(
+                f"canary reset: {'deleting' if args.execute else 'DRY RUN — would delete'} "
+                f"{len(rows)} identity row(s), {tracked} tracked-profile row(s), "
+                f"{requests} pending request(s). Profiles and history are untouched."
+            )
+
+            if not args.execute:
+                # The no-write promise is structural: the transaction that saw
+                # the rows is rolled back, never committed.
+                transaction.rollback()
+                return 0
+
+            connection.execute(
+                text("DELETE FROM user_tracked_profiles WHERE user_id = ANY(:ids)"), {"ids": ids}
+            )
+            connection.execute(
+                text("DELETE FROM profile_access_requests WHERE user_id = ANY(:ids)"),
+                {"ids": ids},
+            )
+            connection.execute(text("DELETE FROM app_users WHERE id = ANY(:ids)"), {"ids": ids})
+            transaction.commit()
+            print("canary reset: done — the guardian will provision both identities on its next run")
+        return 0
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except CanaryResetError as error:
+        print(f"canary reset failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -309,3 +309,31 @@ class AuthCanaryDiagnosticsTests(unittest.TestCase):
                     continue
                 self.assertNotIn("[[", stripped, f"bashism in sh heredoc: {stripped}")
         self.assertIn("guardian exited within its startup window", workflow)
+
+    def test_the_canary_reset_is_dispatch_only_dry_run_first_and_posix(self) -> None:
+        """A production-row delete must be asked for twice: dispatch, then execute."""
+
+        import re
+
+        workflow = read_repo_file(".github/workflows/canary-reset.yml")
+        script = read_repo_file("deploy/run-canary-reset.py")
+
+        self.assertIn("workflow_dispatch", workflow)
+        self.assertNotIn("schedule:", workflow)
+        self.assertIn("default: false", workflow)
+        # Same concurrency group as the auth canary, so a reset can never race
+        # a live guardian run against the same rows.
+        self.assertIn("group: spyboxd-production-auth-canary", workflow)
+        for block in re.findall(r"sh -s --.*?<<'REMOTE'(.*?)\n\s*REMOTE", workflow, re.S):
+            for line in block.splitlines():
+                if not line.strip().startswith("#"):
+                    self.assertNotIn("[[", line, f"bashism in sh heredoc: {line.strip()}")
+
+        # The script's own guarantees: dry run default, admin refusal, and the
+        # dry-run transaction is rolled back rather than committed.
+        self.assertIn('"--execute", action="store_true"', script)
+        self.assertIn("belongs to an administrator; refusing", script)
+        self.assertIn("transaction.rollback()", script)
+        self.assertIn("DELETE FROM app_users", script)
+        self.assertNotIn("DELETE FROM profiles", script)
+        self.assertNotIn("DELETE FROM watch_events", script)


### PR DESCRIPTION
Companion to the canary A account replacement. The guardian's preflight now correctly refuses the mixed state the replacement created (B provisioned, new A absent, an orphan claiming a canary profile, plus the mis-onboarded `@canary_a` identity and its forever-pending profile request). This adds the sanctioned way out: reset to **bootstrap**, which the guardian repairs by provisioning both identities itself.

**Scope of deletion** — exactly the canary rows: `app_users` matched by configured canary ID *or* by canary-profile binding (that clause catches the orphan), plus their `user_tracked_profiles` and `profile_access_requests` rows. Profiles and imported history untouched.

**Safety:**
- `workflow_dispatch` only, `execute` input defaulting to false — the default run is a **dry run whose transaction is rolled back, never committed**
- refuses outright if any matched row belongs to a configured administrator
- shares the auth canary's concurrency group so it cannot race a live guardian
- script copied fresh and hash-verified like the guardian itself; identity values staged via a 0600 env file, never argv
- remote heredocs POSIX (`/bin/sh` on the VPS), swept by test

`125 passed` deploy suite, including the new pin on all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)