### PR TITLE
Measure the wait a person actually had, not the import that ended it

### DIFF
--- a/backend/api/routes/library.py
+++ b/backend/api/routes/library.py
@@ -345,9 +345,16 @@ def get_request_latency(
     db: Session = Depends(get_db),
     user: ClerkUser = Depends(get_current_user),
 ):
-    """How long a completed sync actually takes, measured rather than promised."""
+    """How long asking for a profile actually takes, measured rather than promised.
 
-    return build_request_latency(db, _selected_profiles(db, user, profiles))
+    Fulfilment latency is a property of the instance rather than of a
+    selection, so `profiles` is still validated for access -- an unauthorized
+    username must not answer differently here than anywhere else -- and then
+    deliberately not used to filter the measurement.
+    """
+
+    _selected_profiles(db, user, profiles)
+    return build_request_latency(db, [])
 
 
 @router.get("/data-health/freshness")

--- a/backend/services/data_health.py
+++ b/backend/services/data_health.py
@@ -39,6 +39,7 @@ from database.models import (
     MovieList,
     MovieListItem,
     Profile,
+    ProfileAccessRequest,
     ProfileFeedState,
     ProfileFilm,
     ProfileFollowEdge,
@@ -473,33 +474,38 @@ def build_removed(db: Session, profiles: Sequence[Profile], *, limit: int = 20) 
 
 
 def build_request_latency(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
-    """How long a completed sync actually takes, measured rather than promised."""
+    """How long asking for a profile actually takes, end to end.
 
-    profile_ids = [profile.id for profile in profiles]
-    if not profile_ids:
-        return {"runs": 0, "median_seconds": None, "worst_seconds": None, "caveat": "No profiles selected."}
+    Measured from the moment somebody asked to the moment the profile became
+    available, across every request this instance has fulfilled.
 
-    # Full reads only. An RSS top-up finishes in well under a second, and it
-    # runs on a feed schedule, so the last 30 syncs of any kind are all
-    # top-ups: the panel measured them and answered "a request takes 0s"
-    # beside a request queue whose real answer is minutes.
-    syncs = (
-        db.query(ProfileSync.started_at, ProfileSync.completed_at)
+    It deliberately does not measure ``profile_syncs``. Those rows time the
+    *ingestion* of a bundle the residential runner already produced — seconds,
+    for work that took a person hours to get around to — so a panel asking
+    "how long does a request take" answered "0s" beside a queue whose real
+    answer is days. The wait is dominated by the two things a sync row cannot
+    see: waiting for an admin to run the batch, and the scrape itself. Request
+    to availability is the only span that contains both.
+    """
+
+    del profiles  # Fulfilment latency is a property of the instance, not of a selection.
+
+    rows = (
+        db.query(ProfileAccessRequest.requested_at, ProfileAccessRequest.resolved_at)
         .filter(
-            ProfileSync.profile_id.in_(profile_ids),
-            ProfileSync.status == "completed",
-            ProfileSync.completed_at.isnot(None),
-            ProfileSync.source_kind != INCREMENTAL_SOURCE_KIND,
+            ProfileAccessRequest.status == "fulfilled",
+            ProfileAccessRequest.resolved_at.isnot(None),
+            ProfileAccessRequest.requested_at.isnot(None),
         )
-        .order_by(ProfileSync.started_at.desc())
+        .order_by(ProfileAccessRequest.resolved_at.desc())
         .limit(30)
         .all()
     )
 
     durations = sorted(
-        (completed - started).total_seconds()
-        for started, completed in syncs
-        if completed and started and completed >= started
+        (resolved - requested).total_seconds()
+        for requested, resolved in rows
+        if resolved and requested and resolved >= requested
     )
 
     if not durations:
@@ -508,9 +514,8 @@ def build_request_latency(db: Session, profiles: Sequence[Profile]) -> Dict[str,
             "median_seconds": None,
             "worst_seconds": None,
             "caveat": (
-                "No completed full read in this selection carries both a start and an end time, "
-                "so there is nothing to measure. An estimate would be a promise rather than a "
-                "figure."
+                "No request has been fulfilled yet, so there is nothing to measure. An estimate "
+                "would be a promise rather than a figure."
             ),
         }
 
@@ -520,10 +525,11 @@ def build_request_latency(db: Session, profiles: Sequence[Profile]) -> Dict[str,
         "median_seconds": round(median),
         "worst_seconds": round(durations[-1]),
         "caveat": (
-            f"Median of the last {len(durations)} completed full reads, so the estimate is "
-            "measured rather than promised. Incremental feed top-ups are excluded: they finish "
-            "in under a second and answer a different question. A large diary dominates the "
-            "worst case — a big profile read at a rate that does not trip the feed."
+            f"Measured across the last {len(durations)} fulfilled "
+            f"{'request' if len(durations) == 1 else 'requests'}, from asking to available. "
+            "A full read runs on a residential machine somebody has to start, so the wait is "
+            "mostly queue rather than compute — which is why this is measured rather than "
+            "promised."
         ),
     }
 

--- a/backend/tests/test_library_sections.py
+++ b/backend/tests/test_library_sections.py
@@ -25,7 +25,9 @@ from database.models import (
     MovieList,
     MovieListItem,
     MovieWatchProvider,
+    AppUser,
     Profile,
+    ProfileAccessRequest,
     ProfileFeedState,
     ProfileFilm,
     ProfileSync,
@@ -72,7 +74,9 @@ def _compile_big_integer_as_sqlite_integer(_type, _compiler, **_kwargs):
 
 
 TABLES = (
+    AppUser.__table__,
     Profile.__table__,
+    ProfileAccessRequest.__table__,
     ProfileSync.__table__,
     SyncDataset.__table__,
     ProfileFeedState.__table__,
@@ -229,6 +233,30 @@ def _sync(database: Session, profile: Profile, *, datasets: dict[str, int]) -> P
         )
     database.commit()
     return sync
+
+
+
+def _fulfilled_request(
+    database: Session, profile: Profile, *, waited: timedelta
+) -> ProfileAccessRequest:
+    """Somebody asked, and `waited` later the profile was available."""
+
+    user = AppUser(clerk_user_id=f"user_{next(_IDS)}")
+    database.add(user)
+    database.commit()
+    requested_at = datetime(2026, 8, 1, 9, tzinfo=timezone.utc)
+    request = ProfileAccessRequest(
+        user_id=user.id,
+        requested_username=profile.username,
+        normalized_username=profile.username.casefold(),
+        status="fulfilled",
+        fulfilled_profile_id=profile.id,
+        requested_at=requested_at,
+        resolved_at=requested_at + waited,
+    )
+    database.add(request)
+    database.commit()
+    return request
 
 
 def test_a_runtime_band_nobody_queued_has_no_ratio(database: Session) -> None:
@@ -633,7 +661,7 @@ def test_a_backing_off_feed_reports_why(database: Session) -> None:
     assert "429" in feed["why"]
 
 
-def test_latency_refuses_to_estimate_without_a_completed_run(database: Session) -> None:
+def test_latency_refuses_to_estimate_without_a_fulfilled_request(database: Session) -> None:
     viewer = _profile(database, "viewer")
 
     result = build_request_latency(database, [viewer])
@@ -756,22 +784,24 @@ def test_a_feed_top_up_does_not_make_a_current_importer_look_old(
     assert entry["missing"] == "Up to date"
 
 
-def test_latency_measures_full_reads_rather_than_sub_second_feed_polls(
+def test_latency_measures_the_wait_a_person_had_rather_than_the_import(
     database: Session,
 ) -> None:
-    """A top-up finishes in under a second. Measuring those answered "a
-    request takes 0s" beside a queue whose real answer is minutes."""
+    """A sync row times the ingestion of a bundle the runner already produced
+    -- seconds, for work that waited days on a human. Timing those answered
+    "a request takes 0s" beside a queue whose real answer is days."""
 
     viewer = _profile(database, "viewer")
-    _sync(database, viewer, datasets={"films": 400})  # one hour, start to end
+    _sync(database, viewer, datasets={"films": 400})
     for offset in range(5):
         _incremental_sync(database, viewer, datasets={"films": 1}, minutes_after=offset)
+    _fulfilled_request(database, viewer, waited=timedelta(days=2))
 
     result = build_request_latency(database, [viewer])
 
     assert result["runs"] == 1
-    assert result["median_seconds"] == 3600
-    assert "full reads" in result["caveat"]
+    assert result["median_seconds"] == int(timedelta(days=2).total_seconds())
+    assert "asking to available" in result["caveat"]
 
 
 def test_a_top_up_never_stands_in_for_the_snapshot_beneath_it(

--- a/frontend/src/views/data/ProfilesTab.tsx
+++ b/frontend/src/views/data/ProfilesTab.tsx
@@ -81,7 +81,11 @@ function duration(seconds: number | null): string {
   if (seconds < 90) return `${Math.round(seconds)}s`;
   const minutes = Math.round(seconds / 60);
   if (minutes < 90) return `${minutes}m`;
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+  const hours = Math.floor(minutes / 60);
+  // Days, once there are any. A wait that is mostly somebody getting round
+  // to starting a batch reads as "2d 3h", not as "51h 0m".
+  if (hours >= 24) return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+  return `${hours}h ${minutes % 60}m`;
 }
 
 function errorText(error: unknown): string {
@@ -1175,8 +1179,8 @@ export default function ProfilesTab({
 
       <Panel
         title="HOW LONG A REQUEST ACTUALLY TAKES"
-        src="profile_syncs durations"
-        blurb="Measured from completed runs rather than promised."
+        src="profile_access_requests · requested_at → resolved_at"
+        blurb="From asking to available, across every request this instance has fulfilled — not how long the import ran."
         stats={
           latencyQuery.data && latencyQuery.data.runs
             ? [
@@ -1197,7 +1201,7 @@ export default function ProfilesTab({
           errorBody: 'Every other panel on this tab is unaffected.',
           empty: {
             title: 'Nothing measurable yet',
-            body: 'No completed sync carries both a start and an end time, so an estimate would be a promise rather than a figure.',
+            body: 'No request has been fulfilled here yet, so an estimate would be a promise rather than a figure.',
           },
         })}
       </Panel>

--- a/frontend/src/views/data/RefreshesTab.tsx
+++ b/frontend/src/views/data/RefreshesTab.tsx
@@ -30,7 +30,11 @@ function duration(seconds: number | null): string {
   if (seconds < 90) return `${Math.round(seconds)}s`;
   const minutes = Math.round(seconds / 60);
   if (minutes < 90) return `${minutes}m`;
-  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+  const hours = Math.floor(minutes / 60);
+  // Days, once there are any. A wait that is mostly somebody getting round
+  // to starting a batch reads as "2d 3h", not as "51h 0m".
+  if (hours >= 24) return `${Math.floor(hours / 24)}d ${hours % 24}h`;
+  return `${hours}h ${minutes % 60}m`;
 }
 
 export default function RefreshesTab({ profiles }: { profiles: string[] }) {
@@ -199,7 +203,7 @@ export default function RefreshesTab({ profiles }: { profiles: string[] }) {
 
       <Panel
         title="FULL REFRESH · OWNER EXPORT"
-        src="profile_syncs · exports"
+        src="profile_access_requests · exports"
         stats={
           latencyQuery.data && latencyQuery.data.runs
             ? [


### PR DESCRIPTION
Follow-up to #150, which fixed three panels by excluding the RSS top-ups. This one's median moved 0s → 1s rather than to something plausible — and that tell is the real bug.

`profile_syncs` rows time the **ingestion of a bundle the residential runner already produced**. That is seconds of work. It says nothing about the two things the wait is actually made of: a person getting round to starting the batch, and the scrape itself. So a panel titled "HOW LONG A REQUEST ACTUALLY TAKES" answered in seconds for something that takes days.

`profile_access_requests` already records both ends of the real span — `requested_at` when somebody asked, `resolved_at` stamped exactly at fulfilment. That is the only span that contains the queue, and it is what the panel measures now.

- Fulfilment latency is a property of the instance, not of a selection, so the route still **authorizes** the usernames it is given (an unauthorized username must not answer differently here than anywhere else) and then deliberately does not filter by them.
- `duration()` learned days: a wait that is mostly queue reads as `2d 3h`, not `51h 0m`.
- Panel `src` and blurb now name what is measured, so the source line stays true to the number above it.

Tests rewritten to the new meaning: refuses to estimate with no fulfilled request; measures the person's wait even when sync rows and feed top-ups both exist and are much shorter.

714 backend tests, 286/286 e2e, tsc and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)