### PR TITLE
Stamp the frontend with its build revision and make the canary hold it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,6 +430,9 @@ jobs:
       NEXT_TELEMETRY_DISABLED: "1"
       API_URL: https://api.spyboxd.com
       NEXT_PUBLIC_API_BASE_URL: https://api.spyboxd.com
+      # Inlined into the bundle at build time; the production canary compares
+      # it against the API's /health revision after every deploy.
+      NEXT_PUBLIC_BUILD_REVISION: ${{ github.sha }}
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.PRODUCTION_CLERK_PUBLISHABLE_KEY }}
       # Build-only sentinel. The real live secret remains only in the VPS runtime env.
       CLERK_SECRET_KEY: ${{ format('sk_{0}_{1}', 'live', 'ci_build_only_not_a_secret') }}

--- a/deploy/run-production-canary.py
+++ b/deploy/run-production-canary.py
@@ -391,8 +391,15 @@ def run_canary(
     except Exception as exc:
         raise CanaryError("public data or RSS semantic health contract failed") from exc
 
+    # The homepage must not only render -- it must be THIS release's frontend.
+    # The bundle stamps its own build revision into the root layout
+    # (data-build-revision on <body>), and the API states its revision at
+    # /ready; the two ship as one bundle, so anything but equality means the
+    # web tier is serving a different build than the API it fronts.
     _html_response(
-        request_client.get(f"{web_base}/"), "public homepage", ("spyboxd", "letterboxd")
+        request_client.get(f"{web_base}/"),
+        "public homepage",
+        ("spyboxd", "letterboxd", f'data-build-revision="{revision}"'),
     )
     _html_response(
         request_client.get(f"{web_base}/sign-in"),

--- a/deploy/test_production_canary.py
+++ b/deploy/test_production_canary.py
@@ -121,7 +121,9 @@ def _good_responses():
                 },
             }
         ),
-        f"{web}/": _html_response("Spyboxd Letterboxd"),
+        f"{web}/": _html_response(
+            f'Spyboxd Letterboxd <body data-build-revision="{REVISION}">'
+        ),
         f"{web}/sign-in": _html_response("Spyboxd Clerk sign-in"),
     }
     for path in public_canary.PRIVATE_UI_PATHS:
@@ -1315,3 +1317,21 @@ class AbsentApiRouteControlTests(unittest.TestCase):
             covered = [p for p in public_canary.PRIVATE_API_PATHS if p.startswith(prefix)]
             self.assertTrue(covered, f"no {prefix} endpoint is checked by the canary")
         self.assertGreaterEqual(len(public_canary.PRIVATE_API_PATHS), 60)
+
+    def test_homepage_serving_a_different_build_revision_is_rejected(self):
+        """The web tier answering with last week's bundle is a failed deploy,
+        not a healthy one -- the frontend stamps its build revision into the
+        root layout and the canary holds it to the API's own revision."""
+
+        responses = _good_responses()
+        responses["https://spyboxd.com/"] = _html_response(
+            f'Spyboxd Letterboxd <body data-build-revision="{"b" * 40}">'
+        )
+        with self.assertRaises(public_canary.CanaryError) as caught:
+            public_canary.run_canary(
+                web_base="https://spyboxd.com",
+                api_base="https://api.spyboxd.com",
+                validator_path=DEPLOY_DIR / "check-runtime-health.py",
+                client=FakeClient(responses),
+            )
+        self.assertIn("public homepage", str(caught.exception))

--- a/frontend/e2e/build-revision.spec.ts
+++ b/frontend/e2e/build-revision.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * The frontend states which build it is, the way the API states its revision
+ * at /health. In this environment the value is the 'dev' fallback; production
+ * bundles carry the git SHA, and the deploy canary holds it to the API's.
+ */
+test('every page carries the build revision on its body', async ({ page }) => {
+  await installApiMocks(page);
+
+  await page.goto('/overview');
+
+  await expect(page.locator('body')).toHaveAttribute('data-build-revision', /^(dev|[0-9a-f]{40})$/);
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 import Providers from './providers';
 import { ibmPlexSans, jetbrainsMono } from './fonts';
+import { BUILD_REVISION } from '../buildRevision';
 import { THEME_INIT_SCRIPT } from '../components/terminal/theme';
 import '../index.css';
 
@@ -32,7 +33,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               dense terminal layout is the whole screen flashing. */}
           <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
         </head>
-        <body>
+        {/* The build's own revision, stamped where an anonymous GET can read
+            it: the root layout is server-rendered on every page, so the
+            production canary can compare this against the API's /health
+            revision without signing in. */}
+        <body data-build-revision={BUILD_REVISION}>
           <Providers>{children}</Providers>
         </body>
       </html>

--- a/frontend/src/buildRevision.ts
+++ b/frontend/src/buildRevision.ts
@@ -1,0 +1,14 @@
+/**
+ * The Git revision this frontend was built from, inlined at build time.
+ *
+ * CI sets NEXT_PUBLIC_BUILD_REVISION to the bundle's own commit before
+ * `npm run build`, so the value is a property of the artifact rather than of
+ * whatever is checked out where it happens to run. The API already answers
+ * /health with its revision; this is the web half of the same question, and
+ * the production canary asserts the two agree after every deploy. Local dev
+ * builds carry 'dev'.
+ */
+export const BUILD_REVISION: string = process.env.NEXT_PUBLIC_BUILD_REVISION ?? 'dev';
+
+export const SHORT_BUILD_REVISION: string =
+  BUILD_REVISION === 'dev' ? 'dev' : BUILD_REVISION.slice(0, 7);

--- a/frontend/src/components/terminal/StatusBar.tsx
+++ b/frontend/src/components/terminal/StatusBar.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { SignOutButton, UserButton, useAuth } from '@clerk/nextjs';
 import { useQuery } from '@tanstack/react-query';
 import { LogOut } from 'lucide-react';
+import { BUILD_REVISION, SHORT_BUILD_REVISION } from '../../buildRevision';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
 import { useScopedProfiles } from '../../hooks/useScopedProfiles';
 import { dashboardApi } from '../../services/api';
@@ -135,6 +136,17 @@ export default function StatusBar({ section, tab }: { section: SectionDef; tab: 
         )}
 
         <ThemeToggle />
+
+        {/* Which build is actually running -- the web half of the API's
+            /health revision. Hidden below lg: it is an operator's fact, not a
+            reader's, and phone width is spent on the reader. */}
+        <span
+          className="hidden text-t9 text-term-dim2 lg:inline"
+          title={`frontend build ${BUILD_REVISION}`}
+          data-testid="build-revision"
+        >
+          {SHORT_BUILD_REVISION}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
The API states its revision at /health; the frontend stated nothing, so verifying a deploy's web tier relied on visual inspection.

- CI inlines `NEXT_PUBLIC_BUILD_REVISION=${{ github.sha }}` into the release bundle build — the value is a property of the artifact, not of whatever is checked out where it runs.
- The root layout (server-rendered on every page) stamps `data-build-revision` on `<body>`, readable by an anonymous GET.
- The status bar shows the short SHA at `lg+` (an operator's fact; phone width is spent on the reader).
- `deploy/run-production-canary.py` now requires the homepage's stamp to equal the `/ready` revision — the two ship as one bundle, so inequality means the web tier is serving a different build than the API it fronts. A mismatch test pins the failure; the assertion is revision-relative, so scheduled canaries stay correct when main is ahead of the deploy.

Deploy tests 121 passed; frontend 286/286 e2e (marker spec added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)