### PR TITLE
Let the backfill preflight run where there is no database

### DIFF
--- a/.github/workflows/credits-summary-backfill.yml
+++ b/.github/workflows/credits-summary-backfill.yml
@@ -66,6 +66,14 @@ jobs:
       # thing about to rewrite every row still agrees with the thing that
       # writes new ones -- before any credential is loaded.
       - name: Prove the summary still matches the document it replaces
+        env:
+          # Importing the services package resolves DATABASE_URL at import
+          # time. These tests compare two in-memory dictionaries and never open
+          # a connection, and SQLAlchemy builds its engine lazily, so a
+          # placeholder is enough -- and pointing it at a closed port means a
+          # test that did try to connect would fail loudly rather than reach
+          # anything real.
+          DATABASE_URL: postgresql+psycopg://unused:unused@127.0.0.1:1/never_connected
         run: |
           set -Eeuo pipefail
           python3 -m pip install --quiet --disable-pip-version-check \


### PR DESCRIPTION
Importing the services package resolves `DATABASE_URL` at import time, so the equivalence tests passed in CI — where a Postgres service sets it — and failed on the backfill runner, where nothing does.

They compare two in-memory dictionaries and never open a connection. The placeholder points at a **closed port**, so a test that did try to connect fails loudly rather than reaching anything real.

Third time this shape has bitten: a script that imports the application to inspect it inherits the application's need for a database.

Verified with `DATABASE_URL` pointed at the closed port: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)