### PR TITLE
Give the sweep's pre-flight the stack its own checks need

### DIFF
--- a/.github/workflows/panel-sweep.yml
+++ b/.github/workflows/panel-sweep.yml
@@ -58,10 +58,16 @@ jobs:
       # Runs before any credential is loaded, and includes the check that no
       # database-touching function is unclassified -- so a coverage gap is
       # caught here rather than discovered against production.
+      #
+      # The locked requirements are installed because two of these assertions
+      # import the real `services` package. Skipping them without the stack
+      # would turn the completeness check into a no-op on the one run where it
+      # is about to matter.
       - name: Test the sweep's own safety and completeness rules
         run: |
           set -Eeuo pipefail
-          python3 -m pip install --quiet --disable-pip-version-check pytest
+          python3 -m pip install --quiet --disable-pip-version-check \
+            -r requirements.lock pytest
           python3 -m pytest -q deploy/test_panel_sweep.py
 
       - name: Establish one pinned IPv4 production SSH connection

--- a/deploy/panel_sweep.py
+++ b/deploy/panel_sweep.py
@@ -210,11 +210,15 @@ def make_read_only(db: Any) -> None:
     everywhere; this is the extra one that holds where it counts.
     """
 
-    from sqlalchemy import text
-
     dialect = getattr(getattr(db, "bind", None), "dialect", None)
     if getattr(dialect, "name", None) != "postgresql":
         return
+
+    # Imported after the check, not before it: on the path where this function
+    # does nothing it should also need nothing, so the safety tests can run
+    # anywhere without the database stack installed.
+    from sqlalchemy import text
+
     db.execute(text("SET TRANSACTION READ ONLY"))
 
 

--- a/deploy/test_panel_sweep.py
+++ b/deploy/test_panel_sweep.py
@@ -218,6 +218,30 @@ def test_the_real_service_package_has_no_undeclared_database_functions() -> None
     assert stale == [], f"these exclusions name functions that no longer exist: {stale}"
 
 
+def test_postgres_is_asked_for_a_read_only_transaction_and_sqlite_is_not() -> None:
+    """The guard that stops a stray write from landing on production.
+
+    Asserted in both directions: a missing statement on Postgres is a silent
+    loss of the protection, and issuing it on SQLite is an error.
+    """
+
+    class Recorder:
+        def __init__(self, dialect_name: str):
+            self.bind = types.SimpleNamespace(dialect=types.SimpleNamespace(name=dialect_name))
+            self.statements = []
+
+        def execute(self, statement):
+            self.statements.append(str(statement))
+
+    postgres = Recorder("postgresql")
+    sweep_module.make_read_only(postgres)
+    assert postgres.statements == ["SET TRANSACTION READ ONLY"]
+
+    sqlite = Recorder("sqlite")
+    sweep_module.make_read_only(sqlite)
+    assert sqlite.statements == []
+
+
 def test_only_the_database_url_is_taken_from_the_api_environment(tmp_path) -> None:
     """api.env holds every production secret. A read-only checker has business
     with exactly one line of it."""


### PR DESCRIPTION
The first production run of #167 failed **before reaching production**.

The pre-flight step installed `pytest` alone, but two of its assertions import the real `services` package to prove no database-touching function is unswept. Without the stack they error rather than check — the completeness guarantee failing on exactly the run where it was about to matter.

Now installs `requirements.lock`, so every assertion runs for real before any credential is loaded.

Also moved `sqlalchemy`'s import below the dialect check in `make_read_only`: a function whose whole job on that branch is to do nothing shouldn't need the database stack to decide that. New test pins both directions — Postgres is asked for a read-only transaction, SQLite is not.

12/12 `deploy/test_panel_sweep.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)