### PR TITLE
Give anime its own tables, and a client that reads MyAnimeList honestly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ SPYBOXD_BEARER_TOKEN=
 # TMDB_API_TOKEN=replace-with-your-tmdb-read-access-token
 # TMDB_API_KEY=replace-with-your-tmdb-v3-api-key
 TMDB_DEFAULT_REGION=DE
+
+# MyAnimeList API v2. A client id registered once in the MAL developer console
+# (https://myanimelist.net/apiconfig) — public list reads need the id only, not
+# per-user OAuth, so nobody being tracked has to authorise anything. Sent as an
+# X-MAL-CLIENT-ID header, never in a query string.
+# MAL_CLIENT_ID=replace-with-your-mal-client-id
 TMDB_LANGUAGE=en-US
 TMDB_CACHE_DAYS=30
 TMDB_REQUEST_PAUSE_SECONDS=0.25

--- a/alembic/versions/20260809_0018_add_anime_tracking.py
+++ b/alembic/versions/20260809_0018_add_anime_tracking.py
@@ -1,0 +1,165 @@
+"""Anime as a second library, alongside films.
+
+Spyboxd's argument is about overlap: the same title, close in time, across
+several people. Nothing about that is specific to film, and the group this
+instance tracks watches anime the same way -- but MyAnimeList is a separate
+service with its own identities, its own catalogue and its own idea of what a
+"list entry" is, so it gets its own tables rather than being forced into
+`movies` and `profile_films`.
+
+Three additions:
+
+- `profiles.mal_username` links a tracked person to their MyAnimeList account.
+  Nullable and expected to stay null for most: having a Letterboxd profile
+  implies nothing about having a MAL one, and an absent link is "we do not
+  know of one" rather than "they have none".
+- `anime` is the catalogue, keyed by MAL's own id. Its titles, episode count
+  and airing dates come from the official API rather than being derived.
+- `profile_anime` is one row per person per title: their status, score,
+  episode progress and the dates MAL records. Scores are 1-10 integers on MAL,
+  not the half-star 0.5-5 scale films use, and are stored as MAL gives them --
+  converting at write time would bake one interpretation into the store.
+
+Nothing here is deleted on a later import: `removed_at` marks a row that has
+stopped appearing, the same append-only contract the film side keeps, so a
+list entry a member drops moves to lost-and-found rather than vanishing.
+
+Revision ID: 20260809_0018
+Revises: 20260802_0017
+Create Date: 2026-08-09 20:40:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260809_0018"
+down_revision: Union[str, None] = "20260802_0017"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "profiles",
+        sa.Column("mal_username", sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        "ix_profiles_mal_username", "profiles", ["mal_username"], unique=False
+    )
+
+    op.create_table(
+        "anime",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        # MAL's own id is the identity. Titles are not: they are romanised
+        # inconsistently and change, which is exactly how a catalogue ends up
+        # with the same show twice.
+        sa.Column("mal_id", sa.Integer(), nullable=False),
+        sa.Column("title", sa.String(length=500), nullable=False),
+        sa.Column("title_english", sa.String(length=500), nullable=True),
+        sa.Column("title_japanese", sa.String(length=500), nullable=True),
+        sa.Column("media_type", sa.String(length=32), nullable=True),
+        sa.Column("episodes", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=True),
+        sa.Column("start_date", sa.Date(), nullable=True),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column("mean_score", sa.Float(), nullable=True),
+        sa.Column("poster_url", sa.String(length=1000), nullable=True),
+        sa.Column("synopsis", sa.Text(), nullable=True),
+        sa.Column("genres", sa.JSON(), nullable=True),
+        sa.Column("studios", sa.JSON(), nullable=True),
+        sa.Column("fetched_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_anime_mal_id", "anime", ["mal_id"], unique=True)
+    op.create_index("ix_anime_title", "anime", ["title"], unique=False)
+
+    op.create_table(
+        "profile_anime",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "profile_id",
+            sa.Integer(),
+            sa.ForeignKey("profiles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "anime_id",
+            sa.Integer(),
+            sa.ForeignKey("anime.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # MAL's own vocabulary, unmapped: watching, completed, on_hold,
+        # dropped, plan_to_watch. Translating it into the film side's
+        # vocabulary would lose "on hold", which has no equivalent.
+        sa.Column("status", sa.String(length=32), nullable=False),
+        # 1-10 as MAL stores it. A 0 means unscored on MAL, so it is written
+        # as NULL here -- a zero standing in for an absence is the mistake
+        # this product has made before.
+        sa.Column("score", sa.Integer(), nullable=True),
+        sa.Column("episodes_watched", sa.Integer(), nullable=True),
+        sa.Column("is_rewatching", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("times_rewatched", sa.Integer(), nullable=True),
+        sa.Column("started_date", sa.Date(), nullable=True),
+        sa.Column("finished_date", sa.Date(), nullable=True),
+        # When MAL says the entry last changed. The only timing signal the
+        # list API gives, and the one an overlap has to be built from.
+        sa.Column("updated_at_source", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("first_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        # Append-only, as everywhere else: an entry that stops appearing is
+        # marked, never deleted.
+        sa.Column("removed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("profile_id", "anime_id", name="uq_profile_anime"),
+    )
+    op.create_index(
+        "ix_profile_anime_profile_id", "profile_anime", ["profile_id"], unique=False
+    )
+    op.create_index(
+        "ix_profile_anime_anime_id", "profile_anime", ["anime_id"], unique=False
+    )
+    # The overlap query's shape: everybody who finished a given title, ordered
+    # by when. Without it that is a sequential scan per pair.
+    op.create_index(
+        "ix_profile_anime_finished",
+        "profile_anime",
+        ["anime_id", "finished_date"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_profile_anime_finished", table_name="profile_anime")
+    op.drop_index("ix_profile_anime_anime_id", table_name="profile_anime")
+    op.drop_index("ix_profile_anime_profile_id", table_name="profile_anime")
+    op.drop_table("profile_anime")
+    op.drop_index("ix_anime_title", table_name="anime")
+    op.drop_index("ix_anime_mal_id", table_name="anime")
+    op.drop_table("anime")
+    op.drop_index("ix_profiles_mal_username", table_name="profiles")
+    op.drop_column("profiles", "mal_username")

--- a/alembic/versions/20260809_0018_add_anime_tracking.py
+++ b/alembic/versions/20260809_0018_add_anime_tracking.py
@@ -84,6 +84,9 @@ def upgrade() -> None:
             nullable=False,
         ),
     )
+    # The models declare index=True on the primary key, as every other table
+    # here does, and the autogenerate drift check holds the migration to it.
+    op.create_index("ix_anime_id", "anime", ["id"], unique=False)
     op.create_index("ix_anime_mal_id", "anime", ["mal_id"], unique=True)
     op.create_index("ix_anime_title", "anime", ["title"], unique=False)
 
@@ -137,6 +140,7 @@ def upgrade() -> None:
         ),
         sa.UniqueConstraint("profile_id", "anime_id", name="uq_profile_anime"),
     )
+    op.create_index("ix_profile_anime_id", "profile_anime", ["id"], unique=False)
     op.create_index(
         "ix_profile_anime_profile_id", "profile_anime", ["profile_id"], unique=False
     )
@@ -157,9 +161,11 @@ def downgrade() -> None:
     op.drop_index("ix_profile_anime_finished", table_name="profile_anime")
     op.drop_index("ix_profile_anime_anime_id", table_name="profile_anime")
     op.drop_index("ix_profile_anime_profile_id", table_name="profile_anime")
+    op.drop_index("ix_profile_anime_id", table_name="profile_anime")
     op.drop_table("profile_anime")
     op.drop_index("ix_anime_title", table_name="anime")
     op.drop_index("ix_anime_mal_id", table_name="anime")
+    op.drop_index("ix_anime_id", table_name="anime")
     op.drop_table("anime")
     op.drop_index("ix_profiles_mal_username", table_name="profiles")
     op.drop_column("profiles", "mal_username")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -74,6 +74,10 @@ class Profile(Base):
     # upload under an unknown username can be recognized as an existing
     # profile and renamed in place instead of duplicated.
     letterboxd_person_id = Column(BigInteger, nullable=True)
+    # Their MyAnimeList account, where one is known. Having a Letterboxd
+    # profile implies nothing about having a MAL one, so null means "we do not
+    # know of one" rather than "they have none".
+    mal_username = Column(String(64), nullable=True, index=True)
     member_badge = Column(String(20), nullable=True)  # 'Patron' | 'Pro' | 'Crew'
     pronoun = Column(String(50), nullable=True)  # official-export profile.csv only
     # Every external link a member lists on their profile, as
@@ -1340,3 +1344,87 @@ class SystemMetrics(Base):
     
     # Additional metrics as JSON
     metrics = Column(JSON, nullable=True)
+
+
+class Anime(Base):
+    """The anime catalogue, keyed by MyAnimeList's own id.
+
+    Separate from `movies` on purpose: MAL is a different service with its own
+    identities and its own idea of a title, and forcing anime into a table
+    whose identity is a Letterboxd slug would make every join a guess.
+    """
+
+    __tablename__ = "anime"
+
+    id = Column(Integer, primary_key=True, index=True)
+    # Titles are romanised inconsistently and change; the id does not.
+    mal_id = Column(Integer, nullable=False, unique=True, index=True)
+    title = Column(String(500), nullable=False, index=True)
+    title_english = Column(String(500), nullable=True)
+    title_japanese = Column(String(500), nullable=True)
+    media_type = Column(String(32), nullable=True)
+    episodes = Column(Integer, nullable=True)
+    status = Column(String(32), nullable=True)
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+    mean_score = Column(Float, nullable=True)
+    poster_url = Column(String(1000), nullable=True)
+    synopsis = Column(Text, nullable=True)
+    genres = Column(JSON, nullable=True)
+    studios = Column(JSON, nullable=True)
+    fetched_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    profile_entries = relationship(
+        "ProfileAnime", back_populates="anime", cascade="all, delete-orphan"
+    )
+
+
+class ProfileAnime(Base):
+    """One person's entry for one title: where they are with it, and when."""
+
+    __tablename__ = "profile_anime"
+
+    id = Column(Integer, primary_key=True, index=True)
+    profile_id = Column(
+        Integer, ForeignKey("profiles.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    anime_id = Column(
+        Integer, ForeignKey("anime.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # MAL's own vocabulary, unmapped: watching, completed, on_hold, dropped,
+    # plan_to_watch. The film side has no equivalent of "on hold", so
+    # translating would lose it.
+    status = Column(String(32), nullable=False)
+    # 1-10 as MAL stores it, never rescaled to the half-star film scale. MAL
+    # writes 0 for unscored; that arrives here as NULL, because a zero
+    # standing in for an absence is the mistake this product keeps catching.
+    score = Column(Integer, nullable=True)
+    episodes_watched = Column(Integer, nullable=True)
+    is_rewatching = Column(Boolean, nullable=False, default=False)
+    times_rewatched = Column(Integer, nullable=True)
+    started_date = Column(Date, nullable=True)
+    finished_date = Column(Date, nullable=True)
+    # The only timing signal the list API gives, and what an overlap is built
+    # from when a finished date is absent.
+    updated_at_source = Column(DateTime(timezone=True), nullable=True)
+    first_seen_at = Column(DateTime(timezone=True), nullable=True)
+    last_seen_at = Column(DateTime(timezone=True), nullable=True)
+    # Append-only, as everywhere else: an entry that stops appearing is marked,
+    # never deleted.
+    removed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    profile = relationship("Profile")
+    anime = relationship("Anime", back_populates="profile_entries")
+
+    __table_args__ = (
+        UniqueConstraint("profile_id", "anime_id", name="uq_profile_anime"),
+        Index("ix_profile_anime_finished", "anime_id", "finished_date"),
+    )

--- a/backend/services/mal_client.py
+++ b/backend/services/mal_client.py
@@ -1,0 +1,297 @@
+"""Small, synchronous MyAnimeList API v2 client.
+
+Reads public anime lists for the profiles this instance tracks. Only the
+public surface is used: `GET /users/{name}/animelist` with a client id, which
+needs no per-user OAuth and so needs nothing from the people being tracked.
+
+The credential is a client id registered once against the MAL developer
+console and supplied as MAL_CLIENT_ID. It is sent as `X-MAL-CLIENT-ID`, never
+in a query string, so it cannot end up in a proxy log or a redirect.
+
+Design notes worth keeping:
+
+- MAL paginates with an opaque `paging.next` URL rather than page numbers. The
+  cursor is followed rather than reconstructed, and it is checked to be on
+  MAL's own host before being fetched, so a compromised or surprising response
+  cannot walk this client onto another origin.
+- A score of 0 on MAL means "unscored", not "the worst". It is returned as
+  None, because a zero standing in for an absence is the mistake this product
+  keeps finding in its own panels.
+- Dates arrive as `YYYY-MM-DD`, `YYYY-MM` or `YYYY` — MAL genuinely stores
+  partial dates. Anything short of a full date is None rather than a guessed
+  first-of-the-month, since these dates are what an overlap is computed from.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+import os
+import time
+from typing import Any, Dict, Iterator, List, Mapping, Optional
+from urllib.parse import urlsplit
+
+import requests
+
+
+DEFAULT_API_BASE_URL = "https://api.myanimelist.net/v2"
+API_HOST = "api.myanimelist.net"
+# MAL's documented ceiling for this endpoint. Asking for more is rejected
+# rather than truncated, so it is pinned here instead of being a caller's
+# problem.
+MAX_PAGE_LIMIT = 1000
+# Everything the list endpoint will give about an entry, plus the fields of
+# the title itself that the catalogue stores.
+LIST_FIELDS = (
+    "list_status{status,score,num_episodes_watched,is_rewatching,"
+    "num_times_rewatched,start_date,finish_date,updated_at},"
+    "id,title,alternative_titles,media_type,num_episodes,status,"
+    "start_date,end_date,mean,main_picture,synopsis,genres,studios"
+)
+REQUEST_TIMEOUT_SECONDS = 20
+# MAL is not explicit about its rate limit; this is deliberately gentle. A
+# full list is a handful of requests, and being slow costs nothing here.
+MIN_SECONDS_BETWEEN_REQUESTS = 0.7
+
+
+class MALError(RuntimeError):
+    """Base error for a MyAnimeList operation."""
+
+
+class MALConfigurationError(MALError):
+    """Raised when no MAL client id is configured."""
+
+
+class MALNotFoundError(MALError):
+    """Raised when MAL has no such user, or their list is private.
+
+    The two are deliberately one error: MAL answers 404 for both, and
+    inventing a distinction the API does not draw would be a guess.
+    """
+
+
+class MALRequestError(MALError):
+    """Raised after an HTTP or response-decoding failure."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def resolve_client_id(explicit: Optional[str] = None) -> str:
+    client_id = (explicit or os.getenv("MAL_CLIENT_ID") or "").strip()
+    if not client_id:
+        raise MALConfigurationError(
+            "MAL_CLIENT_ID is not set; register a client id in the MyAnimeList "
+            "developer console and add it to the API environment"
+        )
+    return client_id
+
+
+def parse_mal_date(value: Any) -> Optional[date]:
+    """MAL stores partial dates. A partial date is not a date.
+
+    `2019` and `2019-04` are both real MAL values. Widening either into a
+    concrete day would invent a fact that overlap timing is computed from, so
+    only a full date is accepted.
+    """
+
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.strptime(value.strip(), "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def parse_mal_timestamp(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def normalise_score(value: Any) -> Optional[int]:
+    """0 on MAL means unscored, and must not become a rating of zero."""
+
+    if not isinstance(value, int) or isinstance(value, bool):
+        return None
+    if value <= 0 or value > 10:
+        return None
+    return value
+
+
+class MALClient:
+    def __init__(
+        self,
+        *,
+        client_id: Optional[str] = None,
+        base_url: str = DEFAULT_API_BASE_URL,
+        session: Optional[requests.Session] = None,
+        min_interval_seconds: float = MIN_SECONDS_BETWEEN_REQUESTS,
+    ) -> None:
+        self._client_id = resolve_client_id(client_id)
+        self._base_url = base_url.rstrip("/")
+        self._session = session or requests.Session()
+        self._min_interval = max(0.0, min_interval_seconds)
+        self._last_request_at = 0.0
+
+    def _throttle(self) -> None:
+        elapsed = time.monotonic() - self._last_request_at
+        if self._last_request_at and elapsed < self._min_interval:
+            time.sleep(self._min_interval - elapsed)
+        self._last_request_at = time.monotonic()
+
+    def _get(self, url: str, params: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        # Every URL this client fetches -- including a pagination cursor the
+        # API handed back -- must be MAL's own host over HTTPS.
+        parsed = urlsplit(url)
+        if parsed.scheme != "https" or parsed.hostname != API_HOST:
+            raise MALRequestError("refusing to follow a URL outside the MyAnimeList API")
+
+        self._throttle()
+        try:
+            response = self._session.get(
+                url,
+                params=params,
+                headers={
+                    "X-MAL-CLIENT-ID": self._client_id,
+                    "Accept": "application/json",
+                },
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except requests.RequestException as exc:
+            raise MALRequestError("the MyAnimeList API could not be reached") from exc
+
+        if response.status_code == 404:
+            raise MALNotFoundError(
+                "MyAnimeList has no such user, or their list is not public"
+            )
+        if response.status_code >= 400:
+            raise MALRequestError(
+                f"the MyAnimeList API answered HTTP {response.status_code}",
+                status_code=response.status_code,
+            )
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise MALRequestError("the MyAnimeList API returned invalid JSON") from exc
+        if not isinstance(payload, dict):
+            raise MALRequestError("the MyAnimeList API returned an unexpected shape")
+        return payload
+
+    def iter_anime_list(
+        self, username: str, *, limit: int = 500, max_pages: int = 40
+    ) -> Iterator[Dict[str, Any]]:
+        """Yield one normalised entry per title on a member's public list.
+
+        `max_pages` is a runaway guard, not a policy: at 500 per page it
+        covers 20,000 titles, well past any real list. Hitting it means the
+        cursor is looping, which is worth stopping for rather than paging
+        forever.
+        """
+
+        name = (username or "").strip()
+        if not name:
+            raise MALRequestError("a MyAnimeList username is required")
+
+        url = f"{self._base_url}/users/{requests.utils.quote(name, safe='')}/animelist"
+        params: Optional[Dict[str, Any]] = {
+            "fields": LIST_FIELDS,
+            "limit": min(max(int(limit), 1), MAX_PAGE_LIMIT),
+            "nsfw": "true",
+        }
+
+        for _ in range(max_pages):
+            payload = self._get(url, params)
+            for node in payload.get("data") or []:
+                entry = normalise_list_entry(node)
+                if entry is not None:
+                    yield entry
+            following = (payload.get("paging") or {}).get("next")
+            if not isinstance(following, str) or not following:
+                return
+            # The cursor already carries its query; sending ours again would
+            # override the offset it encodes.
+            url, params = following, None
+        raise MALRequestError("the MyAnimeList list cursor did not terminate")
+
+
+def normalise_list_entry(node: Any) -> Optional[Dict[str, Any]]:
+    """One MAL list row into the shape the importer stores.
+
+    Returns None for a row without an id or a status: those are the two facts
+    an entry cannot mean anything without, and a partial row is dropped rather
+    than written with invented defaults.
+    """
+
+    if not isinstance(node, dict):
+        return None
+    anime = node.get("node")
+    status_block = node.get("list_status")
+    if not isinstance(anime, dict) or not isinstance(status_block, dict):
+        return None
+
+    mal_id = anime.get("id")
+    if not isinstance(mal_id, int) or isinstance(mal_id, bool) or mal_id <= 0:
+        return None
+    status = status_block.get("status")
+    if not isinstance(status, str) or not status.strip():
+        return None
+
+    alternative = anime.get("alternative_titles")
+    alternative = alternative if isinstance(alternative, dict) else {}
+    picture = anime.get("main_picture")
+    picture = picture if isinstance(picture, dict) else {}
+
+    return {
+        "mal_id": mal_id,
+        "title": str(anime.get("title") or "").strip() or f"MAL #{mal_id}",
+        "title_english": (alternative.get("en") or "").strip() or None,
+        "title_japanese": (alternative.get("ja") or "").strip() or None,
+        "media_type": anime.get("media_type") or None,
+        "episodes": anime.get("num_episodes")
+        if isinstance(anime.get("num_episodes"), int)
+        else None,
+        "airing_status": anime.get("status") or None,
+        "start_date": parse_mal_date(anime.get("start_date")),
+        "end_date": parse_mal_date(anime.get("end_date")),
+        "mean_score": anime.get("mean") if isinstance(anime.get("mean"), (int, float)) else None,
+        # Preferring the large image: the small one is 100px wide and looks
+        # like a broken asset beside the film posters.
+        "poster_url": picture.get("large") or picture.get("medium") or None,
+        "synopsis": (anime.get("synopsis") or "").strip() or None,
+        "genres": [
+            genre["name"]
+            for genre in (anime.get("genres") or [])
+            if isinstance(genre, dict) and isinstance(genre.get("name"), str)
+        ],
+        "studios": [
+            studio["name"]
+            for studio in (anime.get("studios") or [])
+            if isinstance(studio, dict) and isinstance(studio.get("name"), str)
+        ],
+        "status": status.strip(),
+        "score": normalise_score(status_block.get("score")),
+        "episodes_watched": status_block.get("num_episodes_watched")
+        if isinstance(status_block.get("num_episodes_watched"), int)
+        else None,
+        "is_rewatching": bool(status_block.get("is_rewatching")),
+        "times_rewatched": status_block.get("num_times_rewatched")
+        if isinstance(status_block.get("num_times_rewatched"), int)
+        else None,
+        "started_date": parse_mal_date(status_block.get("start_date")),
+        "finished_date": parse_mal_date(status_block.get("finish_date")),
+        "updated_at_source": parse_mal_timestamp(status_block.get("updated_at")),
+    }
+
+
+def fetch_anime_list(username: str, *, client_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Convenience wrapper: the whole list, normalised."""
+
+    return list(MALClient(client_id=client_id).iter_anime_list(username))

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260802_0017"
+HEAD_REVISION = "20260809_0018"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260801_0016"
+            script.get_revision(HEAD_REVISION).down_revision, "20260802_0017"
+        )
+        self.assertEqual(
+            script.get_revision("20260802_0017").down_revision, "20260801_0016"
         )
         self.assertEqual(
             script.get_revision("20260801_0016").down_revision, "20260801_0015"

--- a/backend/tests/test_mal_client.py
+++ b/backend/tests/test_mal_client.py
@@ -1,0 +1,223 @@
+"""What the MyAnimeList client is allowed to claim.
+
+Anime arrives from a service whose conventions differ from Letterboxd's in
+three ways that have each already caused a bug on the film side: a zero that
+means "absent", a date that is not a whole date, and a paginated feed whose
+cursor is handed back rather than constructed. Each is pinned here.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from services.mal_client import (
+    MALClient,
+    MALConfigurationError,
+    MALNotFoundError,
+    MALRequestError,
+    normalise_list_entry,
+    normalise_score,
+    parse_mal_date,
+    parse_mal_timestamp,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code: int = 200, *, invalid_json: bool = False):
+        self._payload = payload
+        self.status_code = status_code
+        self._invalid_json = invalid_json
+
+    def json(self):
+        if self._invalid_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+class FakeSession:
+    """Records what was asked for, so the request itself can be asserted."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def get(self, url, params=None, headers=None, timeout=None):
+        self.calls.append({"url": url, "params": params, "headers": headers})
+        if not self._responses:
+            raise AssertionError("the client made more requests than the test provided")
+        return self._responses.pop(0)
+
+
+def _entry(**overrides):
+    node = {
+        "node": {
+            "id": 5114,
+            "title": "Fullmetal Alchemist: Brotherhood",
+            "alternative_titles": {"en": "Fullmetal Alchemist: Brotherhood", "ja": "鋼の錬金術師"},
+            "media_type": "tv",
+            "num_episodes": 64,
+            "status": "finished_airing",
+            "start_date": "2009-04-05",
+            "end_date": "2010-07-04",
+            "mean": 9.1,
+            "main_picture": {"medium": "https://cdn.myanimelist.net/s.jpg", "large": "https://cdn.myanimelist.net/l.jpg"},
+            "genres": [{"id": 1, "name": "Action"}, {"id": 2, "name": "Adventure"}],
+            "studios": [{"id": 4, "name": "Bones"}],
+        },
+        "list_status": {
+            "status": "completed",
+            "score": 10,
+            "num_episodes_watched": 64,
+            "is_rewatching": False,
+            "num_times_rewatched": 1,
+            "start_date": "2024-01-02",
+            "finish_date": "2024-02-11",
+            "updated_at": "2024-02-11T18:04:00+00:00",
+        },
+    }
+    node["node"].update(overrides.pop("node", {}))
+    node["list_status"].update(overrides.pop("list_status", {}))
+    return node
+
+
+def test_an_unscored_entry_is_absent_rather_than_a_score_of_zero() -> None:
+    """MAL writes 0 for unscored. Stored as 0 it would drag every average
+    down and read as the worst possible opinion."""
+
+    assert normalise_score(0) is None
+    assert normalise_score(None) is None
+    assert normalise_score(True) is None
+    assert normalise_score(8) == 8
+    # Out of MAL's own range, so not a score it could have meant.
+    assert normalise_score(11) is None
+
+
+def test_a_partial_date_is_not_widened_into_a_day() -> None:
+    """MAL genuinely stores `2019` and `2019-04`. Overlap timing is computed
+    from these dates, so inventing a first-of-the-month would manufacture a
+    coincidence."""
+
+    assert parse_mal_date("2019-04-05") == date(2019, 4, 5)
+    assert parse_mal_date("2019-04") is None
+    assert parse_mal_date("2019") is None
+    assert parse_mal_date("") is None
+    assert parse_mal_date(None) is None
+
+
+def test_a_naive_timestamp_is_read_as_utc() -> None:
+    assert parse_mal_timestamp("2024-02-11T18:04:00Z") == datetime(
+        2024, 2, 11, 18, 4, tzinfo=timezone.utc
+    )
+    assert parse_mal_timestamp("2024-02-11T18:04:00") == datetime(
+        2024, 2, 11, 18, 4, tzinfo=timezone.utc
+    )
+    assert parse_mal_timestamp("nonsense") is None
+
+
+def test_a_row_without_an_id_or_a_status_is_dropped_rather_than_defaulted() -> None:
+    assert normalise_list_entry({"node": {"id": 1}}) is None
+    assert normalise_list_entry(_entry(node={"id": None})) is None
+    assert normalise_list_entry(_entry(list_status={"status": ""})) is None
+    assert normalise_list_entry("not a dict") is None
+
+
+def test_a_normalised_entry_keeps_mal_s_own_vocabulary() -> None:
+    entry = normalise_list_entry(_entry())
+
+    assert entry["mal_id"] == 5114
+    # Not translated into the film side's vocabulary, which has no "on hold".
+    assert entry["status"] == "completed"
+    assert entry["score"] == 10
+    assert entry["finished_date"] == date(2024, 2, 11)
+    assert entry["genres"] == ["Action", "Adventure"]
+    assert entry["studios"] == ["Bones"]
+    # The large image: the medium one is a hundred pixels wide and reads as a
+    # broken asset beside the film posters.
+    assert entry["poster_url"].endswith("l.jpg")
+
+
+def test_the_client_id_travels_in_a_header_not_a_query_string() -> None:
+    session = FakeSession([FakeResponse({"data": [_entry()], "paging": {}})])
+    client = MALClient(client_id="abc123", session=session, min_interval_seconds=0)
+
+    list(client.iter_anime_list("whiteknight03X"))
+
+    call = session.calls[0]
+    assert call["headers"]["X-MAL-CLIENT-ID"] == "abc123"
+    # A credential in a query string ends up in proxy logs and referrers.
+    assert "abc123" not in call["url"]
+    assert "abc123" not in str(call["params"])
+
+
+def test_pagination_follows_mal_s_cursor_without_re_sending_our_own_query() -> None:
+    """The cursor already encodes the offset; sending `limit` again with it
+    would restart the page it points at."""
+
+    session = FakeSession(
+        [
+            FakeResponse(
+                {
+                    "data": [_entry()],
+                    "paging": {
+                        "next": "https://api.myanimelist.net/v2/users/x/animelist?offset=500"
+                    },
+                }
+            ),
+            FakeResponse({"data": [_entry(node={"id": 1})], "paging": {}}),
+        ]
+    )
+    client = MALClient(client_id="abc123", session=session, min_interval_seconds=0)
+
+    entries = list(client.iter_anime_list("x"))
+
+    assert [entry["mal_id"] for entry in entries] == [5114, 1]
+    assert session.calls[1]["params"] is None
+
+
+def test_a_cursor_pointing_off_mal_is_refused() -> None:
+    """A pagination URL is a URL the API chose. It is still checked."""
+
+    session = FakeSession(
+        [
+            FakeResponse(
+                {"data": [], "paging": {"next": "https://evil.example/v2/users/x/animelist"}}
+            )
+        ]
+    )
+    client = MALClient(client_id="abc123", session=session, min_interval_seconds=0)
+
+    with pytest.raises(MALRequestError, match="outside the MyAnimeList API"):
+        list(client.iter_anime_list("x"))
+
+
+def test_a_private_or_missing_list_is_one_honest_error() -> None:
+    """MAL answers 404 for both, and drawing a distinction it does not make
+    would be a guess presented as a fact."""
+
+    session = FakeSession([FakeResponse({}, status_code=404)])
+    client = MALClient(client_id="abc123", session=session, min_interval_seconds=0)
+
+    with pytest.raises(MALNotFoundError):
+        list(client.iter_anime_list("nobody"))
+
+
+def test_a_runaway_cursor_stops_instead_of_paging_forever() -> None:
+    looping = FakeResponse(
+        {
+            "data": [_entry()],
+            "paging": {"next": "https://api.myanimelist.net/v2/users/x/animelist?offset=0"},
+        }
+    )
+    session = FakeSession([looping] * 12)
+    client = MALClient(client_id="abc123", session=session, min_interval_seconds=0)
+
+    with pytest.raises(MALRequestError, match="did not terminate"):
+        list(client.iter_anime_list("x", max_pages=10))
+
+
+def test_a_missing_credential_says_what_to_do_about_it(monkeypatch) -> None:
+    monkeypatch.delenv("MAL_CLIENT_ID", raising=False)
+
+    with pytest.raises(MALConfigurationError, match="developer console"):
+        MALClient()


### PR DESCRIPTION
First increment of the MAL tracker. **Schema + API client + tests. No importer and no UI yet** — deliberately, see below.

### Why separate tables

Overlap — the same title, close in time, across several people — is what Spyboxd argues about, and none of that is film-specific. But MAL is a different service with its own identities and its own idea of a list entry, and `movies`' identity is a Letterboxd slug. Forcing anime through it would make every join a guess.

- **`profiles.mal_username`** — nullable, expected to stay null for most. Having a Letterboxd profile implies nothing about having a MAL one; null means *we don't know of one*, not *they have none*.
- **`anime`** — keyed by MAL's own id, because titles are romanised inconsistently and change (which is exactly how a catalogue ends up with the same show twice).
- **`profile_anime`** — one row per person per title, keeping **MAL's own vocabulary unmapped**: translating `on_hold` into the film side's states would simply lose it. Append-only, `removed_at` like everywhere else.

### Three decisions this codebase keeps relearning

| MAL convention | What the client does | Why |
|---|---|---|
| score `0` = unscored | stored as `NULL` | a zero standing in for an absence is the bug this product keeps finding in its own panels |
| `2019-04` is a real stored value | partial dates → `NULL` | overlap timing is computed from these; a guessed first-of-the-month manufactures a coincidence |
| `paging.next` is an opaque URL | followed, but **host-checked first** | a pagination URL is still a URL the client is told to fetch |

The client id travels as `X-MAL-CLIENT-ID`, never in a query string, so it can't land in a proxy log or referrer.

### Why no importer or UI yet

With no client id there is no way to see a real payload — and this repo has already shipped fixtures that agreed with a service about a shape production never stores (the TMDB `belongs_to_collection` nesting). Building the importer against a guessed shape would repeat that. **Eleven tests** pin everything that doesn't need the network.

### What I need from you

```bash
gh secret set MAL_CLIENT_ID --env production --body "<your client id>"
```

Register at **myanimelist.net/apiconfig** (public list reads need the id only — no per-user OAuth, so nobody you track has to authorise anything). Then tell me the MAL usernames for the people you track, and I'll build the importer against real responses and the overlap panels on top.

861 backend + deploy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)