### PR TITLE
Do not page for a deploy that is still in flight

### DIFF
--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -138,6 +138,13 @@ jobs:
               )
           PY
               printf 'exact_release=false\n' >>"${GITHUB_OUTPUT}"
+              # Distinct from every other reason alignment can fail: this one
+              # is a deploy in flight, which resolves itself in minutes. The
+              # authenticated phase still must not run -- it would be proving
+              # isolation against a release nobody asked about -- but declining
+              # to run is not a failure, and paging for it teaches people that
+              # canary alerts are noise.
+              printf 'release_pending=true\n' >>"${GITHUB_OUTPUT}"
               echo 'Production is temporarily behind current main while its exact CI or deployment is active.'
               ;;
             *)
@@ -157,8 +164,23 @@ jobs:
             echo 'The workflow stages those non-password identity values only for a single run. Clerk, database, password, and session secrets remain on the VPS.'
           } >>"${GITHUB_STEP_SUMMARY}"
 
+      - name: Note that a deploy in flight defers authenticated isolation
+        if: >-
+          env.AUTH_CANARY_REQUIRED == 'true' &&
+          steps.release_alignment.outputs.release_pending == 'true'
+        run: |
+          {
+            echo '### Authenticated isolation deferred'
+            echo
+            echo 'Production is mid-deploy, so there is no settled release to prove isolation against.'
+            echo 'The next scheduled run covers it. This is the guard working, not a failure.'
+          } >>"${GITHUB_STEP_SUMMARY}"
+
       - name: Require exact release alignment for authenticated isolation
-        if: env.AUTH_CANARY_REQUIRED == 'true' && steps.release_alignment.outputs.exact_release != 'true'
+        if: >-
+          env.AUTH_CANARY_REQUIRED == 'true' &&
+          steps.release_alignment.outputs.exact_release != 'true' &&
+          steps.release_alignment.outputs.release_pending != 'true'
         run: |
           echo 'Authenticated isolation is fail-closed until the exact main release is deployed.' >&2
           exit 1

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -510,3 +510,42 @@ class RestoreDrillProvisioningTests(unittest.TestCase):
 
     def test_it_refuses_to_run_as_anybody_but_root(self) -> None:
         self.assertIn('[ "$(id -u)" -eq 0 ]', read_repo_file(self.SCRIPT))
+
+
+class CanaryReleaseGraceTests(unittest.TestCase):
+    """A deploy in flight must not page anybody.
+
+    The alignment guard already recognised "production is mid-deploy" as
+    benign and set exact_release=false for it. The authenticated phase then
+    treated that same benign state as a hard failure, so every fast merge
+    filed a "Production Canary is failing" issue that resolved itself minutes
+    later. An alert that fires on a self-healing condition is how people learn
+    to ignore alerts.
+    """
+
+    WORKFLOW = ".github/workflows/production-canary.yml"
+
+    def test_a_deploy_in_flight_is_reported_separately_from_misalignment(self) -> None:
+        contents = read_repo_file(self.WORKFLOW)
+
+        # The grace path marks itself, rather than being indistinguishable
+        # from every other reason alignment can fail.
+        self.assertIn("printf 'release_pending=true\\n' >>\"${GITHUB_OUTPUT}\"", contents)
+
+    def test_the_hard_failure_excludes_the_deploy_in_flight_case(self) -> None:
+        contents = read_repo_file(self.WORKFLOW)
+        block = contents.split("- name: Require exact release alignment", 1)
+        self.assertEqual(len(block), 2, "the fail-closed step is gone")
+        condition = block[1].split("run:", 1)[0]
+
+        self.assertIn("exact_release != 'true'", condition)
+        self.assertIn("release_pending != 'true'", condition)
+
+    def test_the_authenticated_phase_still_refuses_to_run_mid_deploy(self) -> None:
+        """Deferring is not the same as blessing: isolation must never be
+        proved against a release nobody asked about."""
+
+        contents = read_repo_file(self.WORKFLOW)
+        gate = contents.split("\n  authenticated_canary:", 1)[1].split("runs-on", 1)[0]
+
+        self.assertIn("outputs.exact_release == 'true'", gate)


### PR DESCRIPTION
The alignment guard already recognised "production is mid-deploy" as benign and set `exact_release=false` for it. The authenticated phase then treated **that same benign state** as a hard failure — so a run landing between a merge and its deploy filed a *Production Canary is failing* issue that resolved itself minutes later. Two were filed today ([#185](https://github.com/Yash03x/spyboxd/issues/185)).

An alert that fires on a self-healing condition is how people learn to ignore alerts — precisely what the alerting was built to stop.

The grace path now marks itself (`release_pending`), the fail-closed step excludes that one case, and the authenticated phase **still refuses to run**: deferring is not blessing, and isolation must never be proved against a release nobody asked about.

3 new tests pin all three halves of that. 28 workflow-contract tests, 38 canary tests, zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)