### PR TITLE
Pin nanoid past the advisory that is failing every production build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5309,9 +5309,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -10752,9 +10752,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="
     },
     "napi-postinstall": {
       "version": "0.3.4",
@@ -11070,7 +11070,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "requires": {
-        "nanoid": "^3.3.16",
+        "nanoid": "3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
   },
   "overrides": {
     "postcss": "8.5.25",
-    "sharp": "0.35.3"
+    "sharp": "0.35.3",
+    "nanoid": "3.3.17"
   }
 }


### PR DESCRIPTION
`Frontend / Production build` gates on `npm audit --omit=dev --audit-level=moderate`. **GHSA-2v37-7h3g-55p8** (high, `nanoid <3.3.17`) was published after the last deploy, so every merge to main now fails there — including #150, whose own PR checks were green before the advisory landed. Nothing in the repo changed; the advisory database did.

`nanoid` arrives transitively beneath the already-pinned `postcss`, so it is pinned the same way `postcss` and `sharp` already are — an explicit `overrides` entry — rather than with `npm audit fix`. That keeps the lockfile the single decider of what ships.

The lock diff is scoped to nanoid (`3.3.16 → 3.3.17`); **Next is byte-identical**, which matters because loosely re-resolving this file is exactly what shipped an untested Next and broke every deploy for a day.

`npm audit --omit=dev`: 0 vulnerabilities. tsc clean, production build clean, 286/286 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)