### PR TITLE
Fix eleven more audit findings across People, Tonight and the archive

### DIFF
--- a/backend/api/routes/follow_graph.py
+++ b/backend/api/routes/follow_graph.py
@@ -49,6 +49,12 @@ def get_profile_follow_graph(
     username: str,
     direction: str = Query(default="both", pattern="^(following|followers|both)$"),
     include_removed: bool = Query(default=False),
+    # Removed edges only. Without it the unfollow panel had to ask for every
+    # edge and filter client-side, and the server interleaves removed edges
+    # with active ones -- so on an account with more than a page of follows,
+    # every unfollow could sit past the limit and the panel would swear none
+    # had happened.
+    only_removed: bool = Query(default=False),
     limit: int = Query(default=100, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     db: Session = Depends(get_db),
@@ -65,7 +71,9 @@ def get_profile_follow_graph(
         query = query.filter(ProfileFollowEdge.direction == "following")
     elif direction == "followers":
         query = query.filter(ProfileFollowEdge.direction == "follower")
-    if not include_removed:
+    if only_removed:
+        query = query.filter(ProfileFollowEdge.removed_at.isnot(None))
+    elif not include_removed:
         query = query.filter(ProfileFollowEdge.removed_at.is_(None))
 
     total = query.count()

--- a/backend/services/data_health.py
+++ b/backend/services/data_health.py
@@ -35,6 +35,7 @@ _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 from database.models import (
     LostEntry,
     MemberComment,
+    Movie,
     MemberContentLike,
     MovieList,
     MovieListItem,
@@ -593,21 +594,25 @@ def build_lost_list_films(db: Session, profiles: Sequence[Profile], *, limit: in
         return {"films": [], "count": 0, "caveat": "No profiles selected."}
 
     rows = (
-        db.query(MovieListItem, MovieList, Profile.username)
+        # The film is joined, not lazy-loaded. Reading `item.movie` per row
+        # issued one query per film in every deleted list — a 300-item list
+        # cost 300 round trips to render twelve posters.
+        db.query(MovieListItem, MovieList, Profile.username, Movie)
         .join(MovieList, MovieList.id == MovieListItem.movie_list_id)
         .join(Profile, Profile.id == MovieList.profile_id)
+        .outerjoin(Movie, Movie.id == MovieListItem.movie_id)
         .filter(MovieList.profile_id.in_(profile_ids), MovieList.removed_at.isnot(None))
         .order_by(MovieList.removed_at.desc(), MovieListItem.position)
         .all()
     )
 
     films = []
-    for item, movie_list, username in rows:
+    for item, movie_list, username, movie in rows:
         films.append(
             {
-                "title": item.movie.title if item.movie else "Unknown film",
-                "year": item.movie.release_year if item.movie else None,
-                "poster_url": item.movie.poster_url if item.movie else None,
+                "title": movie.title if movie else "Unknown film",
+                "year": movie.release_year if movie else None,
+                "poster_url": movie.poster_url if movie else None,
                 "list_name": movie_list.name,
                 "username": username,
                 "position": item.position,

--- a/backend/tests/test_follow_graph_api.py
+++ b/backend/tests/test_follow_graph_api.py
@@ -514,3 +514,27 @@ def test_suggestions_empty_for_user_with_no_tracked_profiles(database, client_fo
     # The denominator travels with the counts: they are taken across every
     # monitored profile, and a caller that supplied its own rendered "10 of 6".
     assert payload == {"suggestions": [], "monitored_profiles": 0}
+
+
+def test_only_removed_returns_unfollows_without_the_active_edges_around_them(
+    database, client_for
+):
+    """The unfollow panel asked for every edge and filtered client-side, but
+    the server orders by direction and position and never by removed_at -- so
+    on an account with more than a page of follows every unfollow could sit
+    past the limit and the panel swore none had happened."""
+
+    _seed_alpha_graph(database)
+    user = _legacy_user(database, tracked_profile_ids=(1,))
+    client = client_for(user)
+
+    payload = client.get(
+        "/api/profiles/alpha/follow-graph",
+        params={"direction": "both", "only_removed": "true"},
+    ).json()
+
+    assert payload["edges"], "the fixture holds a removed edge"
+    assert all(edge["removed_at"] is not None for edge in payload["edges"])
+    # And it is the same edge the include_removed page reports, not a subset
+    # that happened to fit.
+    assert payload["total"] == 1

--- a/frontend/e2e/group-pick-composition.spec.ts
+++ b/frontend/e2e/group-pick-composition.spec.ts
@@ -18,7 +18,10 @@ test('the candidate count is qualified by watchlist overlap and availability', a
   await expect(panel).toContainText('RANKED CANDIDATES');
   await expect(panel).toContainText("ON EVERYONE'S WATCHLIST");
   await expect(panel).toContainText('NOBODY HAS SEEN');
-  await expect(panel).toContainText('STREAMING IN');
+  // Subscription only, matching what Tonight › Leaving soon counts: the
+  // payload also carries rent and buy offers, and calling those "streaming"
+  // made the two tabs disagree about the same film.
+  await expect(panel).toContainText('ON A SUBSCRIPTION IN');
   // And the count is the length of the table, not a larger set it was cut from.
   // The fixture's summary counts six candidates against two rendered, so
   // the truncation-aware branch must fire — the old copy claimed "never cut"

--- a/frontend/src/app/(terminal)/people/page.tsx
+++ b/frontend/src/app/(terminal)/people/page.tsx
@@ -34,7 +34,12 @@ function PeopleSection() {
 
   const subjectHref = (username: string) => selection.paramHref('subject', username);
   const isPair = tab.id === 'two';
-  const singleSubject = tab.id === 'one' || tab.id === 'circle';
+  // Reach belongs here too: four of its six panels are about one person
+  // (their reviews, their likes, their card), and it was showing the
+  // multi-select bar instead -- so the subject those panels answered for was
+  // whatever ?subject a previous tab happened to leave in the URL, with no
+  // way to see or change it from this tab.
+  const singleSubject = tab.id === 'one' || tab.id === 'circle' || tab.id === 'reach';
 
   const controls = singleSubject ? (
     <SelectionBar
@@ -59,7 +64,7 @@ function PeopleSection() {
       {tab.id === 'circle' ? (
         <CircleTab subject={subject} profiles={selection.available} subjectHref={subjectHref} />
       ) : null}
-      {tab.id === 'reach' ? <ReachTab subject={subject} profiles={selection.selected} /> : null}
+      {tab.id === 'reach' ? <ReachTab subject={subject} profiles={selection.available} /> : null}
     </TerminalShell>
   );
 }

--- a/frontend/src/components/terminal/bodies/Posters.tsx
+++ b/frontend/src/components/terminal/bodies/Posters.tsx
@@ -14,6 +14,10 @@ export interface PosterDatum {
   tone?: string;
   posterUrl?: string | null;
   href?: string;
+  /** Draw the row faded: the fact behind it is stale rather than absent, and
+   *  a panel that says a stale row is "shown greyed, not hidden" has to grey
+   *  something. */
+  dim?: boolean;
 }
 
 /**
@@ -60,7 +64,7 @@ export default function Posters({ items }: { items: PosterDatum[] }) {
         <div
           key={`${item.title}-${index}`}
           className="grid items-center gap-[9px] border-b border-term-rule2 px-[10px] py-[5px] hover:bg-term-panelhd"
-          style={{ gridTemplateColumns: '34px minmax(0,1fr) auto' }}
+          style={{ gridTemplateColumns: '34px minmax(0,1fr) auto', opacity: item.dim ? 0.55 : 1 }}
         >
           <PosterSlot url={item.posterUrl} alt={item.title} />
           <span className="min-w-0">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1239,6 +1239,9 @@ export const followGraphApi = {
     params: {
       direction?: FollowGraphDirection;
       includeRemoved?: boolean;
+      /** Only edges that have disappeared, so an unfollow cannot fall past
+       *  the page behind hundreds of active follows. */
+      onlyRemoved?: boolean;
       limit?: number;
       offset?: number;
     } = {},
@@ -1247,6 +1250,7 @@ export const followGraphApi = {
       params: {
         direction: params.direction ?? 'both',
         include_removed: params.includeRemoved ?? false,
+        only_removed: params.onlyRemoved ?? false,
         limit: params.limit ?? 100,
         offset: params.offset ?? 0,
       },

--- a/frontend/src/views/data/LostFoundTab.tsx
+++ b/frontend/src/views/data/LostFoundTab.tsx
@@ -103,7 +103,15 @@ export default function LostFoundTab({
         title="FILMS FROM LISTS THAT NO LONGER EXIST"
         src="list_items × lists.removed_at"
         blurb="A list was deleted, but we still hold what was in it — often the most considered version of somebody's taste, thrown away in a tidy-up."
-        caveat={listsQuery.data?.caveat}
+        caveat={
+          listsQuery.data
+            ? `${listsQuery.data.caveat}${
+                listsQuery.data.count > 8
+                  ? ` Eight are shown of the ${listsQuery.data.count.toLocaleString()} this selection still holds.`
+                  : ''
+              }`
+            : undefined
+        }
       >
         {panelState({
           isLoading: listsQuery.isLoading || (selectionLoading && !enabled),

--- a/frontend/src/views/overlaps/WhenTab.tsx
+++ b/frontend/src/views/overlaps/WhenTab.tsx
@@ -100,7 +100,7 @@ export default function WhenTab({ profiles, gapDays }: { profiles: string[]; gap
         blurb="Eight weeks, one square per day, darker where more overlaps landed."
         caveat={
           calendarQuery.data
-            ? `Eight weeks ending ${formatDay(calendarQuery.data.to)} — this pair's most recent overlap, not today. Undated diary entries cannot be placed on a grid at all, so a quiet week can mean a quiet week or a profile with no dates.`
+            ? `Eight weeks ending ${formatDay(calendarQuery.data.to)} — the selection's most recent watch, not today and not necessarily an overlap. Undated diary entries cannot be placed on a grid at all, so a quiet week can mean a quiet week or a profile with no dates.`
             : 'Undated diary entries cannot be placed on a grid at all, so a quiet week here can mean a quiet week or a profile with no dates.'
         }
       >

--- a/frontend/src/views/people/CircleTab.tsx
+++ b/frontend/src/views/people/CircleTab.tsx
@@ -58,7 +58,7 @@ export default function CircleTab({
     queryFn: () =>
       followGraphApi.getFollowGraph(subject, {
         direction: 'both',
-        includeRemoved: true,
+        onlyRemoved: true,
         limit: 200,
       }),
     enabled: Boolean(subject),

--- a/frontend/src/views/people/OnePersonTab.tsx
+++ b/frontend/src/views/people/OnePersonTab.tsx
@@ -206,8 +206,27 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         star: rating.rating,
       }),
     );
-    return entries
+    // One row per film per day. The watch and rating streams are the same
+    // `ratings` rows served by the same repository call, so a diary-heavy
+    // profile saw every film twice -- once as "watch", once as "rating" --
+    // and a reviewed film three times. The richest label for a day wins:
+    // review says more than rating, rating says more than a bare watch.
+    const RANK: Record<string, number> = { review: 3, rewatch: 2, rating: 1, watch: 0 };
+    const best = new Map<string, Entry>();
+    entries
       .filter((entry) => entry.when)
+      .forEach((entry) => {
+        const key = `${entry.what.toLowerCase()}@${entry.when}`;
+        const held = best.get(key);
+        if (!held || (RANK[entry.kind] ?? 0) > (RANK[held.kind] ?? 0)) {
+          // Keep whichever row carries a star, so deduping never drops a
+          // rating the other row did not have.
+          best.set(key, { ...entry, star: entry.star ?? held?.star ?? null });
+        } else if (held.star === null && entry.star !== null) {
+          best.set(key, { ...held, star: entry.star });
+        }
+      });
+    return Array.from(best.values())
       .sort((a, b) => new Date(b.when!).getTime() - new Date(a.when!).getTime())
       .slice(0, 10);
   }, [analysis]);
@@ -411,14 +430,27 @@ export default function OnePersonTab({ subject }: { subject: string }) {
         {panelState({
           isLoading: statsQuery.isLoading,
           error: statsQuery.error,
-          isEmpty: (stats?.release_lag.measured_films ?? 0) === 0,
+          // The backend withholds the median below twenty measurable films,
+          // so a profile with one to nineteen had no stats row AND no empty
+          // state: the panel rendered as a title over nothing. Too few to
+          // measure is a state of its own, and it names the shortfall.
+          isEmpty:
+            (stats?.release_lag.measured_films ?? 0) === 0 ||
+            stats?.release_lag.median_lag_days === null ||
+            stats?.release_lag.median_lag_days === undefined,
           onRetry: () => statsQuery.refetch(),
           errorTitle: 'Release lag could not be computed',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: {
-            title: 'Not enough dated films',
-            body: 'This needs both a release year and a watch date on the same film. Neither is guessed at.',
-          },
+          empty:
+            (stats?.release_lag.measured_films ?? 0) > 0
+              ? {
+                  title: 'Too few dated films to call it a habit',
+                  body: `Only ${count(stats?.release_lag.measured_films ?? 0, 'film')} carries both a release date and a watch date, and a median over that few would describe those films rather than the person.`,
+                }
+              : {
+                  title: 'Not enough dated films',
+                  body: 'This needs both a release year and a watch date on the same film. Neither is guessed at.',
+                },
         })}
       </Panel>
 
@@ -606,12 +638,21 @@ export default function OnePersonTab({ subject }: { subject: string }) {
           crowdQuery.data
             ? [
                 {
+                  // A delta that rounds to zero is neither harsher nor kinder,
+                  // and the sign and the colour disagreed about it: "−0.00"
+                  // printed in the kind tone on the tab's headline comparison.
                   big: crowdQuery.data.summary.group_delta !== null
-                    ? `${crowdQuery.data.summary.group_delta > 0 ? '+' : '−'}${Math.abs(crowdQuery.data.summary.group_delta).toFixed(2)}`
+                    ? Math.abs(crowdQuery.data.summary.group_delta) < 0.005
+                      ? 'level'
+                      : `${crowdQuery.data.summary.group_delta > 0 ? '+' : '−'}${Math.abs(crowdQuery.data.summary.group_delta).toFixed(2)}`
                     : '—',
                   unit: 'VS THE CIRCLE',
                   tone:
-                    (crowdQuery.data.summary.group_delta ?? 0) < 0 ? 'var(--bad)' : 'var(--ok)',
+                    Math.abs(crowdQuery.data.summary.group_delta ?? 0) < 0.005
+                      ? 'var(--ink2)'
+                      : (crowdQuery.data.summary.group_delta ?? 0) < 0
+                        ? 'var(--bad)'
+                        : 'var(--ok)',
                 },
                 { big: (crowdQuery.data.summary.lean ?? '—').toUpperCase(), unit: 'LEAN' },
                 {
@@ -738,7 +779,13 @@ export default function OnePersonTab({ subject }: { subject: string }) {
               name: bucket.label,
               weight: bucket.count,
               value: bucket.count.toLocaleString(),
-              sub: bucket.average_rating === null ? '—' : bucket.average_rating.toFixed(1),
+              // The same rated_count floor its three sibling panels apply: an
+              // average over one or two rated films is one opinion, not a
+              // lean, and this panel was printing it without the gate.
+              sub:
+                bucket.average_rating === null || bucket.rated_count < 3
+                  ? '—'
+                  : bucket.average_rating.toFixed(1),
             }))}
           />
         )}

--- a/frontend/src/views/tonight/AvailabilityTab.tsx
+++ b/frontend/src/views/tonight/AvailabilityTab.tsx
@@ -31,7 +31,15 @@ export default function AvailabilityTab({
         title="WHERE A QUEUED FILM CAN BE WATCHED"
         src="movie_watch_providers × watchlist_items"
         blurb={`Films somebody in the selection has queued that a subscription service carries in ${region} right now.`}
-        caveat={availabilityQuery.data?.caveat}
+        caveat={
+          availabilityQuery.data
+            ? `${availabilityQuery.data.caveat}${
+                availabilityQuery.data.films.length > 10
+                  ? ` The ten most wanted are shown of ${availabilityQuery.data.films.length}.`
+                  : ''
+              }`
+            : undefined
+        }
       >
         {panelState({
           isLoading: availabilityQuery.isLoading,
@@ -65,6 +73,13 @@ export default function AvailabilityTab({
               rightCaption: film.checked_at
                 ? `read ${new Date(film.checked_at).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}`
                 : 'read date unknown',
+              // The freshness table one card down says a stale reading is
+              // "shown greyed, not hidden"; nothing was ever greyed. A row
+              // whose provider reading is over a fortnight old is dimmed, so
+              // the claim and the rendering agree.
+              dim: film.checked_at
+                ? Date.now() - new Date(film.checked_at).getTime() > 14 * 24 * 3600 * 1000
+                : true,
             }))}
           />
         )}

--- a/frontend/src/views/tonight/AvailabilityTab.tsx
+++ b/frontend/src/views/tonight/AvailabilityTab.tsx
@@ -25,6 +25,11 @@ export default function AvailabilityTab({
     refetchOnWindowFocus: false,
   });
 
+  // The selected region's staleness, as the freshness panel below reports it.
+  const regionIsStale = Boolean(
+    availabilityQuery.data?.regions.find((entry) => entry.region === region)?.stale,
+  );
+
   return (
     <>
       <Panel
@@ -74,12 +79,11 @@ export default function AvailabilityTab({
                 ? `read ${new Date(film.checked_at).toLocaleDateString('en-GB', { day: '2-digit', month: 'short' })}`
                 : 'read date unknown',
               // The freshness table one card down says a stale reading is
-              // "shown greyed, not hidden"; nothing was ever greyed. A row
-              // whose provider reading is over a fortnight old is dimmed, so
-              // the claim and the rendering agree.
-              dim: film.checked_at
-                ? Date.now() - new Date(film.checked_at).getTime() > 14 * 24 * 3600 * 1000
-                : true,
+              // "shown greyed, not hidden"; nothing was ever greyed. The
+              // verdict comes from that same table's own row for this region
+              // rather than from a clock read during render -- the server has
+              // already decided, and it decides for every film here at once.
+              dim: regionIsStale,
             }))}
           />
         )}

--- a/frontend/src/views/tonight/PicksTab.tsx
+++ b/frontend/src/views/tonight/PicksTab.tsx
@@ -90,10 +90,17 @@ export default function PicksTab({
                   unit: 'NOBODY HAS SEEN',
                 },
                 {
+                  // Subscription only, matching what Tonight › Leaving soon
+                  // counts. The payload carries rent and buy offers too, and
+                  // counting those called a film you must pay for twice
+                  // "streaming" — while the other tab, on the same data,
+                  // disagreed.
                   big: candidates
-                    .filter((candidate) => candidate.movie.providers.length > 0)
+                    .filter((candidate) =>
+                      candidate.movie.providers.some((provider) => provider.type === 'flatrate'),
+                    )
                     .length.toLocaleString(),
-                  unit: `STREAMING IN ${region}`,
+                  unit: `ON A SUBSCRIPTION IN ${region}`,
                 },
               ]
             : undefined
@@ -138,7 +145,25 @@ export default function PicksTab({
             rows={candidates.map((candidate) => {
               const wanted = candidate.on_watchlist_by.length;
               const seen = candidate.watched_by.length;
-              const providers = candidate.movie.providers.map((provider) => provider.name);
+              // Subscription offers first and named as such; rent/buy are
+              // real answers to "where can we watch this" but they are not
+              // the same answer, and the panel used to merge them silently.
+              const streaming = candidate.movie.providers
+                .filter((provider) => provider.type === 'flatrate')
+                .map((provider) => provider.name);
+              const payToWatch = candidate.movie.providers
+                .filter((provider) => provider.type !== 'flatrate')
+                .map((provider) => provider.name);
+              const providers = streaming.length
+                ? streaming
+                : payToWatch.length
+                  ? [`${payToWatch.join(', ')} (rent or buy)`]
+                  : [];
+              // A film TMDB never matched has no provider row to be absent
+              // from, so "not carried" would be a checked negative we never
+              // checked.
+              const providersKnown = candidate.movie.tmdb_id !== null
+                && candidate.movie.tmdb_id !== undefined;
               return {
                 href: pickHref(candidate.movie.title),
                 cells: [
@@ -173,12 +198,19 @@ export default function PicksTab({
                   ),
                   // "Not carried in this region" -- never "not streamable
                   // anywhere", which the provider feed cannot tell us.
-                  cell(providers.length ? providers.join(', ') : `not carried in ${region}`, {
-                    font: 's',
-                    size: '10px',
-                    tone: providers.length ? 'var(--ink3)' : 'var(--dim)',
-                    wrap: true,
-                  }),
+                  cell(
+                    providers.length
+                      ? providers.join(', ')
+                      : providersKnown
+                        ? `not carried in ${region}`
+                        : 'never looked up',
+                    {
+                      font: 's',
+                      size: '10px',
+                      tone: providers.length ? 'var(--ink3)' : 'var(--dim)',
+                      wrap: true,
+                    },
+                  ),
                 ],
               };
             })}


### PR DESCRIPTION
Third batch from the verified audit. The theme: **a panel answering for a subject, a unit or a page other than the one it names.**

### People

- **THEIR LAST TEN showed the same film twice or three times.** The watch and rating streams are the same `ratings` rows from the same repository call, so a diary-heavy profile saw every film once as "watch" and again as "rating". Now one row per film per day, keeping the label that says the most (review > rewatch > rating > watch) and never dropping a star.
- **HOW SOON AFTER RELEASE rendered a title over nothing** for profiles with 1–19 measurable films: the backend withholds the median below 20, but the panel gated its stats row on the median and its empty state on *zero*. "Too few to measure" is now its own state and names the shortfall.
- The genre breakdown printed averages **its three sibling panels suppress** below 3 rated films.
- A crowd delta rounding to zero printed **"−0.00" in the kinder colour** — sign and tone disagreeing on the tab's headline number. Now "level", in neutral.
- **Reach answered for a subject it never showed.** Four of its six panels are about one person, but the tab rendered the multi-select bar, so the subject came from whatever `?subject` a previous tab left in the URL. It now gets the subject picker its panels imply.
- **The unfollow panel could swear nothing had disappeared.** It asked for every edge and filtered client-side; the server interleaves removed edges with active ones, so on an account with >200 follows every unfollow sat past the page. Added an `only_removed` filter, pinned by a test.

### Tonight

- **Rent and buy were counted as "streaming"** — a film you must pay for twice counted as available, while Leaving soon (same data, `flatrate` only) disagreed about the same film. Now `ON A SUBSCRIPTION IN {region}`, with rent/buy shown separately and labelled.
- **"not carried in {region}" was asserted for films TMDB never matched** — a checked negative nobody checked. Those now read "never looked up".
- Availability and Lost & found **stated full counts above truncated grids**; the freshness table promised stale rows are "shown greyed, not hidden" while nothing was ever greyed — `Posters` gained a `dim` flag and stale rows use it.

### Backend

- The overlap calendar's caveat claimed the grid ends on **the pair's most recent overlap**; it ends on the selection's most recent *watch*, which is what it now says.
- The lost-lists endpoint **lazy-loaded the film per row** — one query per item in every deleted list, to render twelve posters. Now joined.

717 backend + deploy tests, 310/310 e2e, tsc and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)