### PR TITLE
Fix the last fourteen audit findings

### DIFF
--- a/backend/services/films.py
+++ b/backend/services/films.py
@@ -514,7 +514,10 @@ def build_liked_vs_rated(db: Session, profiles: Sequence[Profile]) -> Dict[str, 
         "caveat": (
             "A high score is four stars or more. An unrated film has no score, so it lands in "
             "\"neither\" alongside films that were actually rated low — the two are not the same, "
-            "and People › Watched but never rated separates them."
+            "and People › Watched but never rated separates them. These are logs rather than "
+            "distinct films: a film six of the selection watched is counted six times, once per "
+            "opinion, which is the unit the question needs — the same film can be a heart for "
+            "one person and nothing for another."
         ),
     }
 

--- a/frontend/src/app/(terminal)/overlaps/page.tsx
+++ b/frontend/src/app/(terminal)/overlaps/page.tsx
@@ -34,9 +34,12 @@ function OverlapsSection() {
       hrefFor={selection.toggleHref}
       isLocked={selection.isLockedByMinimum}
     >
-      {/* Closeness only changes what Together, Echoes and When compute. The
-          How-sure tab reports coverage, which no window can alter. */}
-      {tab.id === 'sure' ? null : (
+      {/* Closeness changes what Together and When compute. How sure reports
+          coverage, which no window can alter — and Echoes measures a
+          fortnight either side by construction (its window is
+          `max(closeness, 14)`, and the picker's largest value is 7), so
+          offering the control there promised an effect it cannot have. */}
+      {tab.id === 'sure' || tab.id === 'echoes' ? null : (
         <ClosenessPicker
           value={gapDays}
           hrefFor={(value) => selection.paramHref('close', String(value))}

--- a/frontend/src/app/(terminal)/tonight/page.tsx
+++ b/frontend/src/app/(terminal)/tonight/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 
@@ -30,9 +31,10 @@ function RegionPicker({
         {regions.map((region) => {
           const active = region === value;
           return (
-            <a
+            <Link
               key={region}
               href={hrefFor(region)}
+              scroll={false}
               aria-current={active ? 'true' : undefined}
               className="rounded-[3px] border px-2 py-[3px] text-t10 no-underline hover:no-underline"
               style={{
@@ -44,7 +46,7 @@ function RegionPicker({
               }}
             >
               {region}
-            </a>
+            </Link>
           );
         })}
       </div>

--- a/frontend/src/components/terminal/Rail.tsx
+++ b/frontend/src/components/terminal/Rail.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import React from 'react';
 import { useUser } from '@clerk/nextjs';
 import {
@@ -29,11 +30,22 @@ function initialsFor(name: string | null | undefined): string {
   return trimmed.slice(0, 2).toUpperCase();
 }
 
-function RailItem({ section, active }: { section: SectionDef; active: boolean }) {
+function RailItem({
+  section,
+  active,
+  query,
+}: {
+  section: SectionDef;
+  active: boolean;
+  /** The current selection, carried across the jump. The tab row already
+   *  preserves it; the rail dropped it, so moving from Overlaps to Films
+   *  silently recomputed over a different group of people. */
+  query: string;
+}) {
   const Icon = ICONS[section.icon];
   return (
     <Link
-      href={section.legacyPath ?? `/${section.id}`}
+      href={section.legacyPath ?? `/${section.id}${query}`}
       title={`${section.ordinal} · ${section.name}`}
       aria-label={`${section.ordinal} ${section.name}`}
       aria-current={active ? 'page' : undefined}
@@ -59,6 +71,16 @@ function RailItem({ section, active }: { section: SectionDef; active: boolean })
  */
 export default function Rail({ active }: { active: SectionId }) {
   const { user } = useUser();
+  const searchParams = useSearchParams();
+  // Carry the profile selection between sections. `tab` is deliberately
+  // dropped: it means something different in every section, and a stale one
+  // just resolves to the section's first tab anyway.
+  const carried = React.useMemo(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('tab');
+    const query = params.toString();
+    return query ? `?${query}` : '';
+  }, [searchParams]);
   const initials = initialsFor(
     (user?.username as string | undefined) ?? user?.firstName ?? user?.primaryEmailAddress?.emailAddress,
   );
@@ -73,7 +95,12 @@ export default function Rail({ active }: { active: SectionId }) {
       </span>
 
       {SECTIONS.map((section) => (
-        <RailItem key={section.id} section={section} active={section.id === active} />
+        <RailItem
+          key={section.id}
+          section={section}
+          active={section.id === active}
+          query={carried}
+        />
       ))}
 
       <span className="hidden flex-1 md:block" />

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -192,7 +192,7 @@ export default function PublicDashboard() {
 
       <Panel
         title="ANONYMOUS OVERLAP TOTALS"
-        src="watch_events × watch_events"
+        src="ratings × ratings"
         blurb="How much overlap exists in the dataset. Names, profile pairs, titles, ratings and watch dates stay inside the signed-in workspace."
         wide
       >
@@ -236,7 +236,7 @@ export default function PublicDashboard() {
         />
         <div className="flex flex-wrap items-center gap-3 border-t border-term-rule2 px-[10px] py-[9px]">
           <Link
-            href={isSignedIn ? '/overview' : '/sign-in?redirect_url=%2Fdata%3Ftab%3Dprofiles'}
+            href={isSignedIn ? '/data?tab=profiles' : '/sign-in?redirect_url=%2Fdata%3Ftab%3Dprofiles'}
             className="rounded-[3px] border border-term-accent bg-term-accent px-3 py-[5px] text-t105 font-bold text-term-onaccent no-underline hover:no-underline"
           >
             {isSignedIn ? 'Choose monitored profiles' : 'Sign in for private tools'}

--- a/frontend/src/views/data/ProfilesTab.tsx
+++ b/frontend/src/views/data/ProfilesTab.tsx
@@ -399,6 +399,19 @@ export default function ProfilesTab({
       queryClient.invalidateQueries({ queryKey: ['follow-suggestions'] }),
       queryClient.invalidateQueries({ queryKey: ['follow-graph'] }),
       queryClient.invalidateQueries({ queryKey: ['current-user'] }),
+      // An import rewrites what every Data panel reports, not only the
+      // profile lists: the ledger, feed state, importer versions, the
+      // missing-surface counts and the lost-and-found inventory are all
+      // computed from the rows an upload just added.
+      queryClient.invalidateQueries({ queryKey: ['data-ledger'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-feeds'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-importers'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-counts'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-private'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-coverage'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-removed'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-lost'] }),
+      queryClient.invalidateQueries({ queryKey: ['data-lost-lists'] }),
     ]);
 
   // Mutation configs hold only what is true for EVERY caller (the surface
@@ -456,10 +469,16 @@ export default function ProfilesTab({
       });
       setQueueOutcome({
         ok: true,
+        // Approving a profile that is already synced fulfils on the spot —
+        // the backend tracks it and marks the request `fulfilled`. Promising
+        // "the next residential sync" for that case described work nobody
+        // was going to do.
         text:
           result.request.status === 'rejected'
             ? `@${result.request.requested_username} was rejected.`
-            : `@${result.request.requested_username} was accepted for the next residential sync.`,
+            : result.request.status === 'fulfilled'
+              ? `@${result.request.requested_username} was already synced — it is available now.`
+              : `@${result.request.requested_username} was accepted for the next residential sync.`,
       });
     },
     onError: (error: Error) =>
@@ -899,7 +918,9 @@ export default function ProfilesTab({
               ? 'No synced profiles match that search'
               : 'No synced profiles are available yet',
             body: debouncedCatalogSearch
-              ? 'The search runs over every synced profile, so a miss means the name is not here yet. Ask for it below.'
+              ? isAdmin
+                ? 'The search runs over every synced profile, so a miss means the name is not here yet. Ask for it below.'
+                : 'This list is the corner of the follow graph your own profile reaches, so a miss can mean the name is not here yet OR that nobody you follow is connected to them. Asking for them below works either way.'
               : 'Ask for a username below and it will be read on the next full refresh.',
           },
         }) ?? (

--- a/frontend/src/views/films/LibraryTab.tsx
+++ b/frontend/src/views/films/LibraryTab.tsx
@@ -16,6 +16,17 @@ const NEEDS_ENRICHMENT = {
   cta: { label: 'SEE THE MATCH RATE', href: sectionHref('films', 'gaps') },
 };
 
+/**
+ * Filmography runs and worked-through series need a director or a collection
+ * with more than one film in it — enrichment can be complete and these still
+ * come back empty, so blaming the cache sent the reader to a match-rate page
+ * that would tell them everything was fine.
+ */
+const NEEDS_A_REPEAT = {
+  title: 'Nobody here has been watched twice',
+  body: 'This counts a director or a series only once the selection has seen more than one of their films. A library of one-offs fills every other panel on this tab and leaves this one empty.',
+};
+
 export default function LibraryTab({ profiles }: { profiles: string[] }) {
   const enabled = profiles.length > 0;
   const options = { enabled, staleTime: 5 * 60 * 1000, refetchOnWindowFocus: false };
@@ -174,7 +185,7 @@ export default function LibraryTab({ profiles }: { profiles: string[] }) {
           onRetry: () => filmographyQuery.refetch(),
           errorTitle: 'Filmographies could not be read',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: NEEDS_ENRICHMENT,
+          empty: NEEDS_A_REPEAT,
         }) ?? (
           <Rows
             columns="minmax(0,1.1fr) 52px 56px minmax(0,1.2fr)"
@@ -212,7 +223,7 @@ export default function LibraryTab({ profiles }: { profiles: string[] }) {
           onRetry: () => collectionsQuery.refetch(),
           errorTitle: 'Series could not be read',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: NEEDS_ENRICHMENT,
+          empty: NEEDS_A_REPEAT,
         }) ?? (
           <Rows
             columns="minmax(0,1fr) 60px 66px"

--- a/frontend/src/views/overlaps/EchoesTab.tsx
+++ b/frontend/src/views/overlaps/EchoesTab.tsx
@@ -79,6 +79,9 @@ function followCaveat(graph: CoWatchFollowGraphSummary | undefined): string {
 export default function EchoesTab({ profiles, gapDays }: { profiles: string[]; gapDays: number }) {
   // Echoes need a wider window than a co-watch: somebody acting on a
   // recommendation takes a fortnight, not a day.
+  // A fortnight either side, always. The picker's largest closeness is 7, so
+  // this expression never moved; the tab states the window it uses rather
+  // than implying the control above changes it.
   const echoWindow = Math.max(gapDays, 14);
 
   const echoesQuery = useQuery({

--- a/frontend/src/views/overview/OverviewTab.tsx
+++ b/frontend/src/views/overview/OverviewTab.tsx
@@ -282,11 +282,20 @@ export default function OverviewTab() {
           errorTitle: 'Change history unavailable',
           errorBody: 'The rest of the tab is unaffected; this strip retries on demand.',
           onRetry: () => changesQuery.refetch(),
-          empty: {
-            title: 'No change detected yet',
-            body: 'Every tracked surface has come back identical to the read before it. New rows appear here the moment a refresh finds one.',
-            cta: { label: 'OPEN REFRESH LEDGER', href: sectionHref('data', 'refreshes') },
-          },
+          // With nothing monitored the query never ran, so "no change" would
+          // be a claim about syncs that were never asked for.
+          empty:
+            usernames.length === 0
+              ? {
+                  title: 'Nothing is being monitored yet',
+                  body: 'Change is measured against the profiles you follow here, and there are none, so nothing has been looked at.',
+                  cta: { label: 'CHOOSE WHO TO MONITOR', href: sectionHref('data', 'profiles') },
+                }
+              : {
+                  title: 'No change detected yet',
+                  body: 'Every tracked surface has come back identical to the read before it. New rows appear here the moment a refresh finds one.',
+                  cta: { label: 'OPEN REFRESH LEDGER', href: sectionHref('data', 'refreshes') },
+                },
         }) ?? (
           <Rows
             columns="minmax(0,1.6fr) 62px minmax(0,1.4fr)"
@@ -443,7 +452,13 @@ export default function OverviewTab() {
           onRetry: () => marathonsQuery.refetch(),
           errorTitle: 'Marathon days could not be loaded',
           errorBody: 'Every other panel on this tab is unaffected.',
-          empty: {
+          empty: usernames.length === 0
+            ? {
+                title: 'Nothing is being monitored yet',
+                body: 'A marathon is somebody watching several films in a day, and there is nobody here to have had one.',
+                cta: { label: 'CHOOSE WHO TO MONITOR', href: sectionHref('data', 'profiles') },
+              }
+            : {
             title: 'No marathon days yet',
             body: 'Nobody in the selection has three or more dated films on one day. Undated entries cannot be grouped into a day at all.',
           },

--- a/frontend/src/views/people/TwoPeopleTab.tsx
+++ b/frontend/src/views/people/TwoPeopleTab.tsx
@@ -410,7 +410,7 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
       <Panel
         title="COMMON LOVES"
         src="ratings both high"
-        blurb="Films they both rated at the top of their scale. The shortest possible answer to what these two have in common."
+        blurb="Films they both rated 3.5 or better and landed close on. Agreeing that something was poor is agreement, not a shared love, and it belongs in the panel below."
       >
         {panelState({
           isLoading: dossierQuery.isLoading,
@@ -427,7 +427,15 @@ export default function TwoPeopleTab({ profiles }: { profiles: string[] }) {
             : NEED_TWO,
         }) ?? (
           <Posters
-            items={(dossier?.agreements ?? []).slice(0, 6).map((comparison) => ({
+            // "At the top of their scale" has to mean it. The backend sorts
+            // purely by the gap, so two 2.0s (gap zero) outranked a 4.5 and a
+            // 5.0 -- agreement rendered as love, in green.
+            items={(dossier?.agreements ?? [])
+              .filter((comparison) =>
+                comparison.observations.every((entry) => (entry.rating ?? 0) >= 3.5),
+              )
+              .slice(0, 6)
+              .map((comparison) => ({
               title: comparison.movie.year
                 ? `${comparison.movie.title} (${comparison.movie.year})`
                 : comparison.movie.title,

--- a/frontend/src/views/tonight/PicksTab.tsx
+++ b/frontend/src/views/tonight/PicksTab.tsx
@@ -127,8 +127,14 @@ export default function PicksTab({
           onRetry: () => shortlistQuery.refetch(),
           empty: ready
             ? {
-                title: 'No group picks match these filters',
-                body: 'Nothing on the selected queues is unwatched by everybody in the room. Try another region or a different set of people.',
+                title: 'Nothing on the selected watchlists yet',
+                // This mode ranks whatever is queued -- it never filters to
+                // films nobody has seen, and the region only decides where a
+                // film can be watched, not whether it is listed. Saying
+                // otherwise sent people to change a control that could not
+                // help.
+                body: 'This ranks films somebody in the room has queued, seen or not. Nobody in the selection has a watchlist entry we hold, so there is nothing to rank.',
+                cta: { label: 'CHECK WATCHLIST COVERAGE', href: sectionHref('data', 'missing') },
               }
             : needsTwo,
         }) ?? (


### PR DESCRIPTION
Final batch. **All 51 verified findings are now closed.**

### Two controls that did not behave like their siblings

- **The rail dropped the query string.** Curate three profiles on Overlaps, click Films, and Films silently recomputed over a different group — while the tab row and every selection chip carefully preserve it. The rail now carries the selection (dropping only `tab`, which means something different in each section).
- **Tonight's region picker was a bare `<a>`**, so changing region rebooted the whole application and lost scroll position, where every sibling chip updates in place.

### Panels describing a world the reader is not in

- The catalog's *"a miss means the name is not here yet"* is true for an admin and **false for everybody else**, whose catalog is only the corner of the follow graph their own profile reaches.
- Approving an already-synced profile **fulfils on the spot**; the queue announced "accepted for the next residential sync" — work nobody was going to do.
- Overview told a **brand-new account** that nothing had changed and nobody had a marathon, over queries that never ran because nothing is monitored yet.
- The **Library tab blamed TMDB** for two panels that are empty whenever a library has no director or series watched twice — sending people to a match-rate page that would tell them everything was fine.
- **Tonight's shortlist** claimed to filter to films nobody had seen (that mode never has) and suggested changing a region, which cannot affect what is *queued*.
- **COMMON LOVES** sorted purely by rating gap, so two people agreeing a film was poor (gap 0) outranked a 4.5 against a 5.0 — rendered in green under "the top of their scale". Now floored at 3.5.

### And four more

- Public overlap totals are computed from the **ratings** table and were sourced to `watch_events`.
- The signed-in public CTA said "Choose monitored profiles" and navigated to `/overview`.
- The closeness picker was drawn on **Echoes, where it can do nothing** — the echo window is a fortnight either side and the picker's largest value is 7.
- The liked-vs-rated quadrants count one row **per person per film**, which is the right unit for that question, and said "films".

845 backend + deploy tests, 310/310 e2e, tsc, eslint `--max-warnings=0`, and production build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)