### PR TITLE
Check every panel against the real database, not a fixture of it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,13 @@ jobs:
       - name: Run backend test suite
         run: python -m pytest backend/tests --ignore=backend/tests/test_additive_migrations.py
 
+      # Runs here rather than beside the other deploy tests because it imports
+      # the real `services` package to prove no database-touching function is
+      # unswept -- so a coverage gap fails a pull request instead of first
+      # showing up against production.
+      - name: Prove the panel sweep still covers every builder
+        run: python -m pytest deploy/test_panel_sweep.py -v
+
       - name: Check model and migration parity
         run: python -m alembic check
 

--- a/.github/workflows/panel-sweep.yml
+++ b/.github/workflows/panel-sweep.yml
@@ -1,0 +1,159 @@
+name: Panel Sweep
+
+# Call every panel builder against the real production database and prove it
+# still answers, correctly and quickly.
+#
+# The four existing layers all stop short of this: pytest runs the builders on
+# SQLite fixtures, Playwright runs the panels on mocked responses, and both
+# canaries check privacy and identity rather than data. Every defect this
+# project has actually shipped to production lived in that gap -- Postgres-only
+# SQL, a query that is instant on a fixture and twelve seconds on the real
+# table, a column whose real size took the API down.
+#
+# Read-only: the sweep opens a READ ONLY transaction, calls only `build_`
+# functions, and rolls back without ever committing. It runs on the VPS in the
+# API's own virtualenv, importing exactly what the service unit imports.
+
+on:
+  schedule:
+    - cron: "23 4 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spyboxd-production-panel-sweep
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  panel-sweep:
+    name: Prove every panel against real data
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'workflow_dispatch' ||
+      vars.PRODUCTION_PANEL_SWEEP_ENABLED == 'true')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    environment:
+      name: production
+      url: https://spyboxd.com
+    env:
+      SWEEP_SCRIPT_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Monitor runner file and network activity
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Check out the exact sweep helpers
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ env.SWEEP_SCRIPT_SHA }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      # Runs before any credential is loaded, and includes the check that no
+      # database-touching function is unclassified -- so a coverage gap is
+      # caught here rather than discovered against production.
+      - name: Test the sweep's own safety and completeness rules
+        run: |
+          set -Eeuo pipefail
+          python3 -m pip install --quiet --disable-pip-version-check pytest
+          python3 -m pytest -q deploy/test_panel_sweep.py
+
+      - name: Establish one pinned IPv4 production SSH connection
+        env:
+          SSH_FINGERPRINT: ${{ secrets.VPS_HOST_FINGERPRINT }}
+          SSH_HOST: ${{ secrets.VPS_HOST }}
+          SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_KEY }}
+        run: deploy/production-ssh.sh open
+
+      - name: Call every panel builder against production data
+        id: sweep
+        run: |
+          set -Eeuo pipefail
+          [[ "${SWEEP_SCRIPT_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          timeout --signal=TERM --kill-after=2m 20m \
+            deploy/production-ssh.sh run sh -s -- "${SWEEP_SCRIPT_SHA}" \
+            <<'REMOTE' | tee "${RUNNER_TEMP}/panel-sweep.json"
+          set -eu
+          sweep_script_sha="$1"
+          case "${sweep_script_sha}" in
+            *[!0-9a-f]*|'') echo 'Invalid panel-sweep script SHA.' >&2; exit 64 ;;
+          esac
+          [ "${#sweep_script_sha}" -eq 40 ] || exit 64
+
+          repository_git() {
+            git --git-dir=/opt/spyboxd/repository "$@"
+          }
+          repository_git rev-parse --is-bare-repository >/dev/null
+          timeout --signal=TERM --kill-after=15s 2m \
+            git --git-dir=/opt/spyboxd/repository fetch \
+              --quiet --force --prune origin \
+              '+refs/heads/main:refs/remotes/origin/main'
+          resolved_script_sha="$(
+            repository_git rev-parse --verify "${sweep_script_sha}^{commit}"
+          )"
+          [ "${resolved_script_sha}" = "${sweep_script_sha}" ]
+          repository_git merge-base --is-ancestor \
+            "${sweep_script_sha}" refs/remotes/origin/main
+
+          sweep_runner="$(mktemp /tmp/spyboxd-panel-sweep.XXXXXX)"
+          cleanup_runner() {
+            rm -f -- "${sweep_runner}"
+          }
+          trap cleanup_runner EXIT HUP INT TERM
+          repository_git show \
+            "${sweep_script_sha}:deploy/panel_sweep.py" \
+            >"${sweep_runner}"
+          chmod 0700 "${sweep_runner}"
+
+          current_link=/opt/spyboxd/current
+          python_path="${current_link}/.venv/bin/python"
+          application_root="${current_link}/backend"
+          database_env_file=/etc/spyboxd/api.env
+          [ -L "${current_link}" ]
+          [ -x "${python_path}" ]
+          [ -d "${application_root}" ]
+          [ -f "${database_env_file}" ] && [ ! -L "${database_env_file}" ] \
+            && [ -r "${database_env_file}" ]
+
+          # The sweep reads DATABASE_URL out of the file itself and takes
+          # nothing else from it -- sourcing api.env here would hand a
+          # read-only checker every secret the API holds.
+          "${python_path}" "${sweep_runner}" --json \
+            --application-root "${application_root}" \
+            --database-env-file "${database_env_file}"
+          REMOTE
+
+      # Runs on failure too: a sweep that found a broken builder is exactly the
+      # run whose report is worth reading.
+      - name: Summarize the sweep
+        if: always() && steps.sweep.outcome != 'skipped'
+        env:
+          SWEEP_REPORT: ${{ runner.temp }}/panel-sweep.json
+        run: |
+          set -Eeuo pipefail
+          python3 deploy/summarize_panel_sweep.py "${SWEEP_REPORT}" \
+            >>"${GITHUB_STEP_SUMMARY}"
+
+      - name: Close production SSH and securely remove local key material
+        if: always()
+        run: |
+          if [[ -x deploy/production-ssh.sh ]]; then
+            deploy/production-ssh.sh close
+          fi
+
+  alert_on_failure:
+    name: Alert if this run failed
+    needs: [panel-sweep]
+    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      issues: write
+    uses: ./.github/workflows/failure-alert.yml
+    with:
+      workflow: Panel Sweep

--- a/deploy/panel_sweep.py
+++ b/deploy/panel_sweep.py
@@ -1,0 +1,405 @@
+"""Call every panel builder against real production data, and prove it.
+
+The gap this closes
+-------------------
+Four verification layers already run, and none of them answers the question
+"do the panels work against the real data":
+
+- pytest exercises the builders against SQLite, with fixtures;
+- Playwright exercises the panels against *mocked* API responses;
+- the public canary checks health, the aggregate dashboard, RSS, redirects and
+  that every private route stays private;
+- the authenticated canary checks identity and cross-profile isolation.
+
+Every production defect this project has actually shipped lived in the space
+none of those cover -- SQL that is valid in SQLite and wrong in Postgres, a
+query that is instant on a fixture and twelve seconds on the real table, a
+column whose real-world size took the API down. Those only appear when the real
+builders meet the real database at its real size, which is what this does.
+
+Safety
+------
+Read-only by construction, three ways over:
+
+1. the transaction is opened READ ONLY, so a write raises rather than lands;
+2. only `build_*` functions are called, and every other db-taking function is
+   listed below with the reason it is excluded;
+3. the session is rolled back and closed in a finally, never committed.
+
+Completeness
+------------
+The builder list is derived by walking the API's own `services` package, not hand-written. A
+function taking a database session that is neither swept nor explicitly
+excluded fails the sweep. A new panel builder is therefore covered the moment
+it exists, and a new writer has to be named before this passes -- silence is
+never mistaken for coverage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import json
+import os
+import pkgutil
+import sys
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+
+# Functions that take a database session and are deliberately NOT called.
+# Each entry is a promise that the exclusion was a decision, not an oversight;
+# the sweep fails on anything reaching a session that is not named here or
+# swept below.
+EXCLUDED: Dict[str, str] = {
+    # --- writers: excluded because this sweep must not mutate production ---
+    "letterboxd_ratings.sync_letterboxd_ratings": "writes ratings; scraping job, not a panel",
+    "tmdb_enrichment.enrich_movies": "writes enrichment rows; batch job, not a panel",
+    "rss_incremental.poll_profile_feed": "writes watch events and performs network I/O",
+    "rss_incremental.acquire_profile_feed_lease": "takes a lease other workers honour",
+    "profile_ingestion_lock.lock_profile_ingestion": "takes an advisory lock ingestion honours",
+    "profile_changes.capture_profile_state": "snapshot step of the change writer",
+    "profile_changes.record_profile_changes": "writes the change ledger",
+    "profile_access.ensure_app_user": "creates an app user row",
+    "profile_access.provision_app_user_identity": "writes identity onto an app user",
+    "profile_access.track_profile_by_id": "writes a tracking row",
+    "profile_access.track_or_request_profile": "writes a tracking row or a request",
+    "profile_access.untrack_profile": "deletes a tracking row",
+    "profile_access.decide_profile_request": "resolves a request",
+    "profile_access.fulfill_pending_requests": "resolves requests for a profile",
+    "profile_access.reopen_fulfilled_requests_for_profile": "reopens requests",
+    "profile_access.preserve_profile_tracking_requests": "rewrites request rows",
+    # --- read-only, but need a Clerk identity this sweep deliberately lacks ---
+    # Authorisation is what the authenticated canary proves, with a real
+    # session and a real account. Faking a ClerkUser here would test this
+    # script's idea of an identity rather than production's.
+    "profile_access.accessible_profiles": "needs a real Clerk identity; covered by the auth canary",
+    "profile_access.tracked_profiles": "needs a real Clerk identity; covered by the auth canary",
+    "profile_access.list_profile_catalog": "needs a real Clerk identity; covered by the auth canary",
+    "profile_access.authorize_profile_usernames": "authorisation path; covered by the auth canary",
+    "profile_access.require_profile_access": "authorisation path; covered by the auth canary",
+    "profile_access.list_profile_requests": "needs a real Clerk identity; covered by the auth canary",
+    # --- read-only infrastructure with no panel behind it ---
+    "rss_incremental.due_profiles": "scheduler input; RSS health is a canary check",
+    "operational_health.rss_operational_report": "already asserted by the public canary",
+    "profile_changes.get_recent_profile_changes": "swept through its own entry below",
+}
+
+# Latency ceilings, in seconds, measured on the real table. Generous on
+# purpose: this is a regression alarm, not a benchmark. The filmographies panel
+# once took twelve seconds in production while every test passed, which is the
+# failure this budget exists to catch a second time.
+DEFAULT_BUDGET_SECONDS = 4.0
+BUDGET_OVERRIDES: Dict[str, float] = {
+    # Genuinely heavy joins over the whole catalogue.
+    "films.build_filmographies": 8.0,
+    "films.build_atlas": 8.0,
+    "films.build_keywords": 8.0,
+    "tonight.build_availability": 8.0,
+    "people.build_pair_blind_spots": 8.0,
+}
+
+# Single-profile builders run once per profile, which at twenty profiles would
+# dominate the run. A sample is enough to prove the query executes and is
+# quick; the group builders already touch every profile's rows.
+SINGLE_PROFILE_SAMPLE = 3
+
+
+@dataclass
+class Result:
+    name: str
+    subject: str
+    seconds: float
+    size: Optional[int] = None
+    error: Optional[str] = None
+    over_budget: bool = False
+
+
+@dataclass
+class Sweep:
+    results: List[Result] = field(default_factory=list)
+    undeclared: List[str] = field(default_factory=list)
+    stale_exclusions: List[str] = field(default_factory=list)
+
+    @property
+    def failures(self) -> List[Result]:
+        return [r for r in self.results if r.error or r.over_budget]
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures and not self.undeclared and not self.stale_exclusions
+
+
+def discover_session_functions(package: Any) -> Dict[str, Callable[..., Any]]:
+    """Every public function in `services` whose first argument is a
+    database session.
+
+    Walked rather than listed: a builder that exists but is not swept is the
+    exact blind spot this script is for.
+    """
+
+    found: Dict[str, Callable[..., Any]] = {}
+    for module_info in pkgutil.iter_modules(package.__path__):
+        if module_info.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{package.__name__}.{module_info.name}")
+        for attribute_name, attribute in vars(module).items():
+            if attribute_name.startswith("_") or not inspect.isfunction(attribute):
+                continue
+            # Defined here, not imported from elsewhere -- otherwise a helper
+            # re-exported across modules is swept several times.
+            if attribute.__module__ != module.__name__:
+                continue
+            parameters = list(inspect.signature(attribute).parameters)
+            if parameters and parameters[0] in {"db", "session", "db_session"}:
+                found[f"{module_info.name}.{attribute_name}"] = attribute
+    return found
+
+
+def plan_call(
+    name: str,
+    function: Callable[..., Any],
+    profiles: Sequence[Any],
+) -> List[Tuple[str, Callable[[Any], Any]]]:
+    """How to call one builder, from the shape of its signature.
+
+    Deriving this from the signature rather than a table is what keeps a new
+    `build_x(db, profiles)` covered without anybody remembering to add it.
+    """
+
+    parameters = list(inspect.signature(function).parameters)
+    second = parameters[1] if len(parameters) > 1 else None
+
+    if second == "profiles":
+        return [("all profiles", lambda db: function(db, profiles))]
+    if second == "profile":
+        return [
+            (profile.username, (lambda p: lambda db: function(db, p))(profile))
+            for profile in profiles[:SINGLE_PROFILE_SAMPLE]
+        ]
+    if second == "pair" and len(profiles) >= 2:
+        pair = list(profiles[:2])
+        subject = " + ".join(profile.username for profile in pair)
+        return [(subject, lambda db: function(db, pair, profiles))]
+    return []
+
+
+def measure(result_size: Any) -> Optional[int]:
+    """A rough size signal, so a builder that starts returning nothing is
+    visible in the log even when it does not raise."""
+
+    if isinstance(result_size, dict):
+        for key in ("entries", "rows", "items", "films", "profiles", "people"):
+            value = result_size.get(key)
+            if isinstance(value, list):
+                return len(value)
+        return len(result_size)
+    if isinstance(result_size, list):
+        return len(result_size)
+    return None
+
+
+def make_read_only(db: Any) -> None:
+    """Ask Postgres to reject writes for this transaction.
+
+    Silently a no-op on any engine without the statement (SQLite), because the
+    exclusion list and the unconditional rollback are the guarantees that hold
+    everywhere; this is the extra one that holds where it counts.
+    """
+
+    from sqlalchemy import text
+
+    dialect = getattr(getattr(db, "bind", None), "dialect", None)
+    if getattr(dialect, "name", None) != "postgresql":
+        return
+    db.execute(text("SET TRANSACTION READ ONLY"))
+
+
+def run_sweep(session_factory: Callable[[], Any], profile_loader: Callable[[Any], List[Any]]) -> Sweep:
+    import services as services_package
+
+    sweep = Sweep()
+    discovered = discover_session_functions(services_package)
+
+    db = session_factory()
+    try:
+        # Belt and braces over the exclusion list: in a read-only transaction a
+        # stray write raises instead of landing on production data. Postgres
+        # only -- SQLite has no such statement, and the sweep's real run is
+        # against Postgres, so a local SQLite run leans on the exclusion list
+        # and the rollback alone.
+        make_read_only(db)
+        profiles = profile_loader(db)
+        if len(profiles) < 2:
+            raise SystemExit(
+                f"the sweep needs at least two completed profiles, found {len(profiles)}"
+            )
+
+        for name in sorted(discovered):
+            function = discovered[name]
+            if name in EXCLUDED:
+                continue
+            if not name.split(".", 1)[1].startswith("build_"):
+                sweep.undeclared.append(name)
+                continue
+            calls = plan_call(name, function, profiles)
+            if not calls:
+                sweep.undeclared.append(name)
+                continue
+            budget = BUDGET_OVERRIDES.get(name, DEFAULT_BUDGET_SECONDS)
+            for subject, call in calls:
+                started = time.monotonic()
+                try:
+                    payload = call(db)
+                except Exception:  # noqa: BLE001 - the point is to report any failure
+                    elapsed = time.monotonic() - started
+                    sweep.results.append(
+                        Result(name, subject, elapsed, error=traceback.format_exc(limit=6))
+                    )
+                    # A failed builder can leave the transaction unusable.
+                    db.rollback()
+                    make_read_only(db)
+                    continue
+                elapsed = time.monotonic() - started
+                sweep.results.append(
+                    Result(
+                        name,
+                        subject,
+                        elapsed,
+                        size=measure(payload),
+                        over_budget=elapsed > budget,
+                    )
+                )
+    finally:
+        db.rollback()
+        db.close()
+
+    # An exclusion naming a function that no longer exists is a stale promise,
+    # and hides the next function that takes its name.
+    sweep.stale_exclusions = sorted(set(EXCLUDED) - set(discovered))
+    return sweep
+
+
+def load_completed_profiles(db: Any) -> List[Any]:
+    from database.models import Profile
+
+    return (
+        db.query(Profile)
+        .filter(Profile.scraping_status == "completed")
+        .order_by(Profile.username)
+        .all()
+    )
+
+
+def report(sweep: Sweep, *, as_json: bool) -> None:
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "ok": sweep.ok,
+                    "checked": len(sweep.results),
+                    "undeclared": sweep.undeclared,
+                    "stale_exclusions": sweep.stale_exclusions,
+                    "failures": [
+                        {
+                            "builder": r.name,
+                            "subject": r.subject,
+                            "seconds": round(r.seconds, 3),
+                            "error": r.error,
+                            "over_budget": r.over_budget,
+                        }
+                        for r in sweep.failures
+                    ],
+                    "slowest": [
+                        {"builder": r.name, "subject": r.subject, "seconds": round(r.seconds, 3)}
+                        for r in sorted(sweep.results, key=lambda r: -r.seconds)[:10]
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"panel sweep: {len(sweep.results)} builder calls against production data")
+    for result in sorted(sweep.results, key=lambda r: -r.seconds)[:10]:
+        size = "-" if result.size is None else str(result.size)
+        print(f"  {result.seconds:6.2f}s  {size:>6}  {result.name} [{result.subject}]")
+
+    for name in sweep.undeclared:
+        print(f"UNDECLARED: {name} reaches the database and is neither swept nor excluded", file=sys.stderr)
+    for name in sweep.stale_exclusions:
+        print(f"STALE EXCLUSION: {name} no longer exists", file=sys.stderr)
+    for result in sweep.failures:
+        if result.error:
+            print(f"FAILED: {result.name} [{result.subject}]\n{result.error}", file=sys.stderr)
+        else:
+            budget = BUDGET_OVERRIDES.get(result.name, DEFAULT_BUDGET_SECONDS)
+            print(
+                f"SLOW: {result.name} [{result.subject}] took {result.seconds:.2f}s, budget {budget:.1f}s",
+                file=sys.stderr,
+            )
+
+
+def read_database_url(env_file: str) -> str:
+    """Take only DATABASE_URL out of the API's environment file.
+
+    Parsed here rather than in the calling shell for two reasons: the sweep
+    needs one value out of a file full of production secrets, and sourcing the
+    file would hand it all of them; and a `sed` inside a heredoc inside YAML is
+    three quoting layers deep, which is where the last one of these went wrong.
+
+    A value may be quoted, may be `export`ed, and may itself contain '=' -- a
+    password routinely does -- so it is split once and unwrapped, not matched.
+    """
+
+    from pathlib import Path
+
+    url: Optional[str] = None
+    for raw_line in Path(env_file).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "DATABASE_URL":
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+                value = value[1:-1]
+            url = value
+    if not url:
+        raise SystemExit(f"{env_file} has no DATABASE_URL")
+    return url
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    parser.add_argument(
+        "--application-root",
+        default=os.getenv("SPYBOXD_APPLICATION_ROOT", "/opt/spyboxd/current/backend"),
+        help="the API's own import root -- the same PYTHONPATH the service unit uses,\n"
+        "so the sweep imports exactly what production runs",
+    )
+    parser.add_argument(
+        "--database-env-file",
+        default=os.getenv("SPYBOXD_DATABASE_ENV_FILE"),
+        help="file holding DATABASE_URL; only that one value is read from it",
+    )
+    arguments = parser.parse_args()
+
+    if arguments.application_root not in sys.path:
+        sys.path.insert(0, arguments.application_root)
+    if arguments.database_env_file:
+        os.environ["DATABASE_URL"] = read_database_url(arguments.database_env_file)
+
+    from database.connection import SessionLocal
+
+    sweep = run_sweep(SessionLocal, load_completed_profiles)
+    report(sweep, as_json=arguments.json)
+    return 0 if sweep.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/summarize_panel_sweep.py
+++ b/deploy/summarize_panel_sweep.py
@@ -1,0 +1,76 @@
+"""Render a panel sweep report as a GitHub step summary.
+
+Separate from the workflow because a Python heredoc nested inside a shell
+heredoc inside YAML is three quoting layers deep and silently wrong in at
+least one of them.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def render(report: Dict[str, Any]) -> List[str]:
+    lines = ["### Panel sweep against production data", ""]
+    lines.append(f"- Builder calls: **{report.get('checked', 0)}**")
+    lines.append(
+        f"- Result: **{'every builder answered' if report.get('ok') else 'FAILURES'}**"
+    )
+    for label, key in (
+        ("Reaches the database but unclassified", "undeclared"),
+        ("Exclusions naming functions that no longer exist", "stale_exclusions"),
+    ):
+        if report.get(key):
+            lines.append(f"- {label}: {', '.join(report[key])}")
+
+    failures = report.get("failures") or []
+    if failures:
+        lines += ["", "| Builder | Subject | Seconds | Problem |", "| --- | --- | --- | --- |"]
+        for failure in failures:
+            problem = "over budget" if failure.get("over_budget") else "raised"
+            lines.append(
+                f"| `{failure['builder']}` | {failure['subject']} "
+                f"| {failure['seconds']} | {problem} |"
+            )
+
+    slowest = report.get("slowest") or []
+    if slowest:
+        lines += [
+            "",
+            "<details><summary>Slowest ten</summary>",
+            "",
+            "| Builder | Subject | Seconds |",
+            "| --- | --- | --- |",
+        ]
+        lines += [
+            f"| `{row['builder']}` | {row['subject']} | {row['seconds']} |" for row in slowest
+        ]
+        lines += ["", "</details>"]
+    return lines
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: summarize_panel_sweep.py <report.json>", file=sys.stderr)
+        return 64
+
+    path = Path(sys.argv[1])
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        # An unreadable report means the sweep died before writing one. Saying
+        # so beats an empty summary that reads like a pass.
+        print("### Panel sweep against production data")
+        print()
+        print("The sweep produced no readable report; see the step log.")
+        return 0
+
+    print("\n".join(render(report)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/test_panel_sweep.py
+++ b/deploy/test_panel_sweep.py
@@ -1,0 +1,268 @@
+"""What the panel sweep is allowed to claim, and what it must refuse to.
+
+A checker that quietly skips things is worse than no checker: it reports a
+clean run over a shrinking surface. Most of these tests are about that failure
+mode rather than about the happy path.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _load_sweep():
+    path = Path(__file__).resolve().parent / "panel_sweep.py"
+    spec = importlib.util.spec_from_file_location("panel_sweep", path)
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution: dataclasses resolve annotations through
+    # sys.modules and fail on a module that is not there yet.
+    sys.modules["panel_sweep"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep_module = _load_sweep()
+
+
+class FakeProfile:
+    def __init__(self, username: str, identifier: int):
+        self.username = username
+        self.id = identifier
+
+
+class FakeSession:
+    """Records rollbacks, and refuses to be committed."""
+
+    def __init__(self):
+        self.rollbacks = 0
+        self.closed = False
+        self.bind = types.SimpleNamespace(dialect=types.SimpleNamespace(name="sqlite"))
+
+    def execute(self, *_args, **_kwargs):
+        raise AssertionError("a sqlite session must not be asked to SET TRANSACTION")
+
+    def commit(self):
+        raise AssertionError("the sweep must never commit")
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def _package(**functions) -> types.ModuleType:
+    """A stand-in services package holding one module of the given functions."""
+
+    package = types.ModuleType("fake_services")
+    package.__path__ = []
+    module = types.ModuleType("fake_services.panels")
+    for name, function in functions.items():
+        function.__module__ = "fake_services.panels"
+        setattr(module, name, function)
+    sys.modules["fake_services"] = package
+    sys.modules["fake_services.panels"] = module
+    package.panels = module
+    return package
+
+
+def _run(monkeypatch, package, excluded=None, profiles=None):
+    monkeypatch.setattr(sweep_module, "EXCLUDED", excluded or {})
+    monkeypatch.setitem(sys.modules, "services", package)
+    session = FakeSession()
+    monkeypatch.setattr(
+        sweep_module,
+        "discover_session_functions",
+        lambda _p: sweep_module.discover_session_functions.__wrapped__(package)
+        if hasattr(sweep_module.discover_session_functions, "__wrapped__")
+        else _discover(package),
+    )
+    people = profiles if profiles is not None else [FakeProfile("alpha", 1), FakeProfile("beta", 2)]
+    result = sweep_module.run_sweep(lambda: session, lambda _db: people)
+    return result, session
+
+
+def _discover(package):
+    found = {}
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith(f"{package.__name__}."):
+            continue
+        short = module_name.split(".", 1)[1]
+        for attribute_name, attribute in vars(module).items():
+            if attribute_name.startswith("_") or not callable(attribute):
+                continue
+            if getattr(attribute, "__module__", None) != module_name:
+                continue
+            parameters = list(__import__("inspect").signature(attribute).parameters)
+            if parameters and parameters[0] in {"db", "session", "db_session"}:
+                found[f"{short}.{attribute_name}"] = attribute
+    return found
+
+
+def test_a_builder_that_raises_is_reported_rather_than_swallowed(monkeypatch) -> None:
+    def build_broken(db, profiles):
+        raise RuntimeError("column does not exist")
+
+    result, _ = _run(monkeypatch, _package(build_broken=build_broken))
+
+    assert not result.ok
+    assert len(result.failures) == 1
+    assert "column does not exist" in result.failures[0].error
+
+
+def test_a_builder_that_reaches_the_database_unswept_fails_the_run(monkeypatch) -> None:
+    """The whole point: silence must never be mistaken for coverage.
+
+    A new function that touches the database and is neither a `build_` nor a
+    named exclusion has to be classified before this passes.
+    """
+
+    def helper_touching_the_database(db, something):
+        return {}
+
+    result, _ = _run(monkeypatch, _package(helper_touching_the_database=helper_touching_the_database))
+
+    assert not result.ok
+    assert result.undeclared == ["panels.helper_touching_the_database"]
+
+
+def test_an_exclusion_for_a_function_that_no_longer_exists_fails_the_run(monkeypatch) -> None:
+    """A stale exclusion is a promise about code that is gone, and it would
+    silently absorb the next function to take that name."""
+
+    def build_present(db, profiles):
+        return {}
+
+    result, _ = _run(
+        monkeypatch,
+        _package(build_present=build_present),
+        excluded={"panels.removed_last_year": "reason that outlived its function"},
+    )
+
+    assert not result.ok
+    assert result.stale_exclusions == ["panels.removed_last_year"]
+
+
+def test_a_slow_builder_fails_even_though_it_returned(monkeypatch) -> None:
+    """The twelve-second panel returned correct data. Correct and unusable is
+    still a defect, so latency is a failure and not a note."""
+
+    def build_slow(db, profiles):
+        return {}
+
+    monkeypatch.setattr(sweep_module, "DEFAULT_BUDGET_SECONDS", -1.0)
+    monkeypatch.setattr(sweep_module, "BUDGET_OVERRIDES", {})
+    result, _ = _run(monkeypatch, _package(build_slow=build_slow))
+
+    assert not result.ok
+    assert result.failures[0].over_budget is True
+    assert result.failures[0].error is None
+
+
+def test_the_session_is_rolled_back_and_closed_even_when_a_builder_explodes(monkeypatch) -> None:
+    def build_broken(db, profiles):
+        raise RuntimeError("boom")
+
+    _, session = _run(monkeypatch, _package(build_broken=build_broken))
+
+    assert session.rollbacks >= 1
+    assert session.closed is True
+
+
+def test_a_single_profile_instance_is_refused_rather_than_half_swept(monkeypatch) -> None:
+    """Pair builders need two profiles. Running with one would report a pass
+    over a surface that was never exercised."""
+
+    def build_anything(db, profiles):
+        return {}
+
+    with pytest.raises(SystemExit, match="at least two completed profiles"):
+        _run(monkeypatch, _package(build_anything=build_anything), profiles=[FakeProfile("solo", 1)])
+
+
+def test_single_profile_builders_are_sampled_not_skipped(monkeypatch) -> None:
+    seen = []
+
+    def build_per_person(db, profile):
+        seen.append(profile.username)
+        return {}
+
+    monkeypatch.setattr(sweep_module, "SINGLE_PROFILE_SAMPLE", 2)
+    people = [FakeProfile(name, index) for index, name in enumerate("abcde", start=1)]
+    result, _ = _run(monkeypatch, _package(build_per_person=build_per_person), profiles=people)
+
+    assert result.ok
+    assert seen == ["a", "b"]
+
+
+def test_the_real_service_package_has_no_undeclared_database_functions() -> None:
+    """The exclusion list is checked against the actual codebase here, so the
+    sweep cannot first discover a gap on production."""
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
+    import services  # noqa: PLC0415 - deliberately imported the way production does
+
+    discovered = sweep_module.discover_session_functions(services)
+    undeclared = [
+        name
+        for name in discovered
+        if name not in sweep_module.EXCLUDED and not name.split(".", 1)[1].startswith("build_")
+    ]
+    stale = sorted(set(sweep_module.EXCLUDED) - set(discovered))
+
+    assert undeclared == [], f"these reach the database and are unclassified: {undeclared}"
+    assert stale == [], f"these exclusions name functions that no longer exist: {stale}"
+
+
+def test_only_the_database_url_is_taken_from_the_api_environment(tmp_path) -> None:
+    """api.env holds every production secret. A read-only checker has business
+    with exactly one line of it."""
+
+    env_file = tmp_path / "api.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "CLERK_SECRET_KEY=sk_live_do_not_read_me",
+                "export DATABASE_URL=\"postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd\"",
+                "TMDB_API_KEY='another secret'",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    url = sweep_module.read_database_url(str(env_file))
+
+    # Split once: a password routinely contains '=' and '@'.
+    assert url == "postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd"
+
+
+def test_an_environment_file_without_a_database_url_stops_rather_than_guesses(tmp_path) -> None:
+    env_file = tmp_path / "api.env"
+    env_file.write_text("CLERK_SECRET_KEY=sk_live\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="has no DATABASE_URL"):
+        sweep_module.read_database_url(str(env_file))
+
+
+def test_every_swept_builder_has_a_call_plan() -> None:
+    """A builder whose signature the planner does not recognise would be
+    counted as covered while never being called."""
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
+    import services  # noqa: PLC0415
+
+    discovered = sweep_module.discover_session_functions(services)
+    people = [FakeProfile("alpha", 1), FakeProfile("beta", 2)]
+    unplanned = [
+        name
+        for name, function in discovered.items()
+        if name not in sweep_module.EXCLUDED
+        and name.split(".", 1)[1].startswith("build_")
+        and not sweep_module.plan_call(name, function, people)
+    ]
+
+    assert unplanned == [], f"no call plan for: {unplanned}"

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -355,7 +355,43 @@ class FailureAlertTests(unittest.TestCase):
         ".github/workflows/tmdb-enrichment.yml",
         ".github/workflows/postgres-restore-drill.yml",
         ".github/workflows/canary-reset.yml",
+        ".github/workflows/panel-sweep.yml",
     )
+
+    # Touches production but deliberately does not file an issue, with the
+    # reason. An unlisted production workflow fails the enumeration test below,
+    # so this stays a decision rather than an omission.
+    UNGUARDED = {
+        ".github/workflows/rollback.yml": (
+            "manual dispatch only; a rollback has a person watching it, and an "
+            "issue filed behind their back would arrive after they already knew"
+        ),
+    }
+
+    def test_no_production_workflow_escapes_this_list(self) -> None:
+        """The list above used to be hand-maintained, which is how a new
+        production workflow gets written with no alerting and nothing says so.
+
+        Every workflow that claims the production environment must be either
+        guarded or explicitly excused.
+        """
+
+        production = {
+            f".github/workflows/{path.name}"
+            for path in sorted(ROOT.glob(".github/workflows/*.yml"))
+            if "name: production" in path.read_text(encoding="utf-8")
+        }
+        classified = set(self.GUARDED) | set(self.UNGUARDED)
+        self.assertEqual(
+            production - classified,
+            set(),
+            "these reach production and are neither guarded nor excused",
+        )
+        self.assertEqual(
+            classified - production,
+            set(),
+            "these are classified but no longer reach production",
+        )
 
     def test_every_workflow_that_guards_production_reports_its_own_failure(self) -> None:
         for relative_path in self.GUARDED:


### PR DESCRIPTION
## The gap

Four layers run today. None answers **"do the panels work against the real data"**:

| Layer | Runs the builders against |
|---|---|
| pytest | SQLite, fixtures |
| Playwright (310) | **mocked** API responses |
| Public canary | health, dashboard, RSS, redirects, privacy |
| Auth canary | identity and cross-profile isolation |

Every defect this project has actually shipped to production lived in that gap — Postgres-only SQL, a query instant on a fixture and 12s on the real table, a column whose real size took the API down. All four were found **by hand, after the fact**.

## The check

`deploy/panel_sweep.py` runs on the VPS in the API's own venv, importing exactly what the service unit imports, and calls all **49 panel builders** against real production data. It fails on an exception, on a latency budget, or on a builder it was never told about.

Read-only three ways over: a `READ ONLY` transaction, a `build_`-only call rule with all 25 other db-touching functions named and reasoned, and an unconditional rollback that never commits.

**Coverage is walked, not written down.** A new panel builder is swept the day it exists; a new writer has to be classified before this passes. `test_the_real_service_package_has_no_undeclared_database_functions` runs in CI, so a gap fails a PR rather than being discovered against production.

## Two things the same principle turned up

- The alerting list in `test_workflow_controls.py` was hand-maintained — a new production workflow could ship with no alerting and nothing would say so. Now enumerated from `name: production`.
- `rollback.yml` files no alert. It is dispatch-only so a person is already watching; now an explicit exemption with its reason rather than a silence.

## Verification

- `deploy/test_panel_sweep.py` — 11 passed (including: a broken builder is reported, an unswept one fails the run, a stale exclusion fails the run, a slow-but-correct builder fails)
- `deploy/test_workflow_controls.py` — 25 passed
- backend suite — 728 passed
- zizmor on the new workflow — no findings
- every shell block `bash -n` clean

## After merge

Off until switched on, like the restore drill:

```
gh variable set PRODUCTION_PANEL_SWEEP_ENABLED --body true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)