### PR TITLE
Render the ten things we collected and never showed anybody

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -567,7 +567,14 @@ export const profileStats = {
   },
   // Deliberately overlaps our figures: `directors` agrees, `hours` and
   // `longest_streak` do not, so both comparison branches render.
-  letterboxd_reported: { hours: 2_130, directors: 640, longest_streak: 19 },
+  letterboxd_reported: {
+    hours: 2_130,
+    directors: 640,
+    longest_streak: 19,
+    // A key the label map does not know: the stats page's shape varies by
+    // account, and an unanticipated figure is still theirs.
+    highest_rated_year: 2018,
+  },
 };
 
 // The unwatched watchlist ranked by the circle. One recommendation has no
@@ -1359,7 +1366,12 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
         bio: 'Watching everything, ranking nothing.',
         join_date: null,
         first_logged_date: '2019-03-04',
-        external_links: [],
+        external_links: [
+          { label: 'letterboxd.com/alpha', url: 'https://letterboxd.com/alpha/' },
+          // No label: the importer falls the label back to the URL, and the
+          // panel must print something either way.
+          { url: 'https://alpha.example/blog' },
+        ],
         followers_count: 741,
         following_count: 268,
         caveat: 'Pronouns and location come from an official export only. Where a profile has not supplied one, the row is absent rather than filled with a guess — and Letterboxd publishes no join date on a public page at all.',
@@ -2154,9 +2166,37 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
           },
         ],
         liked_lists: [],
+        // One author resolved and one like that never resolved: the panel must
+        // rank the first and say the second was left out rather than pooled.
+        liked_authors: [{ username: 'carol', likes: 2, unresolved_likes: 1 }],
         comments: [],
-        lost_entries: [],
-        totals: { liked_reviews: 2, liked_lists: 0, comments: 0, lost_entries: 0 },
+        lost_entries: [
+          {
+            lost_kind: 'deleted',
+            entry_type: 'review',
+            title: 'A Film Letterboxd Forgot',
+            release_year: 1998,
+            source_url: null,
+            entry_date: '2019-04-02',
+            watched_date: '2019-04-01',
+            rating: 4,
+            body_text: 'The projector broke twice and it was still the best night of that year.',
+          },
+          // A deleted diary row carries no text; the panel must say so rather
+          // than render an empty cell that reads as text we failed to keep.
+          {
+            lost_kind: 'orphaned',
+            entry_type: 'diary',
+            title: 'An Orphaned Entry',
+            release_year: null,
+            source_url: null,
+            entry_date: '2020-01-05',
+            watched_date: null,
+            rating: null,
+            body_text: null,
+          },
+        ],
+        totals: { liked_reviews: 2, liked_lists: 0, comments: 0, lost_entries: 2 },
       });
     }
   }

--- a/frontend/e2e/represented-data.spec.ts
+++ b/frontend/e2e/represented-data.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+/**
+ * Ten data points were collected or computed, served by the API, and rendered
+ * nowhere — mostly a key inside a payload whose siblings a panel already drew.
+ * The backend had done the work every time; only the last mile was missing.
+ * Each one is pinned here, because "nobody rendered it" is exactly the kind of
+ * regression no other test notices.
+ */
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test("Letterboxd's own stats page is shown, labelled, and attributed to them", async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'WHAT LETTERBOXD SAYS ABOUT THEM' })
+    .first();
+  await expect(panel).toBeVisible();
+  // Renamed for a reader, not dumped as the raw key.
+  await expect(panel.getByText('Hours watched', { exact: true })).toBeVisible();
+  await expect(panel.getByText('2,130')).toBeVisible();
+  await expect(panel.getByText('Longest streak', { exact: true })).toBeVisible();
+  // Their figures, and the panel says whose they are.
+  await expect(panel).toContainText('Their figures, not ours');
+});
+
+test('a key Letterboxd sends that we did not anticipate is still rendered', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'WHAT LETTERBOXD SAYS ABOUT THEM' })
+    .first();
+  // `highest_rated_year` has no entry in the label map; it must appear with
+  // its underscores stripped rather than be dropped.
+  await expect(panel.getByText('highest rated year', { exact: true })).toBeVisible();
+  await expect(panel.getByText('2,018')).toBeVisible();
+});
+
+test('return journeys report the second viewing, not just the rewatch', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'WHEN THEY WENT BACK' }).first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('MEDIAN DAYS BETWEEN')).toBeVisible();
+  await expect(panel.getByText('AVG RATING CHANGE')).toBeVisible();
+  await expect(panel.getByText('Rated it higher')).toBeVisible();
+  await expect(panel.getByText('Rated it lower')).toBeVisible();
+  await expect(panel.getByText('Landed on the same star')).toBeVisible();
+});
+
+test('the director gender split names its denominator rather than the library', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'WHO DIRECTED WHAT THEY WATCH' })
+    .first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('Directed by women', { exact: true })).toBeVisible();
+  await expect(panel.getByText('Mixed directing teams', { exact: true })).toBeVisible();
+  // A film with no recorded gender is excluded, and the caveat says so — the
+  // three counts deliberately do not add up to the library.
+  await expect(panel).toContainText('940');
+  await expect(panel).toContainText('left out of the share');
+});
+
+test('their highest-rated corners are shown with the average\'s own denominator', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'WHERE THEY RATE HIGHEST' }).first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('Genre', { exact: true })).toBeVisible();
+  await expect(panel.getByText('Decade', { exact: true })).toBeVisible();
+  await expect(panel.getByText('Director', { exact: true })).toBeVisible();
+  // RATED is the denominator, distinct from the bucket size.
+  await expect(panel.getByText('RATED', { exact: true })).toBeVisible();
+});
+
+test('the executive producer joins the crew rollup it was computed beside', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'THE CREW BEYOND THE BIG THREE' })
+    .first();
+  await expect(panel.getByText('Executive producer', { exact: true })).toBeVisible();
+  await expect(panel.getByText('Stan Lee')).toBeVisible();
+});
+
+test('a year in the taste timeline reports its rewatches and likes', async ({ page }) => {
+  await page.goto('/people?tab=one&subject=alpha');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'GETTING HARSHER OR SOFTER' }).first();
+  await expect(panel).toBeVisible();
+  // The hint carries the year's shape, not only its average.
+  await expect(panel.locator('[title*="rewatches"]').first()).toBeVisible();
+});
+
+test('the member card shows the links the profile supplied', async ({ page }) => {
+  await page.goto('/people?tab=reach&subject=alpha');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'MEMBER CARD' }).first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('Links', { exact: true })).toBeVisible();
+  await expect(panel).toContainText('letterboxd.com/alpha');
+});
+
+test('liked writing is counted by author, and unresolved likes are declared', async ({ page }) => {
+  await page.goto('/people?tab=reach&subject=alpha');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'WHOSE WRITING THEY LIKE' }).first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('@carol')).toBeVisible();
+  // Excluded rather than pooled under "unknown", and the panel says how many.
+  await expect(panel).toContainText('1 like');
+  await expect(panel).toContainText('could not be traced');
+});
+
+test('lost history shows the text, and says so when an entry never had any', async ({ page }) => {
+  await page.goto('/people?tab=reach&subject=alpha');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'WHAT LETTERBOXD NO LONGER HAS' })
+    .first();
+  await expect(panel).toBeVisible();
+  await expect(panel.getByText('A Film Letterboxd Forgot (1998)')).toBeVisible();
+  await expect(panel).toContainText('The projector broke twice');
+  // An entry with no body is stated as such rather than left blank, which
+  // would read as text we failed to keep.
+  await expect(panel.getByText('no text in the entry')).toBeVisible();
+});
+
+test('a ranked list is distinguishable from a bag of films', async ({ page }) => {
+  await page.goto('/tonight?tab=lists');
+
+  const panel = page.locator('.terminal-root section', { hasText: 'WORK THROUGH A LIST' }).first();
+  await expect(panel.getByText('ORDER', { exact: true })).toBeVisible();
+  await expect(panel.getByText('ranked', { exact: true })).toBeVisible();
+  await expect(panel.getByText('unordered', { exact: true })).toBeVisible();
+});

--- a/frontend/src/components/terminal/sections.ts
+++ b/frontend/src/components/terminal/sections.ts
@@ -88,10 +88,10 @@ export const SECTIONS: SectionDef[] = [
     blurb:
       'Merges Analysis, Compare and Network. Three doors into the same subject become one destination with four tabs.',
     tabs: [
-      { id: 'one', label: 'ONE PERSON', panels: 29 },
+      { id: 'one', label: 'ONE PERSON', panels: 33 },
       { id: 'two', label: 'TWO PEOPLE', panels: 11 },
       { id: 'circle', label: 'THE CIRCLE', panels: 7 },
-      { id: 'reach', label: 'REACH', panels: 6 },
+      { id: 'reach', label: 'REACH', panels: 8 },
     ],
   },
   {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1273,10 +1273,23 @@ export interface LostEntryRecord {
   body_text: string | null;
 }
 
+/**
+ * Authors ranked by how often this member liked their writing. Likes whose
+ * author could not be resolved are excluded rather than bucketed under an
+ * "unknown" author; `unresolved_likes` is how many, so a short list reads as
+ * partial resolution rather than as a short history.
+ */
+export interface MemberLikedAuthor {
+  username: string;
+  likes: number;
+  unresolved_likes: number;
+}
+
 export interface MemberArchiveResponse {
   username: string;
   liked_reviews: MemberContentLikeEntry[];
   liked_lists: MemberContentLikeEntry[];
+  liked_authors: MemberLikedAuthor[];
   comments: MemberCommentEntry[];
   lost_entries: LostEntryRecord[];
   totals: {

--- a/frontend/src/views/people/OnePersonTab.tsx
+++ b/frontend/src/views/people/OnePersonTab.tsx
@@ -34,6 +34,21 @@ import {
 
 const MONTH_INITIAL = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D'];
 
+/**
+ * Letterboxd's stats page names its own figures, and the key set varies by
+ * account. Anything not listed here renders with its underscores stripped
+ * rather than being hidden -- a figure we did not anticipate is still theirs,
+ * and dropping it would quietly lose data we went to a Patron-only page for.
+ */
+const REPORTED_STAT_LABELS: Record<string, string> = {
+  films: 'Films logged',
+  hours: 'Hours watched',
+  countries: 'Countries visited',
+  directors: 'Directors seen',
+  '2_film_days': 'Days with two or more films',
+  longest_streak: 'Longest streak',
+};
+
 function stars(rating: number | null | undefined): string {
   if (rating === null || rating === undefined) return '—';
   const full = Math.floor(rating);
@@ -789,7 +804,10 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                 // is a few tenths, and a 0-5 axis would flatten it to nothing.
                 value: Math.round((own?.average_rating ?? 0) * 100),
                 display: own?.average_rating ? own.average_rating.toFixed(2) : '—',
-                hint: `${point.label}: average ${own?.average_rating?.toFixed(2) ?? '—'} over ${own?.rated_events ?? 0} rated events`,
+                // The year's shape, not just its average: the same payload
+                // carries how much of that year was a second viewing and how
+                // much of it they liked, and both were being thrown away.
+                hint: `${point.label}: average ${own?.average_rating?.toFixed(2) ?? '—'} over ${own?.rated_events ?? 0} rated events · ${own?.rewatch_count ?? 0} of ${own?.watch_events ?? 0} were rewatches · ${own?.liked_count ?? 0} liked`,
               };
             })}
             max={500}
@@ -1237,6 +1255,7 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                 ['Editor', stats?.top_editors?.[0]],
                 ['Writer', stats?.top_writers?.[0]],
                 ['Producer', stats?.top_producers?.[0]],
+                ['Executive producer', stats?.top_executive_producers?.[0]],
                 ['Production design', stats?.top_production_designers?.[0]],
                 ['Costume design', stats?.top_costume_designers?.[0]],
                 ['Casting', stats?.top_casting?.[0]],
@@ -1248,6 +1267,216 @@ export default function OnePersonTab({ subject }: { subject: string }) {
                   cell(role, { size: '9.5px', tone: 'var(--muted)' }),
                   cell(person!.name, { font: 's', size: '10.5px', tone: 'var(--ink2)', wrap: true }),
                   cell(String(person!.count), { align: 'right', tone: 'var(--accent)' }),
+                ],
+              }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHERE THEY RATE HIGHEST"
+        isNew
+        src="profile_films.rating grouped by genre · decade · director"
+        blurb="Their most generous corner of the library, by their own stars rather than by how much they watch."
+        caveat={
+          stats?.highest_rated.genre
+            ? 'Averages run over rated films only, and a bucket needs enough of them to be worth naming — the count beside each average is the denominator, not the bucket size.'
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty:
+            !stats?.highest_rated.genre &&
+            !stats?.highest_rated.decade &&
+            !stats?.highest_rated.director,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Their highest-rated corners could not be read',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'Not enough ratings to name a favourite corner',
+            body: 'Every bucket needs a few rated films before its average says anything, and none has reached that yet.',
+          },
+        }) ?? (
+          <Rows
+            columns="88px minmax(0,1fr) 52px 48px"
+            head={['KIND', 'HIGHEST', ['AVG', 'right'], ['RATED', 'right']]}
+            rows={(
+              [
+                ['Genre', stats?.highest_rated.genre?.label, stats?.highest_rated.genre],
+                ['Decade', stats?.highest_rated.decade?.label, stats?.highest_rated.decade],
+                ['Director', stats?.highest_rated.director?.name, stats?.highest_rated.director],
+              ] as Array<
+                [string, string | undefined, { average_rating: number; rated_count: number } | null | undefined]
+              >
+            )
+              .filter(([, label, entry]) => Boolean(label) && Boolean(entry))
+              .map(([kind, label, entry]) => ({
+                cells: [
+                  cell(kind, { size: '9.5px', tone: 'var(--muted)' }),
+                  cell(label!, { font: 's', size: '10.5px', tone: 'var(--ink2)', wrap: true }),
+                  cell(entry!.average_rating.toFixed(2), {
+                    align: 'right',
+                    tone: 'var(--accent)',
+                  }),
+                  cell(String(entry!.rated_count), { align: 'right', size: '10px' }),
+                ],
+              }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHEN THEY WENT BACK"
+        isNew
+        src="watch_events · the same film, twice"
+        blurb="A film watched again, and what the second viewing did to the rating. The same person, the same film, two sittings — which is the only honest way to measure a mind changing."
+        stats={
+          stats && stats.return_journeys.revisited_films > 0
+            ? [
+                { big: stats.return_journeys.revisited_films, unit: 'WENT BACK TO' },
+                {
+                  big:
+                    stats.return_journeys.median_days_to_return === null
+                      ? '—'
+                      : count(stats.return_journeys.median_days_to_return, 'day').split(' ')[0],
+                  unit: 'MEDIAN DAYS BETWEEN',
+                  tone: 'var(--accent)',
+                },
+                {
+                  big:
+                    stats.return_journeys.average_change === null
+                      ? '—'
+                      : `${stats.return_journeys.average_change > 0 ? '+' : ''}${stats.return_journeys.average_change.toFixed(2)}`,
+                  unit: 'AVG RATING CHANGE',
+                  tone:
+                    (stats.return_journeys.average_change ?? 0) >= 0 ? 'var(--ok)' : 'var(--bad)',
+                },
+              ]
+            : undefined
+        }
+        caveat={
+          stats && stats.return_journeys.revisited_films > 0
+            ? `Only the ${count(stats.return_journeys.rated_twice, 'film')} rated on both viewings can move a number here; a rewatch nobody re-rated is counted as a return and nothing more.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.return_journeys.revisited_films ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'Return journeys could not be read',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'They have not gone back to anything yet',
+            body: 'A return needs two dated viewings of one film. Until then there is no second opinion to compare against.',
+          },
+        }) ?? (
+          <Rows
+            columns="minmax(0,1fr) 52px"
+            head={['ON THE SECOND VIEWING', ['FILMS', 'right']]}
+            rows={(
+              [
+                ['Rated it higher', stats?.return_journeys.rating_rose ?? 0, 'var(--ok)'],
+                ['Rated it lower', stats?.return_journeys.rating_fell ?? 0, 'var(--bad)'],
+                ['Landed on the same star', stats?.return_journeys.rating_held ?? 0, 'var(--ink2)'],
+              ] as Array<[string, number, string]>
+            ).map(([label, value, tone]) => ({
+              cells: [
+                cell(label, { font: 's', size: '10.5px', tone: 'var(--ink2)' }),
+                cell(String(value), { align: 'right', tone }),
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHO DIRECTED WHAT THEY WATCH"
+        isNew
+        src="movie_enrichments.credits · director gender"
+        blurb="The gender split of the directors behind this library, counted from what TMDB records."
+        caveat={
+          stats
+            ? `Measured over the ${stats.director_gender.measured_films.toLocaleString()} films whose director TMDB records a gender for. A film where none is recorded is left out of the share rather than assigned to a side, so these three counts do not add up to the library.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: (stats?.director_gender.measured_films ?? 0) === 0,
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: 'The director split could not be read',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No director gender recorded yet',
+            body: 'TMDB enrichment has not reached enough of this library to measure a split, and guessing one from a name would be a fabrication.',
+            cta: { label: 'SEE THE MATCH RATE', href: sectionHref('films', 'gaps') },
+          },
+        }) ?? (
+          <Bars
+            items={(
+              [
+                ['Directed by men', stats?.director_gender.men ?? 0],
+                ['Directed by women', stats?.director_gender.women ?? 0],
+                ['Mixed directing teams', stats?.director_gender.mixed ?? 0],
+              ] as Array<[string, number]>
+            ).map(([name, weight]) => ({
+              name,
+              weight,
+              value: weight.toLocaleString(),
+              sub:
+                stats && stats.director_gender.measured_films > 0
+                  ? `${Math.round((weight / stats.director_gender.measured_films) * 100)}%`
+                  : undefined,
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHAT LETTERBOXD SAYS ABOUT THEM"
+        isNew
+        src="profiles.stats_snapshot"
+        blurb="Letterboxd's own stats page, verbatim. It counts things we cannot derive — hours in front of a screen, a longest streak — because it sees runtimes and a calendar we do not."
+        caveat="Their figures, not ours, and taken at the last read of that page. Where these disagree with the numbers elsewhere on this tab, both are honest: Letterboxd counts entries we may not hold, and counts them its own way."
+      >
+        {panelState({
+          isLoading: statsQuery.isLoading,
+          error: statsQuery.error,
+          isEmpty: !stats?.letterboxd_reported || Object.keys(stats.letterboxd_reported).length === 0,
+          severity: 'quiet',
+          onRetry: () => statsQuery.refetch(),
+          errorTitle: "Letterboxd's own figures could not be read",
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'That page has never been read for this profile',
+            body: 'The stats page is Patron-only, so it is absent for most accounts rather than empty. Nothing here is inferred when it is missing.',
+          },
+        }) ?? (
+          <Rows
+            columns="minmax(0,1fr) 92px"
+            head={['THEY REPORT', ['VALUE', 'right']]}
+            // The key set varies by account, so this reads whatever the page
+            // gave us rather than asking for a fixed shape and rendering
+            // blanks for the rest.
+            rows={Object.entries(stats?.letterboxd_reported ?? {})
+              .filter(([, value]) => value !== null && value !== '')
+              .map(([key, value]) => ({
+                cells: [
+                  cell(REPORTED_STAT_LABELS[key] ?? key.replace(/_/g, ' '), {
+                    font: 's',
+                    size: '10.5px',
+                    tone: 'var(--ink2)',
+                    wrap: true,
+                  }),
+                  cell(typeof value === 'number' ? value.toLocaleString() : String(value), {
+                    align: 'right',
+                    tone: 'var(--accent)',
+                  }),
                 ],
               }))}
           />

--- a/frontend/src/views/people/ReachTab.tsx
+++ b/frontend/src/views/people/ReachTab.tsx
@@ -10,6 +10,7 @@ import Posters from '../../components/terminal/bodies/Posters';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { BarsSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { count } from '../../components/terminal/plural';
 import { memberArchiveApi, peopleApi, profileApi, profileStatsApi } from '../../services/api';
 
 /** The film a liked review is about, where the short link says so. */
@@ -81,6 +82,8 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
     [archiveQuery.data],
   );
   const likedLists = archiveQuery.data?.liked_lists ?? [];
+  const likedAuthors = archiveQuery.data?.liked_authors ?? [];
+  const lostEntries = archiveQuery.data?.lost_entries ?? [];
   const card = cardQuery.data;
 
   // Films they liked a review of and have no watch record for. "No watch
@@ -235,6 +238,105 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
       </Panel>
 
       <Panel
+        title="WHAT LETTERBOXD NO LONGER HAS"
+        isNew
+        src="lost_entries.body_text"
+        blurb="Their own entries that exist in an export and no longer exist on Letterboxd — the diary rows and reviews the platform cannot show them any more, with the text intact."
+        caveat={
+          lostEntries.length
+            ? `Export-only, and held exactly as the export gave it. Data › Lost & found counts these across everybody; this is the ${count(Math.min(lostEntries.length, 8), 'entry')} shown of ${count(lostEntries.length, 'held')} for @${subject}.`
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: archiveQuery.isLoading,
+          error: archiveQuery.error,
+          isEmpty: lostEntries.length === 0,
+          severity: 'quiet',
+          onRetry: () => archiveQuery.refetch(),
+          errorTitle: 'The archive could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'Nothing of theirs has been lost',
+            body: 'Either every entry in their export still exists on Letterboxd, or no export has been supplied — the two are different, and Data › Lost & found says which.',
+            cta: { label: 'HOW TO SUPPLY AN EXPORT', href: sectionHref('data', 'profiles') },
+          },
+        }) ?? (
+          <Rows
+            columns="52px minmax(0,1fr) 74px minmax(0,1.4fr)"
+            head={['KIND', 'WHAT', ['WHEN', 'right'], 'WHAT IT SAID']}
+            rows={lostEntries.slice(0, 8).map((entry) => ({
+              cells: [
+                cell(entry.entry_type, { size: '9.5px', tone: 'var(--muted)' }),
+                cell(
+                  entry.title
+                    ? entry.release_year
+                      ? `${entry.title} (${entry.release_year})`
+                      : entry.title
+                    : '—',
+                  { font: 's', size: '10.5px', tone: 'var(--ink2)', wrap: true },
+                ),
+                cell(
+                  entry.watched_date || entry.entry_date
+                    ? localDate((entry.watched_date || entry.entry_date) as string).toLocaleDateString(
+                        'en-GB',
+                        { month: 'short', year: 'numeric' },
+                      )
+                    : '—',
+                  { align: 'right', size: '10px', tone: 'var(--muted)' },
+                ),
+                // A deleted diary row carries no text; saying so beats an
+                // empty cell that reads as text we failed to keep.
+                cell(entry.body_text || 'no text in the entry', {
+                  font: 's',
+                  size: '10px',
+                  tone: entry.body_text ? 'var(--ink3)' : 'var(--dim)',
+                  wrap: true,
+                }),
+              ],
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
+        title="WHOSE WRITING THEY LIKE"
+        isNew
+        src="member_content_likes.target_username"
+        blurb="The same likes as the panel above, counted by who wrote the thing. Reading one person repeatedly is a stronger signal than any single like."
+        caveat={
+          likedAuthors.length
+            ? likedAuthors[0].unresolved_likes
+              ? `${count(likedAuthors[0].unresolved_likes, 'like')} could not be traced to an author and are left out entirely rather than pooled under "unknown", so these counts run below the totals above.`
+              : 'Every like held for this profile resolved to an author.'
+            : undefined
+        }
+      >
+        {panelState({
+          isLoading: archiveQuery.isLoading,
+          error: archiveQuery.error,
+          isEmpty: likedAuthors.length === 0,
+          severity: 'quiet',
+          onRetry: () => archiveQuery.refetch(),
+          errorTitle: 'The archive could not be loaded',
+          errorBody: 'Every other panel on this tab is unaffected.',
+          empty: {
+            title: 'No liked writing traced to an author yet',
+            body: 'Likes come from an official export, and each one needs its author resolved before it can be counted here.',
+            cta: { label: 'HOW TO SUPPLY AN EXPORT', href: sectionHref('data', 'profiles') },
+          },
+        }) ?? (
+          <Bars
+            items={likedAuthors.map((author) => ({
+              name: `@${author.username}`,
+              weight: author.likes,
+              value: count(author.likes, 'like'),
+            }))}
+          />
+        )}
+      </Panel>
+
+      <Panel
         title="LIKED BUT NEVER SEEN"
         isNew
         src="member_content_likes × profile_films"
@@ -291,6 +393,19 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
                 ['Location', card?.location],
                 ['First logged', card?.first_logged_date],
                 ['Bio', card?.bio],
+                // Their own links, off their own profile header. The card was
+                // fetching these and rendering the five rows above it. The
+                // label falls back to the URL at import, so one is always
+                // there to print.
+                [
+                  'Links',
+                  card?.external_links?.length
+                    ? card.external_links
+                        .map((link) => link.label || link.url)
+                        .filter(Boolean)
+                        .join(' · ')
+                    : null,
+                ],
               ] as Array<[string, string | null | undefined]>
             )
               // A field the profile never supplied is absent, not an empty row

--- a/frontend/src/views/tonight/ListsTab.tsx
+++ b/frontend/src/views/tonight/ListsTab.tsx
@@ -61,12 +61,20 @@ export default function ListsTab({ profiles }: { profiles: string[] }) {
           },
         }) ?? (
           <Rows
-            columns="minmax(0,1.3fr) 70px minmax(0,0.7fr)"
-            head={['LIST', ['FILMS', 'right'], 'OWNER']}
+            columns="minmax(0,1.3fr) 70px 62px minmax(0,0.7fr)"
+            // ORDER, because a ranked list is a different object from a bag of
+            // films: its first entry is an argument, and working through it in
+            // any other order misreads the owner.
+            head={['LIST', ['FILMS', 'right'], ['ORDER', 'right'], 'OWNER']}
             rows={(listsQuery.data?.lists ?? []).slice(0, 8).map((list) => ({
               cells: [
                 cell(list.name, { font: 's', size: '11px', tone: 'var(--ink)', wrap: true }),
                 cell(list.movie_count.toLocaleString(), { align: 'right', tone: 'var(--ink)' }),
+                cell(list.is_ranked ? 'ranked' : 'unordered', {
+                  align: 'right',
+                  size: '10px',
+                  tone: list.is_ranked ? 'var(--accent)' : 'var(--dim)',
+                }),
                 cell(`@${list.owner}`, { size: '10px', tone: 'var(--muted)' }),
               ],
             }))}


### PR DESCRIPTION
An audit of all 26 tables (~380 columns) against what the panels actually draw found **ten data points that are collected or computed, served by the API, fetched by the client, and rendered nowhere.** The API surface itself is fully consumed — 71 routes, the only frontend-less one is a POST ingestion endpoint — so this was the last mile every time: a key inside a payload whose siblings a panel already drew.

**Four get their own panels** (People › One person), with live values from production:

| Panel | Shows | @whiteknight03x |
|---|---|---|
| WHAT LETTERBOXD SAYS ABOUT THEM | their stats page verbatim | **2,410 hours**, 43 countries, 780 directors, 123 two-film days, **22-week streak** |
| WHEN THEY WENT BACK | the second viewing of a film | 2 revisited, median **10 days**, rating rose 1 / held 1, avg **+0.25** |
| WHO DIRECTED WHAT THEY WATCH | director gender split | 1,053 films measured, **10.2% women** |
| WHERE THEY RATE HIGHEST | most generous genre/decade/director | History 3.48 · 1980s 3.75 · **Park Chan-wook 4.38** |

**Six join panels that already fetched them:** the executive producer in the crew rollup (one of ten, the only one dropped); per-year rewatches and likes in the rating timeline; `external_links` on the member card; the **ranked** flag in the list picker (a ranked list argues for an order — reading it as a bag misreads its owner); authors ranked by liked writing, with unresolved likes declared rather than pooled under "unknown"; and the **text** of entries Letterboxd no longer has.

Product rules held throughout: the stats page is attributed to Letterboxd, not to us, and reads whatever keys it sent (its shape varies by account — an unanticipated key renders rather than being dropped); the gender split names its denominator because films with no recorded gender are excluded, not assigned; a lost entry with no body says so rather than showing a blank that reads as text we failed to keep.

Panel counts updated (One person 29 → 33, Reach 6 → 8) and pinned. New `represented-data.spec.ts` holds all ten, including the unmapped-key fallback and the no-text case.

tsc clean, lint clean, production build clean, **308/308 e2e**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)