### PR TITLE
Fix the first eleven confirmed audit findings

### DIFF
--- a/backend/api/routes/member_archive.py
+++ b/backend/api/routes/member_archive.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from auth import ClerkUser, get_current_user
@@ -135,6 +136,34 @@ def get_member_archive(
         .all()
     )
 
+    # The real holdings, counted in the database rather than over the page
+    # returned above. `limit` bounds what is shipped; it must not bound what
+    # the response claims is held.
+    like_totals = dict(
+        db.query(MemberContentLike.content_type, func.count(MemberContentLike.id))
+        .filter(
+            MemberContentLike.profile_id == profile.id,
+            MemberContentLike.removed_at.is_(None),
+        )
+        .group_by(MemberContentLike.content_type)
+        .all()
+    )
+    comment_total = (
+        db.query(func.count(MemberComment.id))
+        .filter(
+            MemberComment.profile_id == profile.id,
+            MemberComment.removed_at.is_(None),
+        )
+        .scalar()
+        or 0
+    )
+    lost_total = (
+        db.query(func.count(LostEntry.id))
+        .filter(LostEntry.profile_id == profile.id)
+        .scalar()
+        or 0
+    )
+
     # Every slug in the subject's own library, so "liked but never seen" can be
     # decided against all of it. The frontend used to check the like against
     # the ten most recent watches — the only title list it had — and called
@@ -209,11 +238,27 @@ def get_member_archive(
             }
             for entry in lost
         ],
+        # Counted in the database, not over the page above. These are stated
+        # to the reader as what is held for this member, and they were being
+        # derived from rows that had already been through `limit` -- so a
+        # member with 300 liked reviews reported 100, and because one `limit`
+        # covers both like kinds, a burst of liked reviews could push the
+        # liked-list count to zero and the panel would say none were held.
         "totals": {
-            "liked_reviews": sum(1 for like in likes if like.content_type == "review"),
-            "liked_lists": sum(1 for like in likes if like.content_type == "list"),
-            "comments": len(comments),
-            "lost_entries": len(lost),
+            "liked_reviews": like_totals.get("review", 0),
+            "liked_lists": like_totals.get("list", 0),
+            "comments": comment_total,
+            "lost_entries": lost_total,
+        },
+        "truncated": {
+            "liked_reviews": like_totals.get("review", 0) > sum(
+                1 for like in likes if like.content_type == "review"
+            ),
+            "liked_lists": like_totals.get("list", 0) > sum(
+                1 for like in likes if like.content_type == "list"
+            ),
+            "comments": comment_total > len(comments),
+            "lost_entries": lost_total > len(lost),
         },
     }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -106,7 +106,16 @@ def _remove_scraped_profile_directory(username: str) -> None:
 
 # Pydantic models for request/response
 class ProfileCreate(BaseModel):
-    username: str
+    """A placeholder for a Letterboxd account that will be filled by an upload.
+
+    The username is held to Letterboxd's own charset. Unvalidated, an admin
+    pasting "@name" or a profile URL created a row that can never sync and,
+    for the URL, can never be deleted through the API either -- the slashes
+    do not survive the path. A placeholder that cannot become a profile is
+    worse than a rejected form.
+    """
+
+    username: str = Field(pattern=r"^[A-Za-z0-9_]{2,15}$")
     bio: Optional[str] = None
     location: Optional[str] = None
     website: Optional[str] = None

--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -2197,6 +2197,7 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
           },
         ],
         totals: { liked_reviews: 2, liked_lists: 0, comments: 0, lost_entries: 2 },
+        truncated: { liked_reviews: false, liked_lists: false, comments: false, lost_entries: false },
       });
     }
   }

--- a/frontend/e2e/terminal-shell.spec.ts
+++ b/frontend/e2e/terminal-shell.spec.ts
@@ -32,7 +32,7 @@ test('Overview renders the eight panels, each naming the table it reads', async 
     'THE LATEST CHANGES WE DETECTED',
     'WHO WATCHES WITH WHOM',
     'EVERYONE WE ARE WATCHING',
-    'THIS YEAR, MONTH BY MONTH',
+    'THE LAST TWELVE MONTHS',
     'HOW THE GROUP RATES',
     'MARATHON DAYS',
     'LEAVING SOON',

--- a/frontend/src/app/(terminal)/data/page.tsx
+++ b/frontend/src/app/(terminal)/data/page.tsx
@@ -16,7 +16,13 @@ function DataSection() {
   const section = getSection('data');
   const searchParams = useSearchParams();
   const tab = getTab(section, searchParams.get('tab'));
-  const selection = useTerminalSelection({ minSelection: 1 });
+  // Every synced profile by default, not the usual six. This section's
+  // question is "where did all this come from" and its panels are titled as
+  // totalities -- EVERYONE WE HAVE SYNCED sat six rows long directly above a
+  // library panel counting twenty, two panels on one tab disagreeing about
+  // the roster. A comparison tab caps its default because comparing twenty
+  // people is unreadable; an inventory has no such excuse.
+  const selection = useTerminalSelection({ minSelection: 1, defaultCount: Number.MAX_SAFE_INTEGER });
 
   const controls = (
     <SelectionBar
@@ -32,9 +38,9 @@ function DataSection() {
       {tab.id === 'profiles' ? (
         <ProfilesTab profiles={selection.selected} selectionLoading={selection.isLoading} />
       ) : null}
-      {tab.id === 'refreshes' ? <RefreshesTab profiles={selection.selected} /> : null}
-      {tab.id === 'missing' ? <MissingTab profiles={selection.selected} /> : null}
-      {tab.id === 'lost' ? <LostFoundTab profiles={selection.selected} /> : null}
+      {tab.id === 'refreshes' ? <RefreshesTab profiles={selection.selected} selectionLoading={selection.isLoading} /> : null}
+      {tab.id === 'missing' ? <MissingTab profiles={selection.selected} selectionLoading={selection.isLoading} /> : null}
+      {tab.id === 'lost' ? <LostFoundTab profiles={selection.selected} selectionLoading={selection.isLoading} /> : null}
     </TerminalShell>
   );
 }

--- a/frontend/src/components/terminal/TabRow.tsx
+++ b/frontend/src/components/terminal/TabRow.tsx
@@ -26,7 +26,12 @@ export default function TabRow({ section, active }: { section: SectionDef; activ
   return (
     <div
       role="tablist"
-      className="sticky top-[34px] z-40 mt-3 flex items-stretch overflow-x-auto border-b border-term-rule bg-term-bg px-[14px]"
+      // The status bar is one 34px row only from `md` up; below that it
+      // wraps onto a second line and is roughly 60px tall, so pinning the
+      // tabs at 34px slid them under it on a phone. Not sticky at all
+      // below `md`: the wrapped bar already eats enough of a small
+      // viewport without a second fixed strip under it.
+      className="z-40 mt-3 flex items-stretch overflow-x-auto border-b border-term-rule bg-term-bg px-[14px] md:sticky md:top-[34px]"
     >
       {section.tabs.map((tab) => {
         const isActive = tab.id === active.id;

--- a/frontend/src/hooks/useTerminalSelection.ts
+++ b/frontend/src/hooks/useTerminalSelection.ts
@@ -28,8 +28,18 @@ export function useTerminalSelection(options: TerminalSelectionOptions = {}) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
+  // Only profiles that have actually been read. The analytics endpoints
+  // reject a selection containing anything else outright -- /api/spy-signals
+  // and the insights services 400 the whole request if one member is not
+  // `completed` -- so offering an unread profile here does not degrade a
+  // panel, it takes down every panel on the tab. An admin adding a
+  // placeholder was enough to do it: the new row is `pending`, carries the
+  // newest updated_at, sorts first, and lands in the default selection.
   const available = useMemo(
-    () => (profilesQuery.data ?? []).map((profile) => profile.username),
+    () =>
+      (profilesQuery.data ?? [])
+        .filter((profile) => profile.scraping_status === 'completed')
+        .map((profile) => profile.username),
     [profilesQuery.data],
   );
 

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -23,7 +23,11 @@ export default clerkMiddleware(async (auth, request) => {
 
 export const config = {
   matcher: [
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // `txt` and `xml` belong with the other static extensions: without
+    // them /robots.txt went through Clerk and answered a crawler with a
+    // 307 to /sign-in, so the file we ship to say what may be indexed
+    // was itself unreadable.
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|txt|xml|docx?|xlsx?|zip|webmanifest)).*)',
     '/(api|trpc)(.*)',
     '/__clerk/(.*)',
   ],

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -46,6 +46,36 @@ api.interceptors.request.use(async (config) => {
   return config;
 });
 
+/**
+ * Carry the API's own words to the panel that shows them.
+ *
+ * Every error surface in the product promises the reader "the message from
+ * the API" and then printed axios's `Request failed with status code 400`,
+ * which says nothing. The backend answers `{"detail": "..."}` on every
+ * refusal it authors — the 25-profile tracking cap, the 10 active-request
+ * cap, a private profile, a malformed username — and all of it was being
+ * dropped one layer below the panel. Rewriting `message` here fixes every
+ * caller at once, including the mutation outcome lines, rather than each
+ * catch block learning the response shape.
+ */
+api.interceptors.response.use(undefined, (error: unknown) => {
+  if (axios.isAxiosError(error)) {
+    const detail = (error.response?.data as { detail?: unknown } | undefined)?.detail;
+    // FastAPI validation errors answer with a list of objects rather than a
+    // sentence. Those are for a developer, not a reader: leave the status
+    // message alone rather than printing `[object Object]`.
+    if (typeof detail === 'string' && detail.trim()) {
+      error.message = detail.trim();
+    } else if (!error.response) {
+      error.message =
+        error.code === 'ECONNABORTED'
+          ? 'The request took too long and was given up on.'
+          : 'The API could not be reached.';
+    }
+  }
+  return Promise.reject(error);
+});
+
 // Types for API responses
 export interface DataCoverage {
   mode: string;
@@ -1292,11 +1322,21 @@ export interface MemberArchiveResponse {
   liked_authors: MemberLikedAuthor[];
   comments: MemberCommentEntry[];
   lost_entries: LostEntryRecord[];
+  /** Counted in the database, not over the page above: `limit` bounds what
+   *  ships, never what is claimed to be held. */
   totals: {
     liked_reviews: number;
     liked_lists: number;
     comments: number;
     lost_entries: number;
+  };
+  /** Whether this response shipped fewer rows than are held, per surface, so
+   *  a panel can say "showing N of M" instead of implying it has everything. */
+  truncated: {
+    liked_reviews: boolean;
+    liked_lists: boolean;
+    comments: boolean;
+    lost_entries: boolean;
   };
 }
 

--- a/frontend/src/views/data/LostFoundTab.tsx
+++ b/frontend/src/views/data/LostFoundTab.tsx
@@ -24,7 +24,15 @@ const KIND_LABEL: Record<string, string> = {
   orphaned: 'the entry survived but its target could not be resolved',
 };
 
-export default function LostFoundTab({ profiles }: { profiles: string[] }) {
+export default function LostFoundTab({
+  profiles,
+  selectionLoading = false,
+}: {
+  profiles: string[];
+  /** The profile list is still on the wire; an empty selection is not
+   *  yet a fact, so a disabled query must not report an absence. */
+  selectionLoading?: boolean;
+}) {
   const enabled = profiles.length > 0;
   const options = { enabled, staleTime: 5 * 60 * 1000, refetchOnWindowFocus: false };
 
@@ -48,7 +56,7 @@ export default function LostFoundTab({ profiles }: { profiles: string[] }) {
         caveat={lostQuery.data?.caveat}
       >
         {panelState({
-          isLoading: lostQuery.isLoading,
+          isLoading: lostQuery.isLoading || (selectionLoading && !enabled),
           error: lostQuery.error,
           isEmpty: (lostQuery.data?.entries.length ?? 0) === 0,
           onRetry: () => lostQuery.refetch(),
@@ -98,7 +106,7 @@ export default function LostFoundTab({ profiles }: { profiles: string[] }) {
         caveat={listsQuery.data?.caveat}
       >
         {panelState({
-          isLoading: listsQuery.isLoading,
+          isLoading: listsQuery.isLoading || (selectionLoading && !enabled),
           error: listsQuery.error,
           isEmpty: (listsQuery.data?.films.length ?? 0) === 0,
           severity: 'quiet',

--- a/frontend/src/views/data/MissingTab.tsx
+++ b/frontend/src/views/data/MissingTab.tsx
@@ -28,7 +28,15 @@ const FEATURE_LABEL: Record<string, string> = {
   recent_changes: 'Overview › What changed',
 };
 
-export default function MissingTab({ profiles }: { profiles: string[] }) {
+export default function MissingTab({
+  profiles,
+  selectionLoading = false,
+}: {
+  profiles: string[];
+  /** The profile list is still on the wire; an empty selection is not
+   *  yet a fact, so a disabled query must not report an absence. */
+  selectionLoading?: boolean;
+}) {
   const enabled = profiles.length > 0;
   const options = { enabled, staleTime: 60 * 1000, refetchOnWindowFocus: false };
 
@@ -62,7 +70,7 @@ export default function MissingTab({ profiles }: { profiles: string[] }) {
         caveat={countsQuery.data?.caveat}
       >
         {panelState({
-          isLoading: countsQuery.isLoading,
+          isLoading: countsQuery.isLoading || (selectionLoading && !enabled),
           error: countsQuery.error,
           isEmpty: (countsQuery.data?.profiles.length ?? 0) === 0,
           onRetry: () => countsQuery.refetch(),
@@ -111,7 +119,7 @@ export default function MissingTab({ profiles }: { profiles: string[] }) {
         caveat={privateQuery.data?.caveat}
       >
         {panelState({
-          isLoading: privateQuery.isLoading,
+          isLoading: privateQuery.isLoading || (selectionLoading && !enabled),
           error: privateQuery.error,
           isEmpty: (privateQuery.data?.profiles.length ?? 0) === 0,
           onRetry: () => privateQuery.refetch(),
@@ -147,7 +155,7 @@ export default function MissingTab({ profiles }: { profiles: string[] }) {
         caveat="A blocked view is not broken. It is a question this selection cannot answer yet, and the blocker beside it is the thing that would change that."
       >
         {panelState({
-          isLoading: coverageQuery.isLoading,
+          isLoading: coverageQuery.isLoading || (selectionLoading && !enabled),
           error: coverageQuery.error,
           isEmpty: (coverageQuery.data?.feature_readiness.length ?? 0) === 0,
           onRetry: () => coverageQuery.refetch(),
@@ -191,7 +199,7 @@ export default function MissingTab({ profiles }: { profiles: string[] }) {
         caveat={removedQuery.data?.caveat}
       >
         {panelState({
-          isLoading: removedQuery.isLoading,
+          isLoading: removedQuery.isLoading || (selectionLoading && !enabled),
           error: removedQuery.error,
           isEmpty: (removedQuery.data?.removed.length ?? 0) === 0,
           severity: 'quiet',

--- a/frontend/src/views/data/RefreshesTab.tsx
+++ b/frontend/src/views/data/RefreshesTab.tsx
@@ -37,7 +37,15 @@ function duration(seconds: number | null): string {
   return `${hours}h ${minutes % 60}m`;
 }
 
-export default function RefreshesTab({ profiles }: { profiles: string[] }) {
+export default function RefreshesTab({
+  profiles,
+  selectionLoading = false,
+}: {
+  profiles: string[];
+  /** The profile list is still on the wire; an empty selection is not
+   *  yet a fact, so a disabled query must not report an absence. */
+  selectionLoading?: boolean;
+}) {
   const enabled = profiles.length > 0;
   const options = { enabled, staleTime: 60 * 1000, refetchOnWindowFocus: false };
 
@@ -72,7 +80,7 @@ export default function RefreshesTab({ profiles }: { profiles: string[] }) {
         caveat={ledgerQuery.data?.caveat}
       >
         {panelState({
-          isLoading: ledgerQuery.isLoading,
+          isLoading: ledgerQuery.isLoading || (selectionLoading && !enabled),
           error: ledgerQuery.error,
           isEmpty: (ledgerQuery.data?.surfaces.length ?? 0) === 0,
           onRetry: () => ledgerQuery.refetch(),
@@ -129,7 +137,7 @@ export default function RefreshesTab({ profiles }: { profiles: string[] }) {
         caveat={feedsQuery.data?.caveat}
       >
         {panelState({
-          isLoading: feedsQuery.isLoading,
+          isLoading: feedsQuery.isLoading || (selectionLoading && !enabled),
           error: feedsQuery.error,
           isEmpty: (feedsQuery.data?.feeds.length ?? 0) === 0,
           onRetry: () => feedsQuery.refetch(),
@@ -170,7 +178,7 @@ export default function RefreshesTab({ profiles }: { profiles: string[] }) {
         caveat={importersQuery.data?.caveat}
       >
         {panelState({
-          isLoading: importersQuery.isLoading,
+          isLoading: importersQuery.isLoading || (selectionLoading && !enabled),
           error: importersQuery.error,
           isEmpty: (importersQuery.data?.profiles.length ?? 0) === 0,
           onRetry: () => importersQuery.refetch(),

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -55,21 +55,44 @@ function relativeDays(iso: string | null | undefined): string {
 /** Plain-English summary of one detected change, plus where it is explained. */
 function describeChange(change: RecentChange): { what: string; where: string; href: string } {
   const film = change.movie?.title ?? change.list?.name ?? change.entity_type;
+  // Every arm below is a change type `record_profile_changes` actually
+  // writes. Two of the original arms -- `watch_added` and `rating_added` --
+  // were names nothing in the backend has ever emitted, so the everyday
+  // events (`diary_added`, `film_added`) fell through to the default and a
+  // newly logged film was captioned "diary added" and pointed at Data ›
+  // What's missing, a tab about scrape gaps.
   switch (change.change_type) {
-    case 'watch_added':
+    case 'diary_added':
       return { what: `${film} logged`, where: 'Overlaps › Together', href: sectionHref('overlaps', 'together') };
+    case 'diary_removed':
+      return { what: `${film} — diary entry gone`, where: 'Data › Lost & found', href: sectionHref('data', 'lost') };
+    case 'film_added':
+      return { what: `${film} first seen`, where: 'Films › The library', href: sectionHref('films', 'library') };
+    case 'film_removed':
+      return { what: `${film} no longer listed`, where: 'Data › Lost & found', href: sectionHref('data', 'lost') };
     case 'rating_changed':
       return {
         what: `${film} — rating changed`,
         where: 'People › One person',
         href: sectionHref('people', 'one'),
       };
-    case 'rating_added':
-      return { what: `${film} rated`, where: 'People › One person', href: sectionHref('people', 'one') };
+    case 'like_changed':
+      return { what: `${film} — like changed`, where: 'People › One person', href: sectionHref('people', 'one') };
     case 'review_added':
       return { what: `${film} reviewed`, where: 'People › Reach', href: sectionHref('people', 'reach') };
+    case 'review_updated':
+    case 'text_changed':
+      return { what: `${film} — review rewritten`, where: 'People › Reach', href: sectionHref('people', 'reach') };
+    case 'review_removed':
+      return { what: `${film} — review gone`, where: 'Data › Lost & found', href: sectionHref('data', 'lost') };
     case 'watchlist_added':
       return { what: `${film} queued`, where: 'Tonight › Picks', href: sectionHref('tonight', 'picks') };
+    case 'watchlist_removed':
+      return { what: `${film} left the watchlist`, where: 'Tonight › Picks', href: sectionHref('tonight', 'picks') };
+    case 'favorite_added':
+      return { what: `${film} made a favourite`, where: 'People › One person', href: sectionHref('people', 'one') };
+    case 'favorite_removed':
+      return { what: `${film} dropped as a favourite`, where: 'People › One person', href: sectionHref('people', 'one') };
     case 'follow_added':
     case 'follower_gained':
       return { what: `${film || 'A follow'} added`, where: 'People › The circle', href: sectionHref('people', 'circle') };
@@ -78,6 +101,10 @@ function describeChange(change: RecentChange): { what: string; where: string; hr
       return { what: `${film || 'A follow'} dropped`, where: 'People › The circle', href: sectionHref('people', 'circle') };
     case 'list_added':
     case 'list_updated':
+    case 'list_removed':
+    case 'list_item_added':
+    case 'list_item_removed':
+    case 'list_item_updated':
       return { what: `List "${film}" changed`, where: 'Tonight › Lists', href: sectionHref('tonight', 'lists') };
     default:
       return {
@@ -156,7 +183,12 @@ export default function OverviewTab() {
   // ---- 01 · the group in five numbers -------------------------------------
   const groupStats = stats
     ? [
-        { big: profiles.length.toLocaleString(), unit: 'PROFILES', tone: 'var(--accent)' },
+        // From the same snapshot as the other four. Reading the separate
+        // profiles query here put a confident 0 beside real film and
+        // rating totals whenever that slower query was still in flight or
+        // had failed -- and counted pending profiles the other four
+        // numbers exclude, so the row mixed denominators unlabelled.
+        { big: stats.total_profiles.toLocaleString(), unit: 'PROFILES', tone: 'var(--accent)' },
         { big: stats.total_movies_tracked.toLocaleString(), unit: 'FILMS' },
         {
           big: Object.values(distribution).reduce((sum, value) => sum + value, 0).toLocaleString(),
@@ -175,6 +207,11 @@ export default function OverviewTab() {
       value: entry.movies_watched,
       inner: entry.unique_movies ?? undefined,
       display: entry.movies_watched === 0 ? '—' : String(entry.movies_watched),
+      // The month in progress is drawn hatched, as it is everywhere else that
+      // renders this feed. Solid, five days of August stood next to twelve
+      // full months and read as the group's watching collapsing.
+      partial: entry.is_partial,
+      hint: `${entry.month}${entry.is_partial ? ', month to date' : ''}: ${count(entry.movies_watched, 'watch', 'watches')}`,
     };
   });
 
@@ -354,10 +391,10 @@ export default function OverviewTab() {
       </Panel>
 
       <Panel
-        title="THIS YEAR, MONTH BY MONTH"
+        title="THE LAST TWELVE MONTHS"
         src="watch_events.watched_date"
         blurb="Full bar is watches. The lighter block inside it is how many were films nobody in the group had logged before — the gap between the two is rewatching and catching up."
-        caveat="Months with no bar are the future or a month with no dated entries, not a collapse in watching."
+        caveat="A month with no bar had no dated entry at all. The window ends with the month in progress, drawn hatched because it is not finished, not a collapse in watching."
       >
         {panelState({
           isLoading: analyticsQuery.isLoading,
@@ -417,7 +454,9 @@ export default function OverviewTab() {
             rows={(marathonsQuery.data?.marathons ?? []).map((day) => ({
               cells: [
                 cell(
-                  new Date(day.date).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' }),
+                  // Local, not UTC: `new Date('2026-07-15')` is UTC midnight,
+                  // which prints as the 14th anywhere west of Greenwich.
+                  formatDay(day.date),
                   { size: '10.5px', tone: 'var(--ink3)' },
                 ),
                 cell(`@${day.username} · ${day.titles.slice(0, 3).join(', ')}`, {

--- a/frontend/src/views/people/ReachTab.tsx
+++ b/frontend/src/views/people/ReachTab.tsx
@@ -192,7 +192,7 @@ export default function ReachTab({ subject, profiles }: { subject: string; profi
         title="WHAT THEY ENDORSED"
         src="member_content_likes"
         blurb="Reviews and lists they liked. A read of somebody's attention that does not require them to have watched anything."
-        caveat={`Export-only. ${likedReviews.length.toLocaleString()} liked reviews and ${likedLists.length.toLocaleString()} liked lists held for @${subject}.`}
+        caveat={`Export-only. ${(archiveQuery.data?.totals.liked_reviews ?? 0).toLocaleString()} liked reviews and ${(archiveQuery.data?.totals.liked_lists ?? 0).toLocaleString()} liked lists held for @${subject}${archiveQuery.data?.truncated.liked_reviews || archiveQuery.data?.truncated.liked_lists ? `, of which the ten most recent are shown` : ''}.`}
       >
         {panelState({
           isLoading: archiveQuery.isLoading,


### PR DESCRIPTION
A nine-lens audit of the live product produced 68 findings. **51 survived double verification** — once for reachability in shipped code, once for whether production-shaped data actually triggers them (17 were refuted). This is the first batch of eleven, grouped by what was wrong rather than by file.

### The selection was not what the panels claimed

- **BLOCKER** — profiles that have not finished a first read could enter the default selection, and `/api/spy-signals` plus the insights services **400 the entire request** if one member is not `completed`. So an admin adding a placeholder through the panel this repo shipped last week put a `pending` row at the top of the list (newest `updated_at` sorts first) and **took down every panel on Overlaps and People**. The selection now offers only profiles that have been read.
- Data defaulted to 6 profiles while its panels are titled as totalities: `EVERYONE WE HAVE SYNCED` listed 6 rows directly above `THE LIBRARY'S STATE` counting 20. Data now defaults to all of them — an inventory has no excuse for a cap.
- Refreshes, What's missing and Lost & found stopped reporting absences while the profile list is still on the wire.

### The API's own words never reached the reader

Every error surface promises "the message from the API" and printed axios's `Request failed with status code 400`. The 25-profile tracking cap, the 10 active-request cap and a private profile all arrived as that same sentence. **One response interceptor** now carries the `detail` the backend already sends — fixing every panel and every mutation outcome line at once.

### Overview described events it never receives

The change strip switched on `watch_added` and `rating_added` — names **nothing in the backend has ever emitted**. The everyday events (`diary_added`, `film_added`) fell through to the default arm, so a newly logged film was captioned "diary added" and pointed at Data › What's missing, a tab about scrape gaps. Every arm is now a type `record_profile_changes` actually writes. Also: marathon dates parsed date-only strings as UTC (printing the previous day west of Greenwich), the in-progress month drew solid so five days of August read as a collapse, and the PROFILES stat came from a different query than its four neighbours and could show `0` beside real totals.

### And four more

- **`robots.txt` was behind Clerk** — `.txt` missing from the middleware's static exclusion, so the file that says what may be indexed answered crawlers with a 307 to `/sign-in`. Verified live before the fix.
- The placeholder form accepted any string, including a profile URL whose slashes made the row **undeletable through the API**.
- Archive totals were counted *after* the LIMIT and presented as holdings; now counted in the database, with a `truncated` flag so panels can say "showing N of M".
- The mobile tab row pinned at `top-34px` under a status bar that is ~60px when it wraps.

714 backend + 128 deploy tests, 310/310 e2e, tsc and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)