### PR TITLE
Give the restore drill the one thing it has always been missing

### DIFF
--- a/deploy/postgres_restore_drill.py
+++ b/deploy/postgres_restore_drill.py
@@ -74,7 +74,14 @@ def _decode_dotenv_value(raw_value: str) -> str:
 
 def read_database_url(env_path: Path) -> str:
     if env_path.is_symlink() or not env_path.is_file():
-        fail("the production database environment file must be a regular file")
+        # The commonest cause by far is that it was never created: the deploy
+        # account's sudo cannot write /etc/spyboxd, so the drill cannot
+        # bootstrap itself and skipped silently every night instead.
+        fail(
+            f"{env_path} is missing or is not a regular file. Run "
+            "deploy/provision-restore-drill.sh as root on the VPS to create the "
+            "restore role and this file."
+        )
 
     database_url: str | None = None
     try:
@@ -646,7 +653,8 @@ def run_restore_drill() -> None:
     ):
         fail(
             "the restore-drill environment file must be root-owned, grouped to the "
-            "deploy account's primary group, and mode 0640"
+            "deploy account's primary group, and mode 0640. "
+            "deploy/provision-restore-drill.sh writes it that way."
         )
 
     connection = parse_database_url(database_url)

--- a/deploy/provision-restore-drill.sh
+++ b/deploy/provision-restore-drill.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Provision the restore drill's dedicated PostgreSQL role and credential file.
+#
+# Run ONCE, as root, on the production VPS. Everything the nightly drill needs
+# that automation deliberately cannot create for itself:
+#
+#   1. a `spyboxd_restore` role with CREATEDB and NOT superuser, so the drill
+#      can build a scratch database to restore into while the application role
+#      stays NOCREATEDB;
+#   2. /etc/spyboxd/restore-drill.env holding that role's DATABASE_URL,
+#      root-owned, grouped to the deploy account, mode 0640.
+#
+# The deploy account's sudo is scoped to systemctl/nginx/ufw on purpose, which
+# is why the drill could never bootstrap itself — it failed on the missing file
+# every night since it was written, and nobody was told because the schedule
+# skips unless PRODUCTION_RESTORE_DRILL_ENABLED is set.
+#
+# Idempotent: re-running rotates the password and rewrites the file. It never
+# touches the application role, the application database, or any data.
+
+set -Eeuo pipefail
+
+API_ENV=/etc/spyboxd/api.env
+DRILL_ENV=/etc/spyboxd/restore-drill.env
+DRILL_ROLE=spyboxd_restore
+DEPLOY_ACCOUNT="${SPYBOXD_DEPLOY_ACCOUNT:-spyboxd-deploy}"
+
+die() {
+  printf '[provision-restore-drill] %s\n' "$1" >&2
+  exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || die 'run this as root: it writes /etc/spyboxd and creates a database role.'
+
+for command_name in install psql python3 openssl getent; do
+  command -v "${command_name}" >/dev/null 2>&1 \
+    || die "required command not found: ${command_name}"
+done
+
+[ -f "${API_ENV}" ] && [ ! -L "${API_ENV}" ] \
+  || die "${API_ENV} must exist and be a regular file"
+
+deploy_group="$(getent group "$(id -gn "${DEPLOY_ACCOUNT}" 2>/dev/null || true)" >/dev/null 2>&1 \
+  && id -gn "${DEPLOY_ACCOUNT}")" \
+  || die "cannot resolve the deploy account's group; set SPYBOXD_DEPLOY_ACCOUNT"
+
+# Reuse the application's host, port and database name — the drill reads the
+# same database, it just connects as a role allowed to CREATE DATABASE. The URL
+# is parsed rather than pattern-matched so a password containing '@' or '/'
+# cannot split it wrongly.
+read -r db_host db_port db_name <<EOF
+$(python3 - "${API_ENV}" <<'PY'
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+url = None
+for raw in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if line.startswith("export "):
+        line = line[7:].lstrip()
+    key, separator, value = line.partition("=")
+    if separator and key.strip() == "DATABASE_URL":
+        url = value.strip().strip('"').strip("'")
+if not url:
+    raise SystemExit("api.env has no DATABASE_URL")
+parts = urlsplit(url)
+if not parts.hostname or not parts.path.lstrip("/"):
+    raise SystemExit("api.env DATABASE_URL is missing a host or database name")
+print(parts.hostname, parts.port or 5432, parts.path.lstrip("/"))
+PY
+)
+EOF
+
+[ -n "${db_name}" ] || die 'could not read the production database name from api.env'
+
+password="$(openssl rand -base64 33 | tr -d '\n=+/' | cut -c1-32)"
+[ "${#password}" -ge 24 ] || die 'failed to generate a sufficiently long password'
+
+# CREATEDB so the drill can build its scratch database; NOSUPERUSER because the
+# drill refuses a superuser outright, and a backup verifier has no business
+# holding one. CONNECT is all it needs on the production database itself.
+# Values arrive on stdin via \set rather than as -v arguments: argv is world
+# readable through ps, and one of these is a password. The CREATE is written as
+# a generated statement run through \gexec because psql does not interpolate
+# its variables inside a dollar-quoted DO block — there, `:'role'` would be
+# taken literally and the role would be created with that name.
+psql -v ON_ERROR_STOP=1 --quiet --no-psqlrc <<SQL
+\set role '${DRILL_ROLE}'
+\set password '${password}'
+\set dbname '${db_name}'
+
+SELECT format('CREATE ROLE %I LOGIN CREATEDB NOSUPERUSER', :'role')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = :'role')
+\gexec
+
+ALTER ROLE :"role" WITH LOGIN CREATEDB NOSUPERUSER PASSWORD :'password';
+GRANT CONNECT ON DATABASE :"dbname" TO :"role";
+SQL
+
+# Written via a 0600 temp file in the same directory and moved into place, so
+# the credential is never briefly world-readable.
+umask 077
+temp_env="$(mktemp /etc/spyboxd/.restore-drill.env.XXXXXX)"
+trap 'rm -f -- "${temp_env}"' EXIT
+printf 'DATABASE_URL=postgresql+psycopg://%s:%s@%s:%s/%s\n' \
+  "${DRILL_ROLE}" "${password}" "${db_host}" "${db_port}" "${db_name}" >"${temp_env}"
+install -o root -g "${deploy_group}" -m 0640 "${temp_env}" "${DRILL_ENV}"
+rm -f -- "${temp_env}"
+trap - EXIT
+
+printf '[provision-restore-drill] %s is ready, owned root:%s mode 0640.\n' \
+  "${DRILL_ENV}" "${deploy_group}"
+printf '[provision-restore-drill] Now enable the nightly schedule:\n'
+printf '  gh variable set PRODUCTION_RESTORE_DRILL_ENABLED --body true\n'
+printf '[provision-restore-drill] Then prove it end to end:\n'
+printf '  gh workflow run "PostgreSQL Restore Drill"\n'

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -439,3 +439,37 @@ class FailureAlertTests(unittest.TestCase):
 
     def test_the_alert_runs_the_same_hardened_runner_as_everything_else(self) -> None:
         self.assertIn(HARDEN_RUNNER, read_repo_file(self.ALERT))
+
+
+class RestoreDrillProvisioningTests(unittest.TestCase):
+    """The drill has never once run: it needs a credential file the deploy
+    account's sudo cannot write, so it failed on the first check every night
+    and the schedule skipped without telling anybody."""
+
+    SCRIPT = "deploy/provision-restore-drill.sh"
+
+    def test_the_drill_names_the_script_that_unblocks_it(self) -> None:
+        drill = read_repo_file("deploy/postgres_restore_drill.py")
+        self.assertIn("deploy/provision-restore-drill.sh", drill)
+
+    def test_the_restore_role_can_create_a_database_but_is_not_a_superuser(self) -> None:
+        contents = read_repo_file(self.SCRIPT)
+        # The drill refuses a superuser outright, and the application role must
+        # stay NOCREATEDB — which is the whole reason for a separate role.
+        self.assertIn("CREATEDB NOSUPERUSER", contents)
+        self.assertNotIn("SUPERUSER;", contents)
+
+    def test_the_credential_never_reaches_argv(self) -> None:
+        contents = read_repo_file(self.SCRIPT)
+        # `ps` is world readable; the password goes in on stdin.
+        self.assertNotIn("-v password=", contents)
+        self.assertIn("\\set password", contents)
+
+    def test_the_file_is_written_with_the_ownership_the_drill_demands(self) -> None:
+        contents = read_repo_file(self.SCRIPT)
+        self.assertIn("install -o root -g \"${deploy_group}\" -m 0640", contents)
+        drill = read_repo_file("deploy/postgres_restore_drill.py")
+        self.assertIn("0o640", drill)
+
+    def test_it_refuses_to_run_as_anybody_but_root(self) -> None:
+        self.assertIn('[ "$(id -u)" -eq 0 ]', read_repo_file(self.SCRIPT))


### PR DESCRIPTION
**The nightly restore drill has never run.** It reads `/etc/spyboxd/restore-drill.env`, that file has never existed, and the schedule is gated behind `PRODUCTION_RESTORE_DRILL_ENABLED` which was never set — so it skipped every night, silently, and failed in 24 seconds the first time it was actually dispatched. An untested backup is a hope.

**It cannot bootstrap itself, and shouldn't be able to.** The credential belongs to a *separate* PostgreSQL role with `CREATEDB` — so the drill can build a scratch database to restore into while the application role stays `NOCREATEDB` — and the deploy account's sudo is scoped to `systemctl`/`nginx`/`ufw` on purpose. Both halves need root.

So this adds the one command that does it, run once on the VPS:

```bash
sudo deploy/provision-restore-drill.sh
```

It creates the role `CREATEDB NOSUPERUSER` (the drill refuses a superuser outright, and a backup verifier has no business holding one), reuses the application's host/port/database from `api.env` by **parsing** the URL rather than pattern-matching it, and writes the credential root-owned, grouped to the deploy account, mode 0640 — exactly what the drill checks for. Idempotent; re-running rotates the password and touches no data.

Two details that would have been bugs:
- the password goes in **on stdin via `\set`**, not as `-v password=`, because argv is readable through `ps`;
- the CREATE runs through **`\gexec`**, not a `DO $$` block — psql does not interpolate its variables inside dollar quotes, so `:'role'` would have created a role named literally `:'role'`.

The drill's two failure messages now name the script rather than describing the state. Five tests pin the role's privileges, the credential staying out of argv, the ownership the drill demands, and the root-only guard.

**After merging, your side is:** run the script, then `gh variable set PRODUCTION_RESTORE_DRILL_ENABLED --body true`, then `gh workflow run "PostgreSQL Restore Drill"` — the script prints all three.

133 deploy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)