### PR TITLE
Stop six panels describing something other than what they measured

### DIFF
--- a/backend/services/films.py
+++ b/backend/services/films.py
@@ -255,7 +255,15 @@ def build_runtime(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
     watched: Counter[str] = Counter()
     seen: set[int] = set()
     for row in rows:
-        if row.enrichment_movie_id is None or row.runtime_minutes is None or row.movie_id in seen:
+        # TMDB stores an unfilled runtime as 0, not as null, so `is None` alone
+        # let every unmeasured film land in the shortest band -- the panel
+        # reported a taste for films under 90 minutes that was really a gap in
+        # enrichment. A runtime of zero is an absence.
+        if (
+            row.enrichment_movie_id is None
+            or not row.runtime_minutes
+            or row.movie_id in seen
+        ):
             continue
         seen.add(row.movie_id)
         for label, low, high in RUNTIME_BANDS:
@@ -265,15 +273,24 @@ def build_runtime(db: Session, profiles: Sequence[Profile]) -> Dict[str, Any]:
 
     queued: Counter[str] = Counter()
     if profile_ids:
+        # Distinct films, matching WATCHED. Counting watchlist rows meant a
+        # film four people had queued arrived as four, so QUEUED and WATCHED
+        # were different units printed as one ratio.
         queue_rows = (
-            db.query(MovieEnrichment.runtime_minutes)
+            db.query(MovieEnrichment.movie_id, MovieEnrichment.runtime_minutes)
             .join(WatchlistItem, WatchlistItem.movie_id == MovieEnrichment.movie_id)
             .filter(WatchlistItem.profile_id.in_(profile_ids), WatchlistItem.removed_at.is_(None))
+            .distinct()
             .all()
         )
-        for (runtime,) in queue_rows:
-            if runtime is None:
+        # Deduplicated here rather than with DISTINCT ON, which Postgres only
+        # accepts alongside a matching ORDER BY and SQLite does not implement
+        # at all -- the shape of bug this repository has shipped before.
+        queued_seen: set[int] = set()
+        for movie_id, runtime in queue_rows:
+            if not runtime or movie_id in queued_seen:
                 continue
+            queued_seen.add(movie_id)
             for label, low, high in RUNTIME_BANDS:
                 if runtime >= low and (high is None or runtime <= high):
                     queued[label] += 1

--- a/backend/tests/test_library_sections.py
+++ b/backend/tests/test_library_sections.py
@@ -837,3 +837,33 @@ def test_a_surface_only_ever_topped_up_still_reports_what_it_has(
     assert surfaces["films"]["rows"] == 3
     assert surfaces["films"]["authoritative_profiles"] == 0
     assert "none authoritative" in surfaces["films"]["result"]
+
+
+def test_a_film_with_no_recorded_runtime_is_not_a_short_film(database: Session) -> None:
+    """TMDB stores an unfilled runtime as 0, not as null. Counting those put
+    every unmeasured film in the shortest band, so the panel reported a taste
+    for films under 90 minutes that was really a gap in enrichment."""
+
+    viewer = _profile(database, "viewer")
+    _film(database, viewer, _movie(database, "Unmeasured", runtime=0))
+    _film(database, viewer, _movie(database, "Genuinely Short", runtime=80))
+
+    bands = {band["label"]: band for band in build_runtime(database, [viewer])["bands"]}
+
+    assert bands["under 90"]["watched"] == 1
+
+
+def test_queued_and_watched_are_the_same_unit(database: Session) -> None:
+    """QUEUED counted watchlist rows while WATCHED counted distinct films, so
+    one film four people had queued arrived as four and the ratio beside them
+    divided one unit by another."""
+
+    first = _profile(database, "first")
+    second = _profile(database, "second")
+    movie = _movie(database, "Everybody Queued It", runtime=100)
+    _queued(database, first, movie, date(2026, 1, 1))
+    _queued(database, second, movie, date(2026, 1, 2))
+
+    bands = {band["label"]: band for band in build_runtime(database, [first, second])["bands"]}
+
+    assert bands["90–110"]["queued"] == 1

--- a/frontend/src/views/overlaps/EchoesTab.tsx
+++ b/frontend/src/views/overlaps/EchoesTab.tsx
@@ -32,6 +32,21 @@ function echoReason(echo: RewatchEcho): { text: string; tone: string } {
   return { text: 'follows not imported', tone: 'var(--dim)' };
 }
 
+/**
+ * Same-day echoes have no earlier and later side, so the follow question the
+ * caption answers -- did the follower follow the person they followed --
+ * cannot be asked of them at all. The backend returns `follow_backed: null`
+ * for every one of them regardless of how complete the follow graph is, and
+ * captioning that as "follows not imported" told the reader their import was
+ * missing when it was not.
+ */
+function echoEvidence(echo: RewatchEcho): { text: string; tone: string } {
+  if (echo.timing === 'same_day') {
+    return { text: 'same day — no lead to follow', tone: 'var(--dim)' };
+  }
+  return echoReason(echo);
+}
+
 function echoTiming(echo: RewatchEcho): string {
   if (echo.timing === 'same_day') return 'Same day';
   return `${echo.day_gap} day${echo.day_gap === 1 ? '' : 's'} later`;
@@ -145,14 +160,18 @@ export default function EchoesTab({ profiles, gapDays }: { profiles: string[]; g
         }) ?? (
           <Posters
             items={echoes.slice(0, 10).map((echo) => {
-              const reason = echoReason(echo);
+              const reason = echoEvidence(echo);
               const leader = echo.participants.find((person) => person.timing_role !== 'follower');
               const follower = echo.participants.find((person) => person.timing_role === 'follower');
               return {
                 title: echo.movie.year ? `${echo.movie.title} (${echo.movie.year})` : echo.movie.title,
                 posterUrl: echo.movie.poster_url,
+                // Each side says what it actually was. The backend requires
+                // only ONE of the pair to be a rewatch, so captioning the
+                // earlier watcher as the rewatcher credited a first viewing
+                // as a revisit whenever the pattern ran the other way round.
                 sub: follower
-                  ? `@${leader?.username ?? '?'} rewatched, @${follower.username} followed`
+                  ? `@${leader?.username ?? '?'} ${leader?.watch_kind === 'rewatch' ? 'rewatched' : 'first watched'}, @${follower.username} ${follower.watch_kind === 'rewatch' ? 'rewatched' : 'watched'} after`
                   : echo.participants.map((person) => `@${person.username}`).join(' + '),
                 right: echoTiming(echo),
                 tone: echo.timing === 'same_day' ? 'var(--ok)' : 'var(--accent)',

--- a/frontend/src/views/overlaps/TogetherTab.tsx
+++ b/frontend/src/views/overlaps/TogetherTab.tsx
@@ -124,6 +124,20 @@ export default function TogetherTab({
     cta: { label: 'CHOOSE WHO TO MONITOR', href: sectionHref('data', 'profiles') },
   };
 
+  /**
+   * "Two profiles are needed" is true only when fewer than two are selected.
+   * Every panel here used it for any empty result, so two sparse profiles
+   * with nothing in common were told to go and monitor somebody — with a
+   * button to a page whose job they had already done.
+   */
+  const nothingFound = (what: string) =>
+    profiles.length < 2
+      ? emptyState
+      : {
+          title: `No ${what} in this window`,
+          body: 'The selected profiles have nothing that qualifies here. Widen the closeness above, pick a different pair, or wait for the next refresh.',
+        };
+
   return (
     <>
       <Panel
@@ -174,7 +188,13 @@ export default function TogetherTab({
           summary
             ? [
                 { big: summary.same_day_events.toLocaleString(), unit: 'SAME DAY', tone: 'var(--ok)' },
-                { big: summary.one_day_gap_events.toLocaleString(), unit: 'WITHIN A DAY' },
+                // Only while the window actually includes it. The backend
+                // counts one-day gaps regardless of the selected closeness,
+                // so under SAME DAY this printed a WITHIN A DAY figure larger
+                // than the IN THIS WINDOW total sitting beside it.
+                ...(gapDays >= 1
+                  ? [{ big: summary.one_day_gap_events.toLocaleString(), unit: 'WITHIN A DAY' }]
+                  : []),
                 { big: windowTotal.toLocaleString(), unit: 'IN THIS WINDOW' },
               ]
             : undefined
@@ -188,7 +208,7 @@ export default function TogetherTab({
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'Closeness tiers could not be counted',
           errorBody: 'The overlap feed did not answer.',
-          empty: emptyState,
+          empty: nothingFound('overlap close enough to measure'),
           skeleton: <BarsSkeleton rows={3} />,
         }) ?? (
           <Bars
@@ -264,7 +284,7 @@ export default function TogetherTab({
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'The pair leaderboard could not be loaded',
           errorBody: 'The overlap feed did not answer.',
-          empty: emptyState,
+          empty: nothingFound('pair with a shared film'),
           skeleton: <BarsSkeleton rows={6} />,
         }) ?? (
           <Bars
@@ -305,7 +325,7 @@ export default function TogetherTab({
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'Most shared titles could not be loaded',
           errorBody: 'The overlap feed did not answer.',
-          empty: emptyState,
+          empty: nothingFound('film everybody has seen'),
           skeleton: <BarsSkeleton rows={6} />,
         }) ?? (
           <Bars
@@ -332,7 +352,7 @@ export default function TogetherTab({
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'Consensus hits could not be loaded',
           errorBody: 'The overlap feed did not answer.',
-          empty: emptyState,
+          empty: nothingFound('film the group agreed on'),
         }) ?? (
           <Rows
             columns="minmax(0,1.4fr) 52px 62px 58px"
@@ -373,7 +393,7 @@ export default function TogetherTab({
           onRetry: () => signalsQuery.refetch(),
           errorTitle: 'Divisive titles could not be loaded',
           errorBody: 'The overlap feed did not answer.',
-          empty: emptyState,
+          empty: nothingFound('film that split the room'),
         }) ?? (
           <Rows
             columns="minmax(0,1.4fr) 52px 62px 58px"


### PR DESCRIPTION
Second batch from the verified audit. All the same kind of defect: the number was computed correctly and then **captioned as something it is not**.

**Echoes credited the rewatch to the wrong person.** The backend requires only *one* side of the pair to be a rewatch (`if not (left['is_rewatch'] or right['is_rewatch']): continue`), but the caption hardcoded `@leader rewatched, @follower followed`. When the later watcher was the one revisiting, the caption said the opposite of what happened. Each side now reports its own `watch_kind`, which the payload has always carried.

**Same-day echoes claimed a missing import.** They were captioned "follows not imported" — which reads as *your data is incomplete*. The backend returns `follow_backed: null` for **every** same-day echo regardless of import coverage, because with no earlier and later side the follow question cannot be asked at all. They now say "same day — no lead to follow".

**Five Together panels told people to go and choose profiles they had already chosen.** `HOW CLOSE IN TIME`, `PAIR LEADERBOARD`, `EVERYONE'S SEEN IT`, `AGREED ON AND LIKED` and `SPLIT THE ROOM` answered *any* empty result with "Two profiles are needed" and a CTA to the profile picker. Each now names what it did not find.

**The closeness stat row contradicted itself.** The backend counts one-day gaps regardless of the selected window, so with SAME DAY selected `WITHIN A DAY` could print a larger number than the `IN THIS WINDOW` total beside it. It is now only drawn when the window includes it.

**Runtime Appetite counted two different things.** TMDB stores an unfilled runtime as `0`, not null, so every unmeasured film landed in the shortest band — a reported taste for films under 90 minutes that was really an enrichment gap. And `QUEUED` counted watchlist *rows* while `WATCHED` counted distinct *films*, so one film four people queued arrived as four and the ratio between them divided one unit by another.

The dedup deliberately avoids `DISTINCT ON`: Postgres accepts it only with a matching `ORDER BY` and SQLite does not implement it — the SQLite-passes/Postgres-fails shape this repo has shipped before. Two new backend tests pin both runtime fixes.

844 backend + deploy tests, 310/310 e2e, tsc and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)