### PR TITLE
Do not send an empty argument over ssh

### DIFF
--- a/.github/workflows/credits-summary-backfill.yml
+++ b/.github/workflows/credits-summary-backfill.yml
@@ -46,8 +46,12 @@ jobs:
       url: https://spyboxd.com
     env:
       BACKFILL_SCRIPT_SHA: ${{ github.sha }}
-      BACKFILL_LIMIT: ${{ inputs.limit }}
-      BACKFILL_DRY_RUN: ${{ inputs.dry_run }}
+      # 0 means "everything remaining", never the empty string: arguments are
+      # re-split by the remote shell, so an empty one disappears and shifts
+      # every argument after it. `set -eu` caught that as "3: parameter not
+      # set" rather than silently running with the wrong flags.
+      BACKFILL_LIMIT: ${{ inputs.limit || '0' }}
+      BACKFILL_DRY_RUN: ${{ inputs.dry_run || 'false' }}
 
     steps:
       - name: Monitor runner file and network activity
@@ -91,7 +95,8 @@ jobs:
         run: |
           set -Eeuo pipefail
           [[ "${BACKFILL_SCRIPT_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${BACKFILL_LIMIT}" =~ ^[0-9]*$ ]]
+          # Non-empty by construction, for the reason given above.
+          [[ "${BACKFILL_LIMIT}" =~ ^[0-9]+$ ]]
           [[ "${BACKFILL_DRY_RUN}" =~ ^(true|false)$ ]]
           timeout --signal=TERM --kill-after=2m 40m \
             deploy/production-ssh.sh run sh -s -- \
@@ -105,7 +110,7 @@ jobs:
           esac
           [ "${#backfill_script_sha}" -eq 40 ] || exit 64
           case "${backfill_limit}" in
-            *[!0-9]*) echo 'Invalid limit.' >&2; exit 64 ;;
+            *[!0-9]*|'') echo 'Invalid limit.' >&2; exit 64 ;;
           esac
 
           repository_git() {
@@ -136,8 +141,11 @@ jobs:
           [ "${active_release}" = "/opt/spyboxd/releases/${backfill_script_sha}" ]
 
           set -- "${runner}"
-          [ -n "${backfill_limit}" ] && set -- "$@" --limit "${backfill_limit}"
+          [ "${backfill_limit}" = "0" ] || set -- "$@" --limit "${backfill_limit}"
           [ "${backfill_dry_run}" = "true" ] && set -- "$@" --dry-run
+          # `set -e` would end the script on the false branch of the test
+          # above, which reads as a clean exit having done nothing.
+          true
 
           cd "${current_link}"
           "${python_path}" "$@"


### PR DESCRIPTION
An empty `limit` meant an empty argument, and arguments are re-split by the remote shell — so it **disappeared and shifted every argument after it**. `set -eu` caught it as `3: parameter not set` rather than letting the run proceed with the wrong flags.

The limit is now `0` for "everything remaining", never empty, and both ends reject an empty value rather than treating it as a default.

The dry-run test had the other half of the same problem: a bare `&&` under `set -e` **ends the script on its false branch**, which reads as a clean exit having done nothing.

Simulated all four input combinations under `sh -eu` before shipping:

```
limit=0   dry=true  -> backfill_credits_summary.py --dry-run
limit=0   dry=false -> backfill_credits_summary.py
limit=500 dry=true  -> backfill_credits_summary.py --limit 500 --dry-run
limit=500 dry=false -> backfill_credits_summary.py --limit 500
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)