### PR TITLE
Promote the three values the panel reads out of raw_payload

### DIFF
--- a/alembic/versions/20260810_0020_promote_detail_fields.py
+++ b/alembic/versions/20260810_0020_promote_detail_fields.py
@@ -1,0 +1,60 @@
+"""Three values the panels read out of raw_payload, promoted to columns.
+
+`raw_payload` holds the whole TMDB response including watch providers. The film
+query never selected it -- that mistake was made once and took the API down --
+and instead extracted three values from it by JSON path.
+
+That is still expensive, for a reason the JSON path does not make obvious:
+Postgres has to detoast the whole payload to read any part of it. Behind one
+profile's library that is 39MB, and once `credits` stopped being the bottleneck
+(20260810_0019) these three paths were 65% of what the query cost.
+
+So they become columns. `raw_payload` stays exactly as it is -- the record of
+what TMDB returned -- and these are the derived read-path copies, the same
+arrangement `genres` and `production_countries` already have.
+
+`belongs_to_collection` becomes `collection_name` rather than a JSON copy: the
+only thing read from it is the franchise name.
+
+Column only. Filling it is `scripts/backfill_credits_summary.py`, resumable and
+paced, for the same reason as the last one: this database is live and rewriting
+every enrichment row holds a lock for the length of the rewrite. Readers fall
+back to the payload while a row is NULL, so the deploy is safe in either order.
+
+Revision ID: 20260810_0020
+Revises: 20260810_0019
+Create Date: 2026-08-10 04:05:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "20260810_0020"
+down_revision: Union[str, None] = "20260810_0019"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "movie_enrichments",
+        sa.Column("production_companies", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column(
+        "movie_enrichments",
+        sa.Column("spoken_languages", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column(
+        "movie_enrichments",
+        sa.Column("collection_name", sa.String(length=300), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("movie_enrichments", "collection_name")
+    op.drop_column("movie_enrichments", "spoken_languages")
+    op.drop_column("movie_enrichments", "production_companies")

--- a/backend/database/models.py
+++ b/backend/database/models.py
@@ -1252,6 +1252,14 @@ class MovieEnrichment(Base):
     # is distinct from a film whose credits are genuinely empty.
     credits_summary = Column(_json_type(), nullable=True)
     production_countries = Column(_json_type(), nullable=False, server_default=sql_text("'[]'"))
+    # Three values the panels read out of `raw_payload`, promoted to columns of
+    # their own. Extracting them by JSON path still made Postgres detoast the
+    # whole payload -- 39MB behind one profile's library -- which was 65% of
+    # the film query once `credits` stopped being the bottleneck. Nullable, so
+    # NULL means "not extracted yet" and readers fall back to the payload.
+    production_companies = Column(_json_type(), nullable=True)
+    spoken_languages = Column(_json_type(), nullable=True)
+    collection_name = Column(String(300), nullable=True)
     poster_path = Column(String(500), nullable=True)
     backdrop_path = Column(String(500), nullable=True)
     raw_payload = Column(_json_type(), nullable=False, server_default=sql_text("'{}'"))

--- a/backend/services/profile_stats.py
+++ b/backend/services/profile_stats.py
@@ -256,17 +256,13 @@ def _actor_values(credits: Any) -> List[_Value]:
 def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
     """Bulk-load one profile's library in a single query.
 
-    Only the columns the statistics need are selected. ``raw_payload`` holds
-    the entire TMDB response including watch providers -- tens of megabytes
-    across a large library -- so the two fragments needed from it are extracted
-    by JSON path in the database instead of shipping the whole document.
+    Only the columns the statistics need are selected, and none of them is
+    ``raw_payload``. That column holds the entire TMDB response including watch
+    providers -- 39MB behind a single large library -- and reading any part of
+    it, even by JSON path, makes Postgres detoast the whole thing. The three
+    values the panel wants from it therefore live in columns of their own,
+    filled by the enrichment writer and the backfill script.
     """
-
-    production_companies = MovieEnrichment.raw_payload["details"]["production_companies"]
-    spoken_languages = MovieEnrichment.raw_payload["details"]["spoken_languages"]
-    # TMDB names the franchise a film belongs to; 1,143 of the 4,554 enriched
-    # films carry one and nothing had ever read it.
-    belongs_to_collection = MovieEnrichment.raw_payload["details"]["belongs_to_collection"]
     rows = (
         db.query(
             ProfileFilm.rating,
@@ -289,9 +285,9 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
             # and are fetched below.
             MovieEnrichment.credits_summary,
             MovieEnrichment.production_countries,
-            production_companies.label("production_companies"),
-            spoken_languages.label("spoken_languages"),
-            belongs_to_collection.label("belongs_to_collection"),
+            MovieEnrichment.production_companies,
+            MovieEnrichment.spoken_languages,
+            MovieEnrichment.collection_name,
         )
         .join(Movie, Movie.id == ProfileFilm.movie_id)
         .outerjoin(MovieEnrichment, MovieEnrichment.movie_id == Movie.id)
@@ -302,21 +298,33 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
         .all()
     )
 
-    # Films the backfill has not summarised yet still have to render their
-    # crew, so the full document is fetched for exactly those. The set shrinks
-    # to nothing once `scripts/backfill_credits_summary.py` has run, and a
-    # deploy that lands before the backfill is therefore correct, just no
-    # faster than before for the rows still missing.
-    unsummarised = [
-        int(row.movie_id) for row in rows if row.credits_summary is None and row.enrichment_movie_id
+    # Films the backfill has not reached yet still have to render, so the
+    # originals are fetched for exactly those. The set shrinks to nothing once
+    # `scripts/backfill_credits_summary.py` has run, which is what makes a
+    # deploy landing before the backfill correct -- just no faster than before
+    # for the rows still missing.
+    unfilled = [
+        int(row.movie_id)
+        for row in rows
+        if row.enrichment_movie_id
+        and (row.credits_summary is None or row.production_companies is None)
     ]
-    fallback_credits: Dict[int, Any] = {}
-    if unsummarised:
-        fallback_credits = {
-            int(movie_id): payload
-            for movie_id, payload in db.query(
-                MovieEnrichment.movie_id, MovieEnrichment.credits
-            ).filter(MovieEnrichment.movie_id.in_(unsummarised))
+    fallback: Dict[int, Any] = {}
+    if unfilled:
+        fallback = {
+            int(movie_id): {
+                "credits": credits,
+                "production_companies": companies,
+                "spoken_languages": languages,
+                "collection": collection,
+            }
+            for movie_id, credits, companies, languages, collection in db.query(
+                MovieEnrichment.movie_id,
+                MovieEnrichment.credits,
+                MovieEnrichment.raw_payload["details"]["production_companies"],
+                MovieEnrichment.raw_payload["details"]["spoken_languages"],
+                MovieEnrichment.raw_payload["details"]["belongs_to_collection"],
+            ).filter(MovieEnrichment.movie_id.in_(unfilled))
         }
 
     films: List[_FilmRow] = []
@@ -325,10 +333,18 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
         release_year = row.release_year
         if not release_year and row.release_date is not None:
             release_year = row.release_date.year
+        original = fallback.get(int(row.movie_id)) or {}
         credits = row.credits_summary
         if not isinstance(credits, Mapping):
-            credits = fallback_credits.get(int(row.movie_id))
+            credits = original.get("credits")
         credits = credits if isinstance(credits, Mapping) else {}
+        companies = row.production_companies
+        if companies is None:
+            companies = original.get("production_companies")
+        languages = row.spoken_languages
+        if languages is None:
+            languages = original.get("spoken_languages")
+        collection = row.collection_name or _collection_name(original.get("collection"))
         films.append(
             _FilmRow(
                 movie_id=int(row.movie_id),
@@ -347,7 +363,7 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
                 ),
                 genres=_plain_values(_as_string_list(row.genres)),
                 countries=_country_values(row.production_countries),
-                languages=_language_values(row.original_language, row.spoken_languages),
+                languages=_language_values(row.original_language, languages),
                 directors=_director_values(credits),
                 director_genders=_director_genders(credits),
                 composers=_crew_values(credits, BELOW_THE_LINE_JOBS["composer"]),
@@ -356,12 +372,12 @@ def _film_rows(db: Session, profile_id: int) -> List[_FilmRow]:
                 ),
                 editors=_crew_values(credits, BELOW_THE_LINE_JOBS["editor"]),
                 actors=_actor_values(credits),
-                studios=_plain_values(_as_string_list(row.production_companies)),
+                studios=_plain_values(_as_string_list(companies)),
                 extra_crew={
                     key: _crew_values(credits, job)
                     for key, job in EXTRA_CREW_JOBS.items()
                 },
-                collection=_collection_name(row.belongs_to_collection),
+                collection=collection,
             )
         )
     return films

--- a/backend/services/tmdb_enrichment.py
+++ b/backend/services/tmdb_enrichment.py
@@ -197,6 +197,18 @@ def summarize_credits(credits: Any) -> Dict[str, Any]:
     return {"crew": crew, "cast": cast}
 
 
+def collection_name(payload: Any) -> Optional[str]:
+    """The franchise TMDB places a film in, if any.
+
+    Most films belong to none, which is why this is nullable rather than a
+    bucket: a standalone film is not a one-film franchise.
+    """
+
+    if not isinstance(payload, Mapping):
+        return None
+    return str(payload.get("name") or "").strip() or None
+
+
 def build_enrichment_values(details: Mapping[str, Any]) -> Dict[str, Any]:
     """Map a TMDB detail response to typed MovieEnrichment fields."""
     keywords_payload = _as_dict(details.get("keywords"))
@@ -225,6 +237,11 @@ def build_enrichment_values(details: Mapping[str, Any]) -> Dict[str, Any]:
         # panels read without paying for the rest.
         "credits_summary": summarize_credits(credits),
         "production_countries": _as_list(details.get("production_countries")),
+        # Promoted out of raw_payload. Reading them back by JSON path made
+        # Postgres detoast the whole payload, which was 65% of the film query.
+        "production_companies": _as_list(details.get("production_companies")),
+        "spoken_languages": _as_list(details.get("spoken_languages")),
+        "collection_name": collection_name(details.get("belongs_to_collection")),
         "poster_path": str(details.get("poster_path") or "").strip() or None,
         "backdrop_path": str(details.get("backdrop_path") or "").strip() or None,
     }

--- a/backend/tests/test_additive_migrations.py
+++ b/backend/tests/test_additive_migrations.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_REVISION = "20260313_0001"
 FOUNDATION_REVISION = "20260728_0002"
 BACKFILL_REVISION = "20260728_0003"
-HEAD_REVISION = "20260810_0019"
+HEAD_REVISION = "20260810_0020"
 TEST_DATABASE_NAME_PATTERN = re.compile(r"(?:^|[_-])(?:ci|test|testing)(?:$|[_-])")
 TEST_SCHEMA_NAME_PATTERN = re.compile(r"^spyboxd_migration_test_[0-9a-f]{24}$")
 
@@ -104,7 +104,10 @@ class AdditiveMigrationContractTests(unittest.TestCase):
 
         self.assertEqual(script.get_heads(), [HEAD_REVISION])
         self.assertEqual(
-            script.get_revision(HEAD_REVISION).down_revision, "20260809_0018"
+            script.get_revision(HEAD_REVISION).down_revision, "20260810_0019"
+        )
+        self.assertEqual(
+            script.get_revision("20260810_0019").down_revision, "20260809_0018"
         )
         self.assertEqual(
             script.get_revision("20260809_0018").down_revision, "20260802_0017"

--- a/scripts/backfill_credits_summary.py
+++ b/scripts/backfill_credits_summary.py
@@ -42,7 +42,7 @@ if _ENV_FILE and not os.getenv("DATABASE_URL"):
 
 from database.connection import SessionLocal  # noqa: E402
 from database.models import MovieEnrichment  # noqa: E402
-from services.tmdb_enrichment import summarize_credits  # noqa: E402
+from services.tmdb_enrichment import collection_name, summarize_credits  # noqa: E402
 
 
 def _measure(value: Any) -> int:
@@ -66,9 +66,21 @@ def main() -> int:
 
     db = SessionLocal()
     try:
-        query = db.query(MovieEnrichment.movie_id, MovieEnrichment.credits)
+        # The three detail values come out of raw_payload by JSON path here,
+        # which is the expensive read this backfill exists to stop the panels
+        # doing. Paying it once, in a paced batch job, is the whole point.
+        query = db.query(
+            MovieEnrichment.movie_id,
+            MovieEnrichment.credits,
+            MovieEnrichment.raw_payload["details"]["production_companies"],
+            MovieEnrichment.raw_payload["details"]["spoken_languages"],
+            MovieEnrichment.raw_payload["details"]["belongs_to_collection"],
+        )
         if not arguments.refresh:
-            query = query.filter(MovieEnrichment.credits_summary.is_(None))
+            query = query.filter(
+                (MovieEnrichment.credits_summary.is_(None))
+                | (MovieEnrichment.production_companies.is_(None))
+            )
         query = query.order_by(MovieEnrichment.movie_id)
         if arguments.limit:
             query = query.limit(arguments.limit)
@@ -79,14 +91,29 @@ def main() -> int:
             return 0
 
         before = after = written = 0
-        for index, (movie_id, credits) in enumerate(rows, start=1):
+        for index, (movie_id, credits, companies, languages, collection) in enumerate(
+            rows, start=1
+        ):
             summary = summarize_credits(credits)
             before += _measure(credits)
             after += _measure(summary)
             if not arguments.dry_run:
                 db.query(MovieEnrichment).filter(
                     MovieEnrichment.movie_id == movie_id
-                ).update({"credits_summary": summary}, synchronize_session=False)
+                ).update(
+                    {
+                        "credits_summary": summary,
+                        # Empty lists rather than NULL: the row has been
+                        # visited, and NULL is what the reader's fallback keys
+                        # off. Leaving it null for a film TMDB lists no
+                        # companies for would make every later page load fetch
+                        # the payload again to learn the same nothing.
+                        "production_companies": companies if isinstance(companies, list) else [],
+                        "spoken_languages": languages if isinstance(languages, list) else [],
+                        "collection_name": collection_name(collection),
+                    },
+                    synchronize_session=False,
+                )
                 written += 1
                 if index % arguments.batch_size == 0:
                     db.commit()


### PR DESCRIPTION
With `credits` no longer the bottleneck, the sweep still had the stats panel at **4.85s** for the largest profile. Measured again rather than assumed:

```
0.06s  core columns only
0.13s  core + credits_summary          (+0.07s)
0.30s  core + three raw_payload paths  (+0.25s)  <-- 65% of what remained
raw_payload behind this one profile: 39 MB
```

The JSON path was already the fix for a worse bug — selecting the whole column once took the API down — and it **hides the cost it does not remove**: Postgres detoasts the entire payload to read any part of it.

So they become columns, filled by the enrichment writer and the same backfill script. `raw_payload` is untouched and stays the record of what TMDB returned. `belongs_to_collection` becomes `collection_name` because the only thing ever read from it is the name.

The backfill writes **empty lists rather than NULL** for a film TMDB lists nothing for — NULL is what the fallback keys off, so leaving it would make every later page load re-read the payload to learn the same nothing.

## Verification

- All **1,666** films of the largest library compared against the original JSON paths — studios and collection: **0 mismatches**
- `_film_rows` 1.28s → 0.49s (**2.6× total**, from 0.71s after the credits fix)
- backend suite **742 passed**, `alembic check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)