### PR TITLE
Give the backfill its database URL the way the sweep already does

### DIFF
--- a/.github/workflows/credits-summary-backfill.yml
+++ b/.github/workflows/credits-summary-backfill.yml
@@ -131,8 +131,11 @@ jobs:
           current_link=/opt/spyboxd/current
           python_path="${current_link}/.venv/bin/python"
           runner="${current_link}/scripts/backfill_credits_summary.py"
+          database_env_file=/etc/spyboxd/api.env
           [ -L "${current_link}" ]
           [ -x "${python_path}" ]
+          [ -f "${database_env_file}" ] && [ ! -L "${database_env_file}" ] \
+            && [ -r "${database_env_file}" ]
           # Run the deployed copy rather than an extracted one: the script
           # imports the application's own summariser, and the two must be the
           # same revision or the rewrite disagrees with the writer.
@@ -148,7 +151,7 @@ jobs:
           true
 
           cd "${current_link}"
-          "${python_path}" "$@"
+          SPYBOXD_DATABASE_ENV_FILE="${database_env_file}" "${python_path}" "$@"
           REMOTE
 
       - name: Close production SSH and securely remove local key material

--- a/backend/env_file.py
+++ b/backend/env_file.py
@@ -1,0 +1,53 @@
+"""Read one value out of a deployment environment file.
+
+Operational scripts that run on the VPS need DATABASE_URL, which lives in
+/etc/spyboxd/api.env alongside every other production secret. They need that
+one line and nothing else, so this takes one key rather than sourcing the file
+or exporting it into the environment.
+
+Deliberately dependency-free: callers import this *before* importing
+`database.connection`, which resolves DATABASE_URL at import time and raises
+without one. Anything imported here would have to survive that ordering.
+
+Not parsed with a regex or `sed`. A value may be quoted, may be `export`ed, and
+routinely contains '=' and '@' because it holds a password — so the line is
+split once on the first '=' and then unwrapped.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+
+def read_env_value(env_file: str, key: str) -> Optional[str]:
+    """The last assignment of `key` in `env_file`, or None.
+
+    Last rather than first: a later line overrides an earlier one when the file
+    is sourced, so anything else would disagree with how the services read it.
+    """
+
+    found: Optional[str] = None
+    for raw_line in Path(env_file).read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        name, separator, value = line.partition("=")
+        if not separator or name.strip() != key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        found = value
+    return found or None
+
+
+def read_database_url(env_file: str) -> str:
+    """DATABASE_URL from a deployment environment file, or a clear failure."""
+
+    url = read_env_value(env_file, "DATABASE_URL")
+    if not url:
+        raise SystemExit(f"{env_file} has no DATABASE_URL")
+    return url

--- a/backend/tests/test_env_file.py
+++ b/backend/tests/test_env_file.py
@@ -1,0 +1,75 @@
+"""Taking one value out of a file full of production secrets.
+
+Operational scripts on the VPS need DATABASE_URL and nothing else out of
+/etc/spyboxd/api.env. Sourcing the file would hand a read-only checker every
+credential the API holds, and a `sed` inside a heredoc inside YAML is three
+quoting layers deep -- which is where an earlier attempt at this went wrong.
+"""
+from __future__ import annotations
+
+import pytest
+
+from env_file import read_database_url, read_env_value
+
+
+def _write(tmp_path, text: str) -> str:
+    path = tmp_path / "api.env"
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+def test_a_password_containing_equals_and_at_survives(tmp_path) -> None:
+    """Split once on the first '=', not matched: production passwords
+    routinely contain both characters and a greedy parse mangles the URL."""
+
+    env = _write(
+        tmp_path,
+        'CLERK_SECRET_KEY=sk_live_do_not_read_me\n'
+        'export DATABASE_URL="postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd"\n'
+        "TMDB_API_KEY='another secret'\n",
+    )
+
+    assert read_database_url(env) == "postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd"
+
+
+def test_only_the_requested_key_is_returned(tmp_path) -> None:
+    env = _write(tmp_path, "DATABASE_URL=postgresql://x/y\nCLERK_SECRET_KEY=sk_live_secret\n")
+
+    assert read_env_value(env, "DATABASE_URL") == "postgresql://x/y"
+    assert read_env_value(env, "NOT_PRESENT") is None
+
+
+def test_the_last_assignment_wins(tmp_path) -> None:
+    """Matching how the file behaves when a service sources it."""
+
+    env = _write(tmp_path, "DATABASE_URL=postgresql://first/db\nDATABASE_URL=postgresql://second/db\n")
+
+    assert read_env_value(env, "DATABASE_URL") == "postgresql://second/db"
+
+
+def test_a_commented_assignment_is_not_read(tmp_path) -> None:
+    env = _write(tmp_path, "# DATABASE_URL=postgresql://commented/db\nDATABASE_URL=postgresql://real/db\n")
+
+    assert read_env_value(env, "DATABASE_URL") == "postgresql://real/db"
+
+
+def test_single_and_double_quotes_are_unwrapped(tmp_path) -> None:
+    assert read_env_value(_write(tmp_path, "K='v'\n"), "K") == "v"
+    assert read_env_value(_write(tmp_path, 'K="v"\n'), "K") == "v"
+    # An unbalanced quote is part of the value, not a wrapper to strip.
+    assert read_env_value(_write(tmp_path, 'K="v\n'), "K") == '"v'
+
+
+def test_a_file_without_the_url_stops_rather_than_guessing(tmp_path) -> None:
+    env = _write(tmp_path, "CLERK_SECRET_KEY=sk_live\n")
+
+    with pytest.raises(SystemExit, match="has no DATABASE_URL"):
+        read_database_url(env)
+
+
+def test_an_empty_assignment_is_absent_rather_than_an_empty_url(tmp_path) -> None:
+    """An empty DATABASE_URL would otherwise be exported and fail much later,
+    inside SQLAlchemy, with a worse message."""
+
+    with pytest.raises(SystemExit, match="has no DATABASE_URL"):
+        read_database_url(_write(tmp_path, "DATABASE_URL=\n"))

--- a/deploy/panel_sweep.py
+++ b/deploy/panel_sweep.py
@@ -412,36 +412,6 @@ def report(sweep: Sweep, *, as_json: bool) -> None:
             )
 
 
-def read_database_url(env_file: str) -> str:
-    """Take only DATABASE_URL out of the API's environment file.
-
-    Parsed here rather than in the calling shell for two reasons: the sweep
-    needs one value out of a file full of production secrets, and sourcing the
-    file would hand it all of them; and a `sed` inside a heredoc inside YAML is
-    three quoting layers deep, which is where the last one of these went wrong.
-
-    A value may be quoted, may be `export`ed, and may itself contain '=' -- a
-    password routinely does -- so it is split once and unwrapped, not matched.
-    """
-
-    from pathlib import Path
-
-    url: Optional[str] = None
-    for raw_line in Path(env_file).read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if line.startswith("export "):
-            line = line[len("export ") :].lstrip()
-        key, separator, value = line.partition("=")
-        if separator and key.strip() == "DATABASE_URL":
-            value = value.strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-                value = value[1:-1]
-            url = value
-    if not url:
-        raise SystemExit(f"{env_file} has no DATABASE_URL")
-    return url
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--json", action="store_true", help="machine-readable output")
@@ -461,6 +431,10 @@ def main() -> int:
     if arguments.application_root not in sys.path:
         sys.path.insert(0, arguments.application_root)
     if arguments.database_env_file:
+        # Imported after the application root is on the path and before
+        # `database.connection`, which resolves DATABASE_URL at import time.
+        from env_file import read_database_url
+
         os.environ["DATABASE_URL"] = read_database_url(arguments.database_env_file)
 
     from database.connection import SessionLocal

--- a/deploy/test_panel_sweep.py
+++ b/deploy/test_panel_sweep.py
@@ -293,34 +293,9 @@ def test_postgres_is_asked_for_a_read_only_transaction_and_sqlite_is_not() -> No
     assert sqlite.statements == []
 
 
-def test_only_the_database_url_is_taken_from_the_api_environment(tmp_path) -> None:
-    """api.env holds every production secret. A read-only checker has business
-    with exactly one line of it."""
-
-    env_file = tmp_path / "api.env"
-    env_file.write_text(
-        "\n".join(
-            [
-                "CLERK_SECRET_KEY=sk_live_do_not_read_me",
-                "export DATABASE_URL=\"postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd\"",
-                "TMDB_API_KEY='another secret'",
-            ]
-        ),
-        encoding="utf-8",
-    )
-
-    url = sweep_module.read_database_url(str(env_file))
-
-    # Split once: a password routinely contains '=' and '@'.
-    assert url == "postgresql+psycopg://user:p=ss@w0rd@db:5432/spyboxd"
-
-
-def test_an_environment_file_without_a_database_url_stops_rather_than_guesses(tmp_path) -> None:
-    env_file = tmp_path / "api.env"
-    env_file.write_text("CLERK_SECRET_KEY=sk_live\n", encoding="utf-8")
-
-    with pytest.raises(SystemExit, match="has no DATABASE_URL"):
-        sweep_module.read_database_url(str(env_file))
+# The environment-file reader moved to backend/env_file.py so the panel sweep
+# and the credits backfill share one implementation; its tests moved with it,
+# to backend/tests/test_env_file.py.
 
 
 def test_every_swept_builder_has_a_call_plan() -> None:

--- a/scripts/backfill_credits_summary.py
+++ b/scripts/backfill_credits_summary.py
@@ -20,15 +20,25 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from dotenv import load_dotenv
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "backend"))
 load_dotenv(REPO_ROOT / ".env")
+
+# On the VPS there is no repo-level .env: DATABASE_URL lives in the API's own
+# environment file, and only that one key is taken from it. Resolved before
+# importing `database.connection`, which reads it at import time.
+_ENV_FILE = os.getenv("SPYBOXD_DATABASE_ENV_FILE")
+if _ENV_FILE and not os.getenv("DATABASE_URL"):
+    from env_file import read_database_url  # noqa: E402
+
+    os.environ["DATABASE_URL"] = read_database_url(_ENV_FILE)
 
 from database.connection import SessionLocal  # noqa: E402
 from database.models import MovieEnrichment  # noqa: E402


### PR DESCRIPTION
The backfill reached the VPS and died importing the application: there is no repo-level `.env` there, `DATABASE_URL` lives in the API's own environment file, and `database.connection` resolves it **at import time**.

The panel sweep had already solved this. Rather than copy fifteen lines of parsing into a second script, the reader moved to `backend/env_file.py` and both call it. Deliberately dependency-free — callers import it *before* `database.connection`, so anything it pulled in would have to survive that ordering.

Its tests moved with it and gained the cases a duplicate would have drifted on:

- the last assignment wins (matching how a service sourcing the file behaves)
- a commented assignment is not read
- an unbalanced quote is part of the value, not a wrapper to strip
- an empty assignment is *absent*, not an empty URL that fails later inside SQLAlchemy with a worse message
- a password containing `=` and `@` survives

Only `DATABASE_URL` is taken. Sourcing `api.env` would hand a maintenance script every credential the API holds.

Verified end to end with a stand-in env file and `DATABASE_URL` unset — the script resolved and connected. 742 backend, 11 sweep, 25 workflow-contract, zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)