### PR TITLE
Stop the changes strip claiming a window it never asked for

### DIFF
--- a/frontend/e2e/represented-data.spec.ts
+++ b/frontend/e2e/represented-data.spec.ts
@@ -140,3 +140,17 @@ test('a ranked list is distinguishable from a bag of films', async ({ page }) =>
   await expect(panel.getByText('ranked', { exact: true })).toBeVisible();
   await expect(panel.getByText('unordered', { exact: true })).toBeVisible();
 });
+
+test('the changes strip states the window it actually drew from', async ({ page }) => {
+  await page.goto('/overview');
+
+  const panel = page
+    .locator('.terminal-root section', { hasText: 'THE LATEST CHANGES WE DETECTED' })
+    .first();
+  await expect(panel).toBeVisible();
+  // It asks the API for history, so it must not claim to be one sync's worth.
+  await expect(panel).not.toContainText('since the last refresh');
+  await expect(panel).not.toContainText('comparing this sync against the last one');
+  // And it names the window it drew from rather than leaving it implied.
+  await expect(panel).toContainText('reaching back to');
+});

--- a/frontend/e2e/terminal-shell.spec.ts
+++ b/frontend/e2e/terminal-shell.spec.ts
@@ -29,7 +29,7 @@ test('Overview renders the eight panels, each naming the table it reads', async 
 
   for (const title of [
     'THE GROUP, IN FIVE NUMBERS',
-    'WHAT CHANGED SINCE THE LAST REFRESH',
+    'THE LATEST CHANGES WE DETECTED',
     'WHO WATCHES WITH WHOM',
     'EVERYONE WE ARE WATCHING',
     'THIS YEAR, MONTH BY MONTH',

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -10,6 +10,8 @@ import Spark from '../../components/terminal/bodies/Spark';
 import { CoWatchMatrix } from '../../components/terminal/bodies/Matrix';
 import { BarsSkeleton, PanelSkeleton, panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
+import { formatDay } from '../../components/terminal/dates';
+import { count } from '../../components/terminal/plural';
 import { importState, sinceLabel } from '../../components/terminal/profileState';
 import { MIN_RATED_OVERLAP, withRatedEvidence } from '../../components/terminal/pairEvidence';
 import { useAdminScope } from '../../hooks/useAdminScope';
@@ -134,6 +136,10 @@ export default function OverviewTab() {
     refetchOnWindowFocus: false,
   });
 
+  // The window the panel actually drew from, so the caveat states it rather
+  // than the copy implying one.
+  const oldestChangeAt = changesQuery.data?.changes.at(-1)?.detected_at ?? null;
+
   const marathonsQuery = useQuery({
     queryKey: ['activity-marathons', usernames],
     queryFn: () => activityApi.getMarathons(usernames, 6),
@@ -215,11 +221,21 @@ export default function OverviewTab() {
         })}
       </Panel>
 
+      {/* Titled "since the last refresh" while asking for the whole change
+          history, which the API distinguishes and reports back in `scope`.
+          The section's question is "what happened while I was away", and a
+          reader who was away a fortnight is not served by one sync's worth of
+          rows -- so the query stays and the copy stops claiming otherwise.
+          The caveat prints the window it actually drew from. */}
       <Panel
-        title="WHAT CHANGED SINCE THE LAST REFRESH"
-        src="refresh_runs · watch_events"
-        blurb="Detected by comparing this sync against the last one. Anything with a zero is not an error — a profile that was not due yet has nothing to report."
-        caveat="Change needs two authoritative reads. A profile's first import is a baseline and deliberately emits nothing."
+        title="THE LATEST CHANGES WE DETECTED"
+        src="profile_data_changes · detected_at"
+        blurb="The most recent changes across the selection, newest first — not one sync's worth. A profile that was not due yet has nothing here, which is not the same as nothing having happened."
+        caveat={
+          oldestChangeAt
+            ? `The ${count(changesQuery.data?.changes.length ?? 0, 'most recent change')}, reaching back to ${formatDay(oldestChangeAt)}. Change needs two authoritative reads: a profile's first import is a baseline and deliberately emits nothing.`
+            : "Change needs two authoritative reads. A profile's first import is a baseline and deliberately emits nothing."
+        }
       >
         {panelState({
           isLoading: changesQuery.isLoading,
@@ -230,8 +246,8 @@ export default function OverviewTab() {
           errorBody: 'The rest of the tab is unaffected; this strip retries on demand.',
           onRetry: () => changesQuery.refetch(),
           empty: {
-            title: 'Nothing changed in the last sync',
-            body: 'Every tracked surface came back identical to the previous read. New rows appear here the moment a refresh finds one.',
+            title: 'No change detected yet',
+            body: 'Every tracked surface has come back identical to the read before it. New rows appear here the moment a refresh finds one.',
             cta: { label: 'OPEN REFRESH LEDGER', href: sectionHref('data', 'refreshes') },
           },
         }) ?? (


### PR DESCRIPTION
Overview's changes panel was titled **"WHAT CHANGED SINCE THE LAST REFRESH"** and blurbed *"detected by comparing this sync against the last one"* — while asking the API for the **whole change history**.

The API distinguishes the two (`latest_sync_only`) and reports which it answered in a `scope` field. The client never passed the flag, so every response came back `scope: "history"` under a heading promising one sync. Verified against production: `/api/recent-changes?limit=8` → `scope: history`.

**The query is the right one to keep.** The section's question is *"what happened while I was away"*, and a reader away a fortnight is not served by one sync's worth of rows. So the copy stops claiming otherwise:

- title → **THE LATEST CHANGES WE DETECTED**
- blurb says "the most recent changes across the selection, newest first — not one sync's worth"
- the caveat now prints **how far back the rows actually reach** rather than leaving the window implied
- empty state no longer says "nothing changed in the last sync"
- `src` corrected to the table it really reads (`profile_data_changes · detected_at`)

Worth noting why this survived: it reads correctly *today* only because the RSS feed keeps producing changes, so history and last-sync happen to overlap. In a quiet week the old copy would have presented a fortnight-old row as something the last refresh had just found.

310/310 e2e (new assertion pins that the panel never re-acquires the claim), tsc and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)