### PR TITLE
Report how many rows each builder sat on, and sample the biggest

### DIFF
--- a/deploy/panel_sweep.py
+++ b/deploy/panel_sweep.py
@@ -114,6 +114,10 @@ class Result:
     subject: str
     seconds: float
     size: Optional[int] = None
+    # How many library rows sat underneath this call. A latency number cannot
+    # be read without it: 7s over 4,000 films and 7s over 200 are different
+    # defects, and only one of them is about the query.
+    scale: Optional[int] = None
     error: Optional[str] = None
     over_budget: bool = False
 
@@ -174,17 +178,49 @@ def plan_call(
     second = parameters[1] if len(parameters) > 1 else None
 
     if second == "profiles":
-        return [("all profiles", lambda db: function(db, profiles))]
+        return [("all profiles", lambda db: function(db, profiles), None)]
     if second == "profile":
+        # Largest first: a builder that is fine on a small library and slow on
+        # a big one is the failure worth finding, and sampling the alphabet
+        # would have missed it.
+        sampled = sorted(profiles, key=_library_size_key, reverse=True)[:SINGLE_PROFILE_SAMPLE]
         return [
-            (profile.username, (lambda p: lambda db: function(db, p))(profile))
-            for profile in profiles[:SINGLE_PROFILE_SAMPLE]
+            (
+                profile.username,
+                (lambda p: lambda db: function(db, p))(profile),
+                _library_size(profile),
+            )
+            for profile in sampled
         ]
     if second == "pair" and len(profiles) >= 2:
-        pair = list(profiles[:2])
+        pair = sorted(profiles, key=_library_size_key, reverse=True)[:2]
         subject = " + ".join(profile.username for profile in pair)
-        return [(subject, lambda db: function(db, pair, profiles))]
+        return [
+            (
+                subject,
+                lambda db: function(db, pair, profiles),
+                sum(_library_size(profile) or 0 for profile in pair) or None,
+            )
+        ]
     return []
+
+
+def _library_size(profile: Any) -> Optional[int]:
+    """Rows behind a profile, as stamped on it by the loader."""
+
+    size = getattr(profile, "_sweep_library_size", None)
+    return size if isinstance(size, int) else None
+
+
+def _library_size_key(profile: Any) -> int:
+    """Sort key: an unstamped profile sorts last rather than raising.
+
+    None is a legitimate answer here -- a caller may not have stamped sizes --
+    and comparing it would turn a missing measurement into a crash.
+    """
+
+    size = _library_size(profile)
+    return size if size is not None else -1
 
 
 def measure(result_size: Any) -> Optional[int]:
@@ -254,14 +290,20 @@ def run_sweep(session_factory: Callable[[], Any], profile_loader: Callable[[Any]
                 sweep.undeclared.append(name)
                 continue
             budget = BUDGET_OVERRIDES.get(name, DEFAULT_BUDGET_SECONDS)
-            for subject, call in calls:
+            for subject, call, scale in calls:
                 started = time.monotonic()
                 try:
                     payload = call(db)
                 except Exception:  # noqa: BLE001 - the point is to report any failure
                     elapsed = time.monotonic() - started
                     sweep.results.append(
-                        Result(name, subject, elapsed, error=traceback.format_exc(limit=6))
+                        Result(
+                            name,
+                            subject,
+                            elapsed,
+                            scale=scale,
+                            error=traceback.format_exc(limit=6),
+                        )
                     )
                     # A failed builder can leave the transaction unusable.
                     db.rollback()
@@ -274,6 +316,7 @@ def run_sweep(session_factory: Callable[[], Any], profile_loader: Callable[[Any]
                         subject,
                         elapsed,
                         size=measure(payload),
+                        scale=scale,
                         over_budget=elapsed > budget,
                     )
                 )
@@ -288,14 +331,28 @@ def run_sweep(session_factory: Callable[[], Any], profile_loader: Callable[[Any]
 
 
 def load_completed_profiles(db: Any) -> List[Any]:
-    from database.models import Profile
+    from sqlalchemy import func
 
-    return (
+    from database.models import Profile, ProfileFilm
+
+    profiles = (
         db.query(Profile)
         .filter(Profile.scraping_status == "completed")
         .order_by(Profile.username)
         .all()
     )
+
+    # One aggregate for the whole set, so every latency in the report can be
+    # read against the number of rows it was working over.
+    sizes = dict(
+        db.query(ProfileFilm.profile_id, func.count(ProfileFilm.id))
+        .filter(ProfileFilm.removed_at.is_(None))
+        .group_by(ProfileFilm.profile_id)
+        .all()
+    )
+    for profile in profiles:
+        profile._sweep_library_size = int(sizes.get(profile.id, 0))
+    return profiles
 
 
 def report(sweep: Sweep, *, as_json: bool) -> None:
@@ -312,13 +369,21 @@ def report(sweep: Sweep, *, as_json: bool) -> None:
                             "builder": r.name,
                             "subject": r.subject,
                             "seconds": round(r.seconds, 3),
+                            "rows": r.scale,
                             "error": r.error,
                             "over_budget": r.over_budget,
                         }
                         for r in sweep.failures
                     ],
+                    # `rows` is what separates "slow per row" from "a lot of
+                    # rows" -- without it a latency number cannot be read.
                     "slowest": [
-                        {"builder": r.name, "subject": r.subject, "seconds": round(r.seconds, 3)}
+                        {
+                            "builder": r.name,
+                            "subject": r.subject,
+                            "seconds": round(r.seconds, 3),
+                            "rows": r.scale,
+                        }
                         for r in sorted(sweep.results, key=lambda r: -r.seconds)[:10]
                     ],
                 },
@@ -329,8 +394,8 @@ def report(sweep: Sweep, *, as_json: bool) -> None:
 
     print(f"panel sweep: {len(sweep.results)} builder calls against production data")
     for result in sorted(sweep.results, key=lambda r: -r.seconds)[:10]:
-        size = "-" if result.size is None else str(result.size)
-        print(f"  {result.seconds:6.2f}s  {size:>6}  {result.name} [{result.subject}]")
+        rows = "-" if result.scale is None else str(result.scale)
+        print(f"  {result.seconds:6.2f}s  over {rows:>6} rows  {result.name} [{result.subject}]")
 
     for name in sweep.undeclared:
         print(f"UNDECLARED: {name} reaches the database and is neither swept nor excluded", file=sys.stderr)

--- a/deploy/summarize_panel_sweep.py
+++ b/deploy/summarize_panel_sweep.py
@@ -28,12 +28,17 @@ def render(report: Dict[str, Any]) -> List[str]:
 
     failures = report.get("failures") or []
     if failures:
-        lines += ["", "| Builder | Subject | Seconds | Problem |", "| --- | --- | --- | --- |"]
+        lines += [
+            "",
+            "| Builder | Subject | Seconds | Rows | Problem |",
+            "| --- | --- | --- | --- | --- |",
+        ]
         for failure in failures:
             problem = "over budget" if failure.get("over_budget") else "raised"
+            rows = failure.get("rows")
             lines.append(
                 f"| `{failure['builder']}` | {failure['subject']} "
-                f"| {failure['seconds']} | {problem} |"
+                f"| {failure['seconds']} | {rows if rows is not None else '-'} | {problem} |"
             )
 
     slowest = report.get("slowest") or []
@@ -42,11 +47,13 @@ def render(report: Dict[str, Any]) -> List[str]:
             "",
             "<details><summary>Slowest ten</summary>",
             "",
-            "| Builder | Subject | Seconds |",
-            "| --- | --- | --- |",
+            "| Builder | Subject | Seconds | Rows |",
+            "| --- | --- | --- | --- |",
         ]
         lines += [
-            f"| `{row['builder']}` | {row['subject']} | {row['seconds']} |" for row in slowest
+            f"| `{row['builder']}` | {row['subject']} | {row['seconds']} "
+            f"| {row.get('rows') if row.get('rows') is not None else '-'} |"
+            for row in slowest
         ]
         lines += ["", "</details>"]
     return lines

--- a/deploy/test_panel_sweep.py
+++ b/deploy/test_panel_sweep.py
@@ -51,9 +51,11 @@ sweep_module = _load_sweep()
 
 
 class FakeProfile:
-    def __init__(self, username: str, identifier: int):
+    def __init__(self, username: str, identifier: int, library_size: int | None = None):
         self.username = username
         self.id = identifier
+        if library_size is not None:
+            self._sweep_library_size = library_size
 
 
 class FakeSession:
@@ -206,7 +208,14 @@ def test_a_single_profile_instance_is_refused_rather_than_half_swept(monkeypatch
         _run(monkeypatch, _package(build_anything=build_anything), profiles=[FakeProfile("solo", 1)])
 
 
-def test_single_profile_builders_are_sampled_not_skipped(monkeypatch) -> None:
+def test_single_profile_builders_sample_the_largest_libraries(monkeypatch) -> None:
+    """Sampling by name would have missed this class of defect entirely.
+
+    The first real finding was a builder that ran in about a second on two
+    profiles and took seven on the biggest one. A sample that ignores size
+    reports a pass on exactly the libraries where nothing goes wrong.
+    """
+
     seen = []
 
     def build_per_person(db, profile):
@@ -214,11 +223,31 @@ def test_single_profile_builders_are_sampled_not_skipped(monkeypatch) -> None:
         return {}
 
     monkeypatch.setattr(sweep_module, "SINGLE_PROFILE_SAMPLE", 2)
-    people = [FakeProfile(name, index) for index, name in enumerate("abcde", start=1)]
+    people = [
+        FakeProfile("small", 1, library_size=90),
+        FakeProfile("biggest", 2, library_size=4200),
+        FakeProfile("middling", 3, library_size=700),
+    ]
     result, _ = _run(monkeypatch, _package(build_per_person=build_per_person), profiles=people)
 
     assert result.ok
-    assert seen == ["a", "b"]
+    assert seen == ["biggest", "middling"]
+    # And the row count travels with the result, so a latency can be read.
+    assert {r.subject: r.scale for r in result.results} == {"biggest": 4200, "middling": 700}
+
+
+def test_an_unstamped_profile_sorts_last_rather_than_crashing(monkeypatch) -> None:
+    """A caller that did not measure library sizes still gets a sweep."""
+
+    def build_per_person(db, profile):
+        return {}
+
+    monkeypatch.setattr(sweep_module, "SINGLE_PROFILE_SAMPLE", 3)
+    people = [FakeProfile("unmeasured", 1), FakeProfile("measured", 2, library_size=10)]
+    result, _ = _run(monkeypatch, _package(build_per_person=build_per_person), profiles=people)
+
+    assert result.ok
+    assert [r.subject for r in result.results] == ["measured", "unmeasured"]
 
 
 def test_the_real_service_package_has_no_undeclared_database_functions() -> None:


### PR DESCRIPTION
The first real finding from #167 was `profile_stats.build_profile_stats` at **7.34s** against a 4s budget. The report gave no way to read that — 7s over 4,000 films and 7s over 200 are different defects, and only one is about the query.

Every result now carries the library size underneath it, from a single aggregate taken alongside the profile list.

**The sampling changed with it.** Single-profile builders were sampled alphabetically — which is exactly how a builder that is fine on a small library and slow on a big one reports a pass. The sample is now the largest libraries, where this class of defect lives.

13/13 `deploy/test_panel_sweep.py`, including a test that pins largest-first and one that pins an unstamped profile sorting last rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)