### PR TITLE
Stop paging for two more guards that were working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,8 @@ jobs:
   deploy_production:
     name: Deploy / Exact-SHA release
     needs: release_bundle
+    outputs:
+      superseded: ${{ steps.staleness.outputs.superseded }}
     concurrency:
       group: spyboxd-production-deploy
       queue: max
@@ -589,6 +591,7 @@ jobs:
           egress-policy: audit
 
       - name: Reject a stale deployable CI result before loading SSH credentials
+        id: staleness
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -609,6 +612,10 @@ jobs:
           )"
           if [[ "${current_main_sha}" != "${RELEASE_SHA}" ]]; then
             echo "Skipping stale CI artifact because main now points to ${current_main_sha}." >&2
+            # Recorded before exiting so the alert can tell this apart from a
+            # deploy that broke. Declining to ship a superseded artifact is the
+            # guard working; the commit that replaced it brings its own deploy.
+            printf 'superseded=true\n' >>"${GITHUB_OUTPUT}"
             exit 75
           fi
 
@@ -1715,7 +1722,20 @@ jobs:
   alert_on_failure:
     name: Alert if this run failed
     needs: [backend, frontend, e2e, compose, release_gate, release_bundle, deploy_production]
-    if: always() && contains(needs.*.result, 'failure') && github.ref == 'refs/heads/main'
+    # A deploy that declined to ship a superseded artifact is not a failure
+    # worth waking anybody for: main moved on, and the commit that moved it
+    # carries its own deploy. Alerting on it taught nobody anything except to
+    # ignore the alerts.
+    if: >-
+      always() && contains(needs.*.result, 'failure') &&
+      github.ref == 'refs/heads/main' &&
+      !(needs.deploy_production.outputs.superseded == 'true' &&
+        needs.backend.result == 'success' &&
+        needs.frontend.result == 'success' &&
+        needs.e2e.result == 'success' &&
+        needs.compose.result == 'success' &&
+        needs.release_gate.result == 'success' &&
+        needs.release_bundle.result == 'success')
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/production-canary.yml
+++ b/.github/workflows/production-canary.yml
@@ -96,10 +96,18 @@ jobs:
               printf 'exact_release=true\n' >>"${GITHUB_OUTPUT}"
               ;;
             ahead)
-              (( ahead_by == 1 )) || {
-                echo 'Production is more than one commit behind current main.' >&2
-                exit 1
-              }
+              # No ceiling on the distance, deliberately. It used to be one
+              # commit, which failed the moment several merges landed close
+              # together -- seven dependency updates in a row put production
+              # legitimately six behind while its deploys queued, and every one
+              # of those queued deploys was going to arrive.
+              #
+              # The distance was never the safety property. "Production is
+              # behind and nothing is doing anything about it" is, and that is
+              # what the active-run check below actually tests. Production's
+              # revision is already proven an ancestor of main above, so a
+              # long distance with a live deploy queue is a slow queue, not a
+              # broken release.
               ci_runs="${RUNNER_TEMP}/spyboxd-active-ci.json"
               gh api \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
@@ -126,15 +134,20 @@ jobs:
                   except ValueError:
                       continue
                   age_seconds = (now - created).total_seconds()
+                  # Any recent active run on main, not only one for the current
+                  # head. During a burst of merges the run in flight is often
+                  # for an intermediate commit, and it is still evidence the
+                  # pipeline is moving -- which is the whole question here.
+                  # Deployment is serialised, so whatever is running now is
+                  # followed by the rest of the queue.
                   if (
-                      run.get("head_sha") == current_main_sha
-                      and run.get("status") in active_statuses
+                      run.get("status") in active_statuses
                       and -300 <= age_seconds <= 1800
                   ):
                       active.append(run)
           if not active:
               raise SystemExit(
-                  "production is behind main and no current production CI started within 30 minutes"
+                  "production is behind main and no production CI started within 30 minutes"
               )
           PY
               printf 'exact_release=false\n' >>"${GITHUB_OUTPUT}"

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -433,15 +433,39 @@ class FailureAlertTests(unittest.TestCase):
     def test_only_a_real_failure_raises_an_alert(self) -> None:
         for relative_path in self.GUARDED:
             contents = read_repo_file(relative_path)
+            condition = contents.split("\n  alert_on_failure:", 1)[1].split("uses:", 1)[0]
             # A cancelled run is somebody pressing the button and a skipped one
             # is a guard working; alerting on either trains people to ignore
             # these. And a fork's failing pull request must not file issues.
-            self.assertIn(
-                "if: always() && contains(needs.*.result, 'failure') "
-                "&& github.ref == 'refs/heads/main'",
-                contents,
-                relative_path,
-            )
+            #
+            # Asserted as three properties rather than one literal string: the
+            # conditions have earned exceptions -- a deploy that declined a
+            # superseded artifact is not a failure -- and pinning the exact
+            # text made adding one look like removing the guard.
+            for required in (
+                "always()",
+                "contains(needs.*.result, 'failure')",
+                "github.ref == 'refs/heads/main'",
+            ):
+                self.assertIn(required, condition, f"{relative_path}: {required}")
+
+    def test_a_superseded_deploy_does_not_alert_while_a_broken_one_still_does(self) -> None:
+        """Merging several changes quickly makes earlier artifacts stale.
+
+        The deploy job refuses to ship one, which is the guard working, and it
+        used to file an issue for it. The exemption is narrow on purpose: it
+        applies only when every other job passed, so a deploy that was both
+        superseded and broken still alerts.
+        """
+
+        contents = read_repo_file(".github/workflows/ci.yml")
+        condition = contents.split("\n  alert_on_failure:", 1)[1].split("uses:", 1)[0]
+
+        self.assertIn("needs.deploy_production.outputs.superseded == 'true'", condition)
+        self.assertIn("printf 'superseded=true\\n' >>\"${GITHUB_OUTPUT}\"", contents)
+        # Every other job must be required green for the exemption to apply.
+        for job in ("backend", "frontend", "e2e", "compose", "release_gate", "release_bundle"):
+            self.assertIn(f"needs.{job}.result == 'success'", condition, job)
 
     def test_the_alert_is_called_rather_than_triggered_by_workflow_run(self) -> None:
         """`workflow_run` runs in the base repository's context and is the


### PR DESCRIPTION
Merging seven dependency updates in a row produced two spurious issues ([#189](https://github.com/Yash03x/spyboxd/issues/189), [#190](https://github.com/Yash03x/spyboxd/issues/190)), both from **correct refusals reported as failures**. Third and fourth instances of the shape #188 fixed.

## The canary's one-commit ceiling

Seven merges put production six commits behind while its deploys queued — and every queued deploy was going to arrive. The distance was never the safety property; *"production is behind and nothing is doing anything about it"* is, and the active-run check already tests exactly that.

The ceiling is gone. The active-run check also no longer insists the run be for the current head — during a burst it is usually for an intermediate commit, and that is still evidence the pipeline is moving.

## The deploy's stale-artifact refusal

Refusing to ship an artifact main has moved past is right, and it filed an issue about it. The job now records `superseded` and the alert excludes that case — **narrowly**: only when every other job passed, so a deploy that was both superseded *and* broken still alerts.

## The test that made this awkward

`test_only_a_real_failure_raises_an_alert` pinned the alert condition as one literal string, which made adding a justified exception look identical to removing the guard. It now asserts the three properties, and a new test pins the exemption's narrowness.

29 workflow-contract tests, 38 canary tests. The 2 remaining zizmor findings are pre-existing lows in `ci.yml`, unchanged by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)