### PR TITLE
Make a production failure reach somebody

### DIFF
--- a/.github/workflows/canary-reset.yml
+++ b/.github/workflows/canary-reset.yml
@@ -160,3 +160,17 @@ jobs:
           if [[ -x deploy/production-ssh.sh ]]; then
             deploy/production-ssh.sh close || true
           fi
+
+  # A failure here has to reach somebody rather than sit in the Actions tab.
+  # `always()` so this still runs when the jobs above failed, and the ref
+  # guard keeps a fork's failing pull request from filing issues here.
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [canary_reset]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: Canary Reset

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1701,3 +1701,17 @@ jobs:
           if [[ -x deploy/production-ssh.sh ]]; then
             deploy/production-ssh.sh close
           fi
+
+  # A failure here has to reach somebody rather than sit in the Actions tab.
+  # `always()` so this still runs when the jobs above failed, and the ref
+  # guard keeps a fork's failing pull request from filing issues here.
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [backend, frontend, e2e, compose, release_gate, release_bundle, deploy_production]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: Production CI

--- a/.github/workflows/failure-alert.yml
+++ b/.github/workflows/failure-alert.yml
@@ -1,0 +1,105 @@
+name: Failure Alert
+
+# Production failures used to land only in the Actions tab, which nobody
+# watches on a good day — the authenticated canary was broken for three days
+# before anyone noticed, and the deploy that a fresh npm advisory blocked
+# failed silently on a merge whose own PR checks were green.
+#
+# Each workflow that guards production calls this at the end of a failed run.
+# It is a called workflow rather than a `workflow_run` listener on purpose:
+# `workflow_run` executes in the base repository's context and is the standard
+# shape of a pwn-request, so the security audit rejects it outright and is
+# right to. Called this way there is no cross-workflow trigger to abuse, and
+# the caller decides when its own failure is worth reporting.
+#
+# The alert is a GitHub issue rather than a chat integration: no secret, no
+# third-party auth, no egress, it reaches whatever notification settings the
+# account already has, and it carries its own state — a still-broken canary
+# comments on the one open issue instead of filing a new one every six hours,
+# so the comment count is how long it has been broken and closing the issue is
+# the acknowledgement.
+
+on:
+  workflow_call:
+    inputs:
+      workflow:
+        description: The failing workflow, named as its own `name:` declares it.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  alert:
+    name: Raise or update the failure issue
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Monitor runner file and network activity
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: File or update the issue for this workflow
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          # Through the environment, never interpolated into the script body:
+          # a branch name is attacker-chosen on a fork and must not be able to
+          # close a string literal.
+          FAILING_WORKFLOW: ${{ inputs.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_BRANCH: ${{ github.ref_name }}
+          RUN_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const {FAILING_WORKFLOW, RUN_URL, RUN_BRANCH, RUN_SHA} = process.env;
+            // One open issue per workflow, found by an exact title rather than
+            // by a label: a label can be edited off an issue by hand, and a
+            // second issue for an already-known failure is the noise that
+            // makes people stop reading these.
+            const title = `${FAILING_WORKFLOW} is failing`;
+            const body = [
+              `**${FAILING_WORKFLOW}** failed.`,
+              '',
+              `- Run: ${RUN_URL}`,
+              `- Branch: \`${RUN_BRANCH}\``,
+              `- Commit: \`${RUN_SHA}\``,
+              '',
+              'This issue stays open until somebody closes it. A repeat failure',
+              'comments here rather than filing a second issue, so the comment',
+              'count is how long this has been broken.',
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const match = existing.find(
+              (issue) => issue.title === title && !issue.pull_request,
+            );
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body,
+              });
+              core.notice(`Commented on existing issue #${match.number}`);
+              return;
+            }
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.notice(`Filed issue #${created.data.number}`);

--- a/.github/workflows/postgres-restore-drill.yml
+++ b/.github/workflows/postgres-restore-drill.yml
@@ -110,3 +110,17 @@ jobs:
           if [[ -x deploy/production-ssh.sh ]]; then
             deploy/production-ssh.sh close
           fi
+
+  # A failure here has to reach somebody rather than sit in the Actions tab.
+  # `always()` so this still runs when the jobs above failed, and the ref
+  # guard keeps a fork's failing pull request from filing issues here.
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [restore-drill]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: PostgreSQL Restore Drill

--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -659,3 +659,17 @@ jobs:
             echo '- The two dedicated identities either passed strict existing-state checks or were safely provisioned from completed unclaimed profiles during their first browser run'
             echo '- One-use tickets and identity configuration were securely removed locally and remotely; Clerk and database secrets remained on the VPS'
           } >>"${GITHUB_STEP_SUMMARY}"
+
+  # A failure here has to reach somebody rather than sit in the Actions tab.
+  # `always()` so this still runs when the jobs above failed, and the ref
+  # guard keeps a fork's failing pull request from filing issues here.
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [public_canary, authenticated_canary]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: Production Canary

--- a/.github/workflows/tmdb-enrichment.yml
+++ b/.github/workflows/tmdb-enrichment.yml
@@ -136,3 +136,17 @@ jobs:
           if [[ -x deploy/production-ssh.sh ]]; then
             deploy/production-ssh.sh close
           fi
+
+  # A failure here has to reach somebody rather than sit in the Actions tab.
+  # `always()` so this still runs when the jobs above failed, and the ref
+  # guard keeps a fork's failing pull request from filing issues here.
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [enrich]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: TMDB Cache Enrichment

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -337,3 +337,105 @@ class AuthCanaryDiagnosticsTests(unittest.TestCase):
         self.assertIn("DELETE FROM app_users", script)
         self.assertNotIn("DELETE FROM profiles", script)
         self.assertNotIn("DELETE FROM watch_events", script)
+
+
+class FailureAlertTests(unittest.TestCase):
+    """A production failure has to reach somebody.
+
+    The authenticated canary was broken for three days before anyone noticed,
+    and a deploy blocked by a fresh npm advisory failed silently on a merge
+    whose own PR checks were green. Both landed only in the Actions tab.
+    """
+
+    ALERT = ".github/workflows/failure-alert.yml"
+
+    GUARDED = (
+        ".github/workflows/ci.yml",
+        ".github/workflows/production-canary.yml",
+        ".github/workflows/tmdb-enrichment.yml",
+        ".github/workflows/postgres-restore-drill.yml",
+        ".github/workflows/canary-reset.yml",
+    )
+
+    def test_every_workflow_that_guards_production_reports_its_own_failure(self) -> None:
+        for relative_path in self.GUARDED:
+            contents = read_repo_file(relative_path)
+            self.assertIn(
+                "uses: ./.github/workflows/failure-alert.yml",
+                contents,
+                f"{relative_path} never reports a failure to anybody",
+            )
+            # The name it reports itself under must be its own `name:`, or the
+            # issue title splits and a still-broken workflow files a second
+            # issue instead of updating the open one.
+            declared = contents.splitlines()[0]
+            self.assertTrue(declared.startswith("name: "))
+            name = declared.removeprefix("name: ").strip()
+            self.assertIn(f"workflow: {name}", contents)
+
+    def test_every_alert_covers_all_of_its_workflow_s_jobs(self) -> None:
+        for relative_path in self.GUARDED:
+            contents = read_repo_file(relative_path)
+            jobs = set(re.findall(r"(?m)^  ([A-Za-z0-9_-]+):$", contents.split("\njobs:", 1)[1]))
+            jobs.discard("alert_on_failure")
+            # Scoped to the alert job: several of these workflows have their
+            # own `needs:` earlier in the file, and reading the first one
+            # tested a different job's dependencies.
+            alert_block = contents.split("\n  alert_on_failure:", 1)
+            self.assertEqual(len(alert_block), 2, relative_path)
+            needs = re.search(r"(?m)^    needs: \[([^\]]*)\]", alert_block[1])
+            self.assertIsNotNone(needs, relative_path)
+            watched = {entry.strip() for entry in needs.group(1).split(",") if entry.strip()}
+            # A job left out of `needs` is a job whose failure is silent.
+            self.assertEqual(
+                jobs,
+                watched,
+                f"{relative_path} does not alert on every one of its jobs",
+            )
+
+    def test_only_a_real_failure_raises_an_alert(self) -> None:
+        for relative_path in self.GUARDED:
+            contents = read_repo_file(relative_path)
+            # A cancelled run is somebody pressing the button and a skipped one
+            # is a guard working; alerting on either trains people to ignore
+            # these. And a fork's failing pull request must not file issues.
+            self.assertIn(
+                "if: always() && contains(needs.*.result, 'failure') "
+                "&& github.ref == 'refs/heads/main'",
+                contents,
+                relative_path,
+            )
+
+    def test_the_alert_is_called_rather_than_triggered_by_workflow_run(self) -> None:
+        """`workflow_run` runs in the base repository's context and is the
+        standard shape of a pwn-request; the security audit rejects it."""
+
+        contents = read_repo_file(self.ALERT)
+        triggers = re.search(r"(?ms)^on:\n((?:^[ ]{2}.*\n|^\n)*)", contents)
+        self.assertIsNotNone(triggers)
+        self.assertIn("workflow_call:", triggers.group(1))
+        self.assertNotIn("workflow_run", triggers.group(1))
+
+    def test_a_repeat_failure_updates_one_issue_rather_than_filing_another(self) -> None:
+        contents = read_repo_file(self.ALERT)
+        self.assertIn("issues.createComment", contents)
+        self.assertIn("issue.title === title", contents)
+
+    def test_the_alert_can_write_issues_and_nothing_else(self) -> None:
+        contents = read_repo_file(self.ALERT)
+        job_permissions = re.search(
+            r"(?ms)^    permissions:\n((?:^      .*\n)+)", contents
+        )
+        self.assertIsNotNone(job_permissions)
+        granted = dict(
+            line.strip().split(": ", 1)
+            for line in job_permissions.group(1).splitlines()
+            if ": " in line
+        )
+        self.assertEqual(granted.get("issues"), "write")
+        self.assertEqual(granted.get("contents"), "read")
+        self.assertNotIn("actions", granted)
+        self.assertNotIn("packages", granted)
+
+    def test_the_alert_runs_the_same_hardened_runner_as_everything_else(self) -> None:
+        self.assertIn(HARDEN_RUNNER, read_repo_file(self.ALERT))


### PR DESCRIPTION
Production failures currently land only in the Actions tab. Two from this week were found by going to look, not by being told:

- the **authenticated canary** was broken for three days
- the **deploy** blocked by a fresh nanoid advisory failed silently, on a merge whose own PR checks had been green

Any failed run of the five workflows guarding production (Production CI, Production Canary, TMDB Cache Enrichment, PostgreSQL Restore Drill, Canary Reset) now opens a GitHub issue.

**Why an issue and not a chat integration:** no secret, no third-party auth, no egress; it reaches the notification settings the account already has; and it carries its own state. A still-broken canary **comments on the one open issue** instead of filing a new one every six hours — so the comment count is how long it has been broken, and closing the issue is the acknowledgement.

**Only `failure`.** A cancelled run is somebody pressing the button; a skipped one is a guard doing its job. Alerting on either is how people learn to ignore these. Job permissions are `issues: write` + `contents: read` and nothing else; same pinned hardened runner as every other workflow.

Five tests pin the parts that would fail open and silent — most importantly that **every guarding workflow's own `name:` appears in the watch list**, since a typo there would silently stop watching production forever. 840 backend + deploy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)