### PR TITLE
Fix audit findings across app and deploy

### DIFF
--- a/.github/workflows/canary-reset.yml
+++ b/.github/workflows/canary-reset.yml
@@ -28,6 +28,7 @@ jobs:
       # Shares the auth canary's group so a reset can never race a live
       # guardian run against the same rows.
       group: spyboxd-production-auth-canary
+      queue: max
       cancel-in-progress: false
     environment:
       name: production

--- a/backend/database/repository.py
+++ b/backend/database/repository.py
@@ -25,6 +25,8 @@ from .models import (
 from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional, Dict, Any, Tuple
 
+from services.profile_username import canonical_profile_username
+
 
 def _format_month_bucket(year: int, month: int) -> str:
     return f"{int(year):04d}-{int(month):02d}"
@@ -667,6 +669,7 @@ class ProfileRepository:
         cleared. App users whose account mirrors the old username follow it.
         Returns whether a feed state row was repointed.
         """
+        new_username = canonical_profile_username(new_username)
         old_username = profile.username
         profile.username = new_username
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,12 +33,13 @@ from database.models import Movie, Profile, ProfileFavoriteMovie, ProfileFilm, W
 from database.repository import (
     ProfileRepository, RatingRepository, ReviewRepository, AnalyticsRepository
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from services.data_coverage import (
     extract_data_coverage,
 )
 from services.ingestion import unified_data_loader
 from services.profile_loader import load_profile_data, validate_import_bundle
+from services.profile_username import canonical_profile_username
 from services.profile_access import (
     accessible_profiles,
     authorize_profile_usernames,
@@ -115,10 +116,15 @@ class ProfileCreate(BaseModel):
     worse than a rejected form.
     """
 
-    username: str = Field(pattern=r"^[A-Za-z0-9_]{2,15}$")
+    username: str
     bio: Optional[str] = None
     location: Optional[str] = None
     website: Optional[str] = None
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, value: str) -> str:
+        return canonical_profile_username(value)
 
 class ProfileUpdate(BaseModel):
     bio: Optional[str] = None
@@ -129,6 +135,11 @@ class ProfileUpdate(BaseModel):
 
 class ProfileRename(BaseModel):
     new_username: str
+
+    @field_validator("new_username")
+    @classmethod
+    def validate_new_username(cls, value: str) -> str:
+        return canonical_profile_username(value)
 
 
 class PublicSystemStats(BaseModel):
@@ -487,11 +498,18 @@ def extract_zip_file(uploaded_file, temp_dir):
     if not safe_filename.lower().endswith(".zip"):
         raise HTTPException(status_code=400, detail="Only ZIP archives are supported")
 
-    zip_path = os.path.join(temp_dir, safe_filename)
+    # One request can contain several archives with the same client filename.
+    # Isolate both the stored ZIP and its extraction tree so a later bundle can
+    # never inherit files from an earlier one.
+    upload_root = tempfile.mkdtemp(prefix="upload-", dir=temp_dir)
+    zip_path = os.path.join(upload_root, safe_filename)
     with open(zip_path, "wb") as f:
         shutil.copyfileobj(uploaded_file.file, f)
 
-    extract_dir = os.path.join(temp_dir, os.path.splitext(safe_filename)[0] or "archive")
+    extract_dir = os.path.join(
+        upload_root,
+        os.path.splitext(safe_filename)[0] or "archive",
+    )
     os.makedirs(extract_dir, exist_ok=True)
     extract_root = os.path.realpath(extract_dir)
     max_members = int(os.getenv("UPLOAD_MAX_ARCHIVE_MEMBERS", "50000"))
@@ -1067,9 +1085,7 @@ async def rename_profile(
     under the new username — otherwise the upload would create a duplicate.
     Shares the ingestion-token trust model with /upload/.
     """
-    new_username = payload.new_username.strip()
-    if not re.fullmatch(r"[A-Za-z0-9_-]{1,50}", new_username):
-        raise HTTPException(status_code=422, detail="Invalid Letterboxd username")
+    new_username = payload.new_username
 
     profile_repo = ProfileRepository(db)
     profile = profile_repo.get_profile_by_username(username)

--- a/backend/scraper_html.py
+++ b/backend/scraper_html.py
@@ -29,6 +29,8 @@ from bs4 import BeautifulSoup
 import re
 from dataclasses import dataclass, asdict
 
+from services.profile_username import is_valid_profile_username
+
 
 class ScrapeValidationError(RuntimeError):
     """Raised when a full scrape cannot prove a dataset was fetched completely."""
@@ -2004,16 +2006,9 @@ class EnhancedLetterboxdScraper:
 
 
 def validate_username(username: str) -> bool:
-    """Validate that the username is reasonable."""
-    if not username:
-        return False
-    
-    # Basic validation - letterboxd usernames are alphanumeric with some special chars
-    import re
-    if not re.match(r'^[a-zA-Z0-9_-]+$', username):
-        return False
-        
-    return True
+    """Validate against the same identity contract used by auth and ingestion."""
+
+    return is_valid_profile_username(username)
 
 
 def main():
@@ -2057,7 +2052,7 @@ Features:
     # Validate username
     if not validate_username(args.username):
         print("Error: Please provide a valid Letterboxd username")
-        print("Username should contain only letters, numbers, underscores, and hyphens")
+        print("Username must be 2-15 characters using letters, numbers, or underscores")
         print("Example: python letterboxd_scraper.py username")
         sys.exit(1)
     

--- a/backend/services/profile_access.py
+++ b/backend/services/profile_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import re
 from datetime import datetime, timezone
 from typing import Any, Iterable, Optional, Sequence
 
@@ -19,9 +18,9 @@ from database.models import (
     Rating,
     UserTrackedProfile,
 )
+from services.profile_username import canonical_profile_username
 
 
-PROFILE_USERNAME = re.compile(r"[A-Za-z0-9_]{2,15}")
 REQUEST_STATUSES = {"pending", "approved", "rejected", "fulfilled"}
 ADMIN_DECISIONS = {"approved", "rejected"}
 
@@ -35,12 +34,13 @@ def _positive_limit(name: str, default: int) -> int:
 
 
 def normalize_profile_username(raw_username: str) -> tuple[str, str]:
-    username = (raw_username or "").strip().lstrip("@")
-    if not PROFILE_USERNAME.fullmatch(username):
+    try:
+        username = canonical_profile_username(raw_username, allow_at_prefix=True)
+    except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Enter a valid Letterboxd username.",
-        )
+        ) from exc
     return username, username.casefold()
 
 
@@ -287,6 +287,27 @@ def track_profile_by_id(
     """Idempotently monitor one selectable catalog profile for this user."""
 
     app_user = ensure_app_user(db, clerk_user)
+    if not clerk_user.is_admin:
+        # Numeric IDs are sequential and therefore cannot serve as proof that a
+        # caller knows a profile. Keep this route inside the same follow-graph
+        # discovery boundary as the catalog that supplies these IDs. A profile
+        # already tracked by the caller remains idempotently selectable even if
+        # a later follow-graph refresh removes the connecting edge.
+        is_already_tracked = (
+            db.query(UserTrackedProfile.id)
+            .filter(
+                UserTrackedProfile.user_id == app_user.id,
+                UserTrackedProfile.profile_id == profile_id,
+            )
+            .first()
+            is not None
+        )
+        if (
+            not is_already_tracked
+            and profile_id not in _connected_profile_ids(db, app_user)
+        ):
+            raise HTTPException(status_code=404, detail="Selectable profile not found")
+
     profile = (
         db.query(Profile)
         .filter(

--- a/backend/services/profile_loader.py
+++ b/backend/services/profile_loader.py
@@ -20,6 +20,7 @@ from services.import_contracts import (
     movie_identity_from_row,
     parse_boolean,
 )
+from services.profile_username import canonical_profile_username
 
 
 FULL_SCRAPE_REQUIRED_DATASETS = {
@@ -405,6 +406,12 @@ def load_profile_data(profile_path: str, username: str) -> LoadedProfileData:
         )
         if profile_username:
             effective_username = profile_username
+
+    # This value becomes both profiles.username and, during a detected rename,
+    # app_users.letterboxd_username.  Validate it before fingerprinting or any
+    # database mutation so ingestion cannot persist an identity that auth will
+    # reject on the next request.
+    effective_username = canonical_profile_username(effective_username)
 
     source_kind = str(scrape_manifest.get("source_kind") or _detect_source_kind(source_files))
     source_fingerprint = bundle_fingerprint(effective_username, source_files.values())

--- a/backend/services/profile_username.py
+++ b/backend/services/profile_username.py
@@ -1,0 +1,52 @@
+"""One storage-safe contract for Letterboxd profile usernames.
+
+Every caller that can persist a profile or app-user identity must agree on this
+shape.  In particular, accepting a wider value during a rename can otherwise
+write an ``app_users.letterboxd_username`` that authentication rejects on the
+very next request.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+PROFILE_USERNAME_PATTERN = r"[A-Za-z0-9_]{2,15}"
+_PROFILE_USERNAME = re.compile(PROFILE_USERNAME_PATTERN)
+_PROFILE_USERNAME_ERROR = (
+    "Letterboxd usernames must be 2-15 characters and use only letters, "
+    "numbers, or underscores."
+)
+
+
+def canonical_profile_username(
+    raw_username: object,
+    *,
+    allow_at_prefix: bool = False,
+) -> str:
+    """Return the canonical storable username or raise ``ValueError``.
+
+    Request forms may allow one decorative ``@`` prefix.  Scraper and archive
+    paths use :func:`is_valid_profile_username` instead so a value accepted
+    there is already canonical and cannot change after validation.
+    """
+
+    if not isinstance(raw_username, str):
+        raise ValueError(_PROFILE_USERNAME_ERROR)
+    username = raw_username.strip()
+    if allow_at_prefix and username.startswith("@"):
+        username = username[1:]
+    if not _PROFILE_USERNAME.fullmatch(username):
+        raise ValueError(_PROFILE_USERNAME_ERROR)
+    return username
+
+
+def is_valid_profile_username(value: object) -> bool:
+    """Whether ``value`` is already a canonical profile username."""
+
+    if not isinstance(value, str):
+        return False
+    try:
+        return canonical_profile_username(value) == value
+    except ValueError:
+        return False

--- a/backend/tests/test_import_contracts.py
+++ b/backend/tests/test_import_contracts.py
@@ -152,6 +152,21 @@ class MovieIdentityContractTests(unittest.TestCase):
 
 
 class ProfileLoaderContractTests(unittest.TestCase):
+    def test_loader_rejects_an_identity_auth_cannot_provision(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pd.DataFrame([{"Username": "film-fan"}]).to_csv(
+                root / "profile.csv",
+                index=False,
+            )
+            pd.DataFrame(columns=["Name", "Year", "Rating"]).to_csv(
+                root / "ratings.csv",
+                index=False,
+            )
+
+            with self.assertRaisesRegex(ValueError, "2-15 characters"):
+                load_profile_data(str(root), "archive-name")
+
     def _write_full_bundle(self, root: Path) -> None:
         pd.DataFrame(
             [{"Username": "viewer", "Display_Name": "Viewer", "Date Joined": "2020-01-02"}]

--- a/backend/tests/test_local_sync_environment.py
+++ b/backend/tests/test_local_sync_environment.py
@@ -3,12 +3,30 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 from dotenv import dotenv_values
 
-from scripts.local_full_sync import load_local_environment
+from scripts.local_full_sync import load_local_environment, validate_username
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    "username,expected",
+    [
+        ("filmfan_7", True),
+        ("ab", True),
+        ("a", False),
+        ("film-fan", False),
+        ("1234567890123456", False),
+    ],
+)
+def test_residential_sync_uses_the_storable_username_contract(
+    username: str,
+    expected: bool,
+) -> None:
+    assert validate_username(username) is expected
 
 
 def test_local_sync_loads_ignored_root_environment(

--- a/backend/tests/test_profile_access.py
+++ b/backend/tests/test_profile_access.py
@@ -242,7 +242,7 @@ def test_primary_identity_fulfillment_is_not_blocked_by_optional_tracking_limit(
     user = _user(letterboxd_username="Primary")
 
     assert provision_app_user_identity(database, user)["primary_profile_status"] == "pending"
-    track_profile_by_id(database, user, optional.id)
+    track_or_request_profile(database, user, optional.username)
 
     primary = _profile(2, "Primary")
     database.add(primary)
@@ -376,7 +376,7 @@ def test_primary_profile_cannot_be_untracked(database):
     database.commit()
     user = _user(letterboxd_username="Alpha")
     provision_app_user_identity(database, user)
-    track_profile_by_id(database, user, beta.id)
+    track_or_request_profile(database, user, beta.username)
 
     with pytest.raises(HTTPException) as raised:
         untrack_profile(database, user, "alpha")
@@ -747,7 +747,7 @@ def test_omitted_dashboard_scope_defaults_non_admin_to_tracked_profiles(database
     )
     database.commit()
     user = _legacy_user(database)
-    track_profile_by_id(database, user, alpha.id)
+    track_or_request_profile(database, user, alpha.username)
 
     result = asyncio.run(
         backend_main.get_consolidated_dashboard_analytics(
@@ -1425,6 +1425,33 @@ def test_a_non_admin_only_browses_their_own_corner_of_the_follow_graph(database)
 
     assert [entry["username"] for entry in catalog["profiles"]] == ["Connected"]
     assert catalog["total"] == 1
+
+
+def test_numeric_tracking_route_cannot_bypass_the_catalog_scope(database):
+    connected = _profile(1, "Connected")
+    stranger = _profile(2, "Stranger")
+    database.add_all([connected, stranger])
+    database.add(_edge(1, connected.id, "viewer"))
+    database.commit()
+    user = _legacy_user(database)
+    _link_handle(database, "user_one", "viewer")
+
+    assert [
+        entry["username"] for entry in list_profile_catalog(database, user)["profiles"]
+    ] == ["Connected"]
+
+    backend_main.app.dependency_overrides[backend_main.get_db] = lambda: database
+    backend_main.app.dependency_overrides[backend_main.get_current_user] = lambda: user
+    try:
+        response = TestClient(backend_main.app).post(
+            f"/profiles/{stranger.id}/tracking"
+        )
+    finally:
+        backend_main.app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Selectable profile not found"}
+    assert database.query(UserTrackedProfile).count() == 0
 
 
 def test_an_admin_still_sees_the_whole_library(database):

--- a/backend/tests/test_profile_rename.py
+++ b/backend/tests/test_profile_rename.py
@@ -7,14 +7,28 @@ from unittest import TestCase
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from backend.database.models import AppUser, Profile, ProfileFeedState
+from backend.auth import ClerkUser
+from backend.database.models import (
+    AppUser,
+    Profile,
+    ProfileAccessRequest,
+    ProfileFeedState,
+    UserTrackedProfile,
+)
 from backend.database.repository import ProfileRepository
+from backend.services.profile_access import provision_app_user_identity
 
 
 class ProfileRenameTests(TestCase):
     def setUp(self):
         self.engine = create_engine("sqlite:///:memory:")
-        for table in (Profile.__table__, ProfileFeedState.__table__, AppUser.__table__):
+        for table in (
+            Profile.__table__,
+            ProfileFeedState.__table__,
+            AppUser.__table__,
+            UserTrackedProfile.__table__,
+            ProfileAccessRequest.__table__,
+        ):
             table.create(self.engine, checkfirst=True)
         self.db = sessionmaker(bind=self.engine)()
 
@@ -85,3 +99,32 @@ class ProfileRenameTests(TestCase):
 
         self.assertFalse(repo.rename_profile(bare, "still_lonely"))
         self.assertEqual(bare.username, "still_lonely")
+
+    def test_accepted_rename_keeps_the_mirrored_app_user_provisionable(self):
+        repo = ProfileRepository(self.db)
+
+        repo.rename_profile(self.profile, "filmfan_7")
+        identity = provision_app_user_identity(
+            self.db,
+            ClerkUser(
+                user_id="user_1",
+                session_id="session_1",
+                letterboxd_username="filmfan_7",
+            ),
+        )
+
+        self.assertEqual(
+            identity,
+            {
+                "letterboxd_username": "filmfan_7",
+                "primary_profile_status": "tracked",
+            },
+        )
+
+    def test_rename_rejects_a_username_that_auth_cannot_provision(self):
+        repo = ProfileRepository(self.db)
+
+        with self.assertRaisesRegex(ValueError, "2-15 characters"):
+            repo.rename_profile(self.profile, "film-fan")
+
+        self.assertEqual(self.profile.username, "gowri_sriya")

--- a/backend/tests/test_resolve_like_targets.py
+++ b/backend/tests/test_resolve_like_targets.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.resolve_like_targets import resolve
+
+
+def test_resolver_fetches_an_official_boxd_short_link():
+    fetched = []
+
+    def fetch(url):
+        fetched.append(url)
+        return SimpleNamespace(
+            headers={
+                "location": (
+                    "https://letterboxd.com/filmfan_7/film/"
+                    "spider-man-brand-new-day/"
+                )
+            }
+        )
+
+    assert resolve("https://boxd.it/fwSSUD", fetch) == (
+        "filmfan_7",
+        "spider-man-brand-new-day",
+    )
+    assert fetched == ["https://boxd.it/fwSSUD"]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://boxd.it/fwSSUD",
+        "https://localhost/fwSSUD",
+        "https://127.0.0.1/fwSSUD",
+        "https://169.254.169.254/latest/meta-data/",
+        "https://boxd.it@127.0.0.1/fwSSUD",
+        "https://user:password@boxd.it/fwSSUD",
+        "https://boxd.it.evil.example/fwSSUD",
+        "https://boxd.it/fwSSUD?next=http://127.0.0.1/",
+        "https://boxd.it/fwSSUD/",
+    ],
+)
+def test_resolver_rejects_non_export_urls_before_fetch(url):
+    fetched = []
+
+    assert resolve(url, lambda value: fetched.append(value)) == (None, None)
+    assert fetched == []

--- a/backend/tests/test_upload_safety.py
+++ b/backend/tests/test_upload_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+from pathlib import Path
 from types import SimpleNamespace
 import tempfile
 import unittest
@@ -15,6 +16,15 @@ def archive_with(filename: str, content: str = "ok") -> BytesIO:
     payload = BytesIO()
     with zipfile.ZipFile(payload, "w") as archive:
         archive.writestr(filename, content)
+    payload.seek(0)
+    return payload
+
+
+def archive_with_files(files: dict[str, str]) -> BytesIO:
+    payload = BytesIO()
+    with zipfile.ZipFile(payload, "w") as archive:
+        for filename, content in files.items():
+            archive.writestr(filename, content)
     payload.seek(0)
     return payload
 
@@ -40,6 +50,33 @@ class UploadExtractionTests(unittest.TestCase):
                 extract_zip_file(upload, temp_dir)
 
         self.assertEqual(raised.exception.status_code, 400)
+
+    def test_identical_upload_basenames_get_isolated_extraction_trees(self) -> None:
+        first = SimpleNamespace(
+            filename="letterboxd-export.zip",
+            file=archive_with_files(
+                {
+                    "bundle/profile.csv": "Username\nfirst\n",
+                    "bundle/ratings.csv": "Name\nPrivate First Film\n",
+                }
+            ),
+        )
+        second = SimpleNamespace(
+            filename="letterboxd-export.zip",
+            file=archive_with_files(
+                {"bundle/watched.csv": "Name\nSecond Film\n"}
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            first_path = Path(extract_zip_file(first, temp_dir))
+            second_path = Path(extract_zip_file(second, temp_dir))
+
+            self.assertNotEqual(first_path, second_path)
+            self.assertTrue((first_path / "ratings.csv").is_file())
+            self.assertTrue((second_path / "watched.csv").is_file())
+            self.assertFalse((second_path / "ratings.csv").exists())
+            self.assertFalse((second_path / "profile.csv").exists())
 
 
 if __name__ == "__main__":

--- a/deploy/nginx/spyboxd.conf
+++ b/deploy/nginx/spyboxd.conf
@@ -152,6 +152,7 @@ server {
     }
 
     location = /ready {
+        limit_req zone=spyboxd_api_per_ip burst=60 nodelay;
         proxy_pass http://127.0.0.1:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -164,6 +165,7 @@ server {
     }
 
     location = /health/rss {
+        limit_req zone=spyboxd_api_per_ip burst=60 nodelay;
         proxy_pass http://127.0.0.1:8000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;

--- a/deploy/test_workflow_controls.py
+++ b/deploy/test_workflow_controls.py
@@ -104,6 +104,21 @@ class WorkflowControlsTests(unittest.TestCase):
         self.assertIn('environment["TMDB_ENRICHMENT_BATCH_SIZE"] = "10"', workflow)
         self.assertIn("--kill-after=15s 8m", workflow)
 
+    def test_database_backed_health_routes_keep_the_api_rate_limit(self) -> None:
+        nginx = read_repo_file("deploy/nginx/spyboxd.conf")
+
+        for route in ("/ready", "/health/rss"):
+            with self.subTest(route=route):
+                location = re.search(
+                    rf"(?ms)^    location = {re.escape(route)} \{{\n(.*?)^    \}}",
+                    nginx,
+                )
+                self.assertIsNotNone(location, f"missing exact Nginx location for {route}")
+                self.assertIn(
+                    "limit_req zone=spyboxd_api_per_ip burst=60 nodelay;",
+                    location.group(1),
+                )
+
     def test_privileged_jobs_start_with_pinned_harden_runner(self) -> None:
         ci = read_repo_file(".github/workflows/ci.yml")
         release_bundle = ci.split("\n  release_bundle:\n", maxsplit=1)[1]
@@ -321,9 +336,14 @@ class AuthCanaryDiagnosticsTests(unittest.TestCase):
         self.assertIn("workflow_dispatch", workflow)
         self.assertNotIn("schedule:", workflow)
         self.assertIn("default: false", workflow)
-        # Same concurrency group as the auth canary, so a reset can never race
-        # a live guardian run against the same rows.
-        self.assertIn("group: spyboxd-production-auth-canary", workflow)
+        # Same queued concurrency group as the auth canary, so a reset can
+        # neither race a live guardian nor be replaced while waiting behind it.
+        reset_concurrency = workflow.split("\n    concurrency:\n", maxsplit=1)[1].split(
+            "\n    environment:", maxsplit=1
+        )[0]
+        self.assertIn("group: spyboxd-production-auth-canary", reset_concurrency)
+        self.assertIn("queue: max", reset_concurrency)
+        self.assertIn("cancel-in-progress: false", reset_concurrency)
         for block in re.findall(r"sh -s --.*?<<'REMOTE'(.*?)\n\s*REMOTE", workflow, re.S):
             for line in block.splitlines():
                 if not line.strip().startswith("#"):

--- a/frontend/e2e/admin.spec.ts
+++ b/frontend/e2e/admin.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-import { installApiMocks } from './fixtures/api';
+import { installApiMocks, profiles } from './fixtures/api';
 
 test('backend admin truth exposes management and the residential sync queue', async ({ page }) => {
   await installApiMocks(page, { isAdmin: true });
@@ -110,6 +110,63 @@ test('an admin can switch between personal monitoring and the preserved global d
   await expect(monitored).toBeVisible();
   await page.getByRole('button', { name: 'Global admin' }).click();
   await expect(managed).toBeVisible();
+});
+
+test('switching to a one-profile monitored scope drops the old global selection', async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+  await page.route(/^http:\/\/(?:127\.0\.0\.1|localhost):8000\/profiles\/?$/, (route) => (
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ profiles }),
+    })
+  ));
+  await page.route(/^http:\/\/(?:127\.0\.0\.1|localhost):8000\/profiles\/tracked$/, (route) => (
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ profiles: profiles.slice(0, 1) }),
+    })
+  ));
+
+  const signalSelections: string[][] = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === '/api/spy-signals') {
+      signalSelections.push(url.searchParams.getAll('profiles'));
+    }
+  });
+
+  await page.goto('/overlaps', { waitUntil: 'networkidle' });
+  expect(signalSelections.at(-1)).toEqual(profiles.slice(0, 6).map((profile) => profile.username));
+  const requestsBeforeSwitch = signalSelections.length;
+
+  await page.getByRole('button', { name: 'Monitored', exact: true }).click();
+
+  await expect(page.getByText('· MONITORED', { exact: false })).toBeVisible();
+  await expect(page.getByText('@alpha', { exact: true })).toBeVisible();
+  await expect(page.getByText('@bravo', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Two profiles are needed', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('Shared Fixture Film', { exact: true })).toHaveCount(0);
+  expect(signalSelections.slice(requestsBeforeSwitch)).toEqual([]);
+});
+
+test('the private workspace still loads when browser storage is denied', async ({ page }) => {
+  await installApiMocks(page, { isAdmin: true });
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  await page.addInitScript(() => {
+    Storage.prototype.getItem = function getItem() {
+      throw new DOMException('Storage blocked', 'SecurityError');
+    };
+  });
+
+  await page.goto('/overview');
+
+  await expect(page.getByRole('heading', { level: 1, name: 'Overview', exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Global admin' })).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByText('This section could not render', { exact: true })).toHaveCount(0);
+  expect(pageErrors).toEqual([]);
 });
 
 test('the admin scope toggle appears on every analytics page and persists across pages', async ({ page }) => {

--- a/frontend/e2e/public-smoke.spec.ts
+++ b/frontend/e2e/public-smoke.spec.ts
@@ -38,6 +38,15 @@ async function expectInsideViewport(page: Page, locator: Locator) {
   }).toBe(true);
 }
 
+async function expectHorizontallyInsideViewport(page: Page, locator: Locator) {
+  await expect.poll(async () => {
+    const viewport = page.viewportSize();
+    const box = await locator.boundingBox();
+    if (!viewport || !box) return false;
+    return box.x >= 0 && box.x + box.width <= viewport.width;
+  }).toBe(true);
+}
+
 test.beforeEach(async ({ page }) => {
   const errors: string[] = [];
   runtimeErrors.set(page, errors);
@@ -117,6 +126,68 @@ test('signed-in public homepage remains aggregate-only', async ({ page }) => {
   await signOut.click();
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole('link', { name: 'Sign in to monitor profiles' })).toBeVisible();
+});
+
+test('signed-in public header fits a 390px phone and keeps its controls usable', async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith('mobile-'), 'Mobile regression');
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const dashboard = page.getByRole('link', { name: 'Open My Dashboard' });
+  const signOut = page.getByRole('button', { name: 'Sign out', exact: true });
+  const userMenu = page.getByRole('button', { name: 'Open user menu' });
+  const theme = page.getByRole('button', { name: /^(?:LIGHT|DARK)$/ });
+
+  for (const control of [dashboard, signOut, userMenu, theme]) {
+    await expect(control).toBeVisible();
+    await expectHorizontallyInsideViewport(page, control);
+  }
+  await expect(signOut).toBeEnabled();
+
+  const pageWidth = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(pageWidth.scroll).toBeLessThanOrEqual(pageWidth.client);
+
+  const initialTheme = await page.locator('html').getAttribute('data-theme');
+  await theme.click();
+  await expect(page.locator('html')).not.toHaveAttribute('data-theme', initialTheme ?? 'dark');
+
+  await dashboard.click();
+  await expect(page).toHaveURL(/\/overview$/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Overview', exact: true })).toBeVisible();
+});
+
+test('anonymous public header fits a 390px phone and keeps its controls usable', async ({
+  page,
+}, testInfo) => {
+  test.skip(!testInfo.project.name.startsWith('mobile-'), 'Mobile regression');
+  await page.context().clearCookies();
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto('/');
+
+  const home = page.getByRole('link', { name: 'Spyboxd public dashboard' });
+  const createAccount = page.getByRole('link', { name: 'Create account' });
+  const signIn = page.getByRole('link', { name: 'Sign in to monitor profiles' });
+  const theme = page.getByRole('button', { name: /^(?:LIGHT|DARK)$/ });
+
+  for (const control of [home, createAccount, signIn, theme]) {
+    await expect(control).toBeVisible();
+    await expectHorizontallyInsideViewport(page, control);
+  }
+
+  const pageWidth = await page.evaluate(() => ({
+    client: document.documentElement.clientWidth,
+    scroll: document.documentElement.scrollWidth,
+  }));
+  expect(pageWidth.scroll).toBeLessThanOrEqual(pageWidth.client);
+
+  const initialTheme = await page.locator('html').getAttribute('data-theme');
+  await theme.click();
+  await expect(page.locator('html')).not.toHaveAttribute('data-theme', initialTheme ?? 'dark');
 });
 
 test('watching activity identifies month-to-date events and excludes them from the completed-month average', async ({ page }) => {
@@ -317,4 +388,37 @@ test('Tonight keeps its selection in the viewport and never paints a broken post
     }).length,
   );
   expect(brokenImages).toBe(0);
+});
+
+test('Tonight offers Worldwide and every supported availability country', async ({ page }) => {
+  const countries = ['AT', 'AU', 'CA', 'DE', 'GB', 'IN', 'US', 'ZA'];
+  await page.route(/^http:\/\/(?:127\.0\.0\.1|localhost):8000\/api\/watch-provider-regions$/, (route) => (
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        default_region: 'ALL',
+        worldwide_region: 'ALL',
+        regions: countries.map((code) => ({ code, movie_count: 1 })),
+      }),
+    })
+  ));
+
+  await page.goto('/tonight?tab=picks');
+
+  const country = page.getByLabel('Availability country');
+  await expect(country).toHaveValue('ALL');
+  await expect(country.locator('option')).toHaveCount(countries.length + 1);
+  await expect(country.locator('option').first()).toHaveText(
+    'Worldwide (any supported availability country)',
+  );
+  await expect(country.locator('option[value="US"]')).toHaveCount(1);
+  await expect(country.locator('option[value="ZA"]')).toHaveCount(1);
+
+  await country.selectOption('ZA');
+  await expect(page).toHaveURL(/region=ZA/);
+  await expect(country).toHaveValue('ZA');
+  await expect(
+    page.getByText('ON A SUBSCRIPTION IN ZA', { exact: true }),
+  ).toBeVisible();
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1879,9 +1879,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5013,9 +5013,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6762,9 +6762,9 @@
       }
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8513,9 +8513,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-          "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+          "version": "5.0.9",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+          "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -9034,9 +9034,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -10542,9 +10542,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -11664,9 +11664,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-          "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+          "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"

--- a/frontend/src/app/(terminal)/tonight/page.tsx
+++ b/frontend/src/app/(terminal)/tonight/page.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
-import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 
 import TerminalShell from '../../../components/terminal/TerminalShell';
@@ -17,40 +16,32 @@ import PicksTab from '../../../views/tonight/PicksTab';
 function RegionPicker({
   value,
   regions,
+  worldwideRegion,
   hrefFor,
 }: {
   value: string;
   regions: string[];
+  worldwideRegion: string;
   hrefFor: (region: string) => string;
 }) {
+  const router = useRouter();
   if (regions.length < 2) return null;
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-t9 tracking-tab text-term-muted2">REGION</span>
-      <div className="flex items-center gap-1">
-        {regions.map((region) => {
-          const active = region === value;
-          return (
-            <Link
-              key={region}
-              href={hrefFor(region)}
-              scroll={false}
-              aria-current={active ? 'true' : undefined}
-              className="rounded-[3px] border px-2 py-[3px] text-t10 no-underline hover:no-underline"
-              style={{
-                borderColor: active ? 'var(--accent)' : 'var(--rule)',
-                background: active
-                  ? 'color-mix(in srgb, var(--accent) 14%, transparent)'
-                  : 'transparent',
-                color: active ? 'var(--accent)' : 'var(--muted)',
-              }}
-            >
-              {region}
-            </Link>
-          );
-        })}
-      </div>
-    </div>
+    <label className="flex items-center gap-2 text-t9 tracking-tab text-term-muted2">
+      AVAILABILITY COUNTRY
+      <select
+        aria-label="Availability country"
+        value={value}
+        onChange={(event) => router.replace(hrefFor(event.target.value), { scroll: false })}
+        className="max-w-[15rem] rounded-[3px] border border-term-rule bg-term-bg px-2 py-[3px] font-term text-t10 tracking-normal text-term-ink3"
+      >
+        {regions.map((region) => (
+          <option key={region} value={region}>
+            {region === worldwideRegion ? 'Worldwide (any supported availability country)' : region}
+          </option>
+        ))}
+      </select>
+    </label>
   );
 }
 
@@ -67,9 +58,22 @@ function TonightSection() {
     refetchOnWindowFocus: false,
   });
 
-  const available = (regionsQuery.data?.regions ?? []).map((entry) => entry.code);
-  const region =
-    searchParams.get('region') ?? regionsQuery.data?.default_region ?? available[0] ?? 'IN';
+  const available = (regionsQuery.data?.regions ?? []).map((entry) => entry.code.toUpperCase());
+  const worldwideRegion = regionsQuery.data?.worldwide_region?.toUpperCase() ?? 'ALL';
+  const requestedRegion = searchParams.get('region')?.trim().toUpperCase();
+  const validRequestedRegion = requestedRegion === worldwideRegion || /^[A-Z]{2}$/.test(requestedRegion ?? '');
+  const region = validRequestedRegion
+    ? requestedRegion!
+    : regionsQuery.data?.default_region?.toUpperCase() ?? worldwideRegion ?? available[0] ?? 'ALL';
+  // `regions` contains countries backed by cached provider data; the API's
+  // Worldwide sentinel is separate. Keep every country selectable instead of
+  // silently dropping everything after the first six, and retain a valid deep
+  // link so the API can honestly say that country has never been read.
+  const regionOptions = Array.from(new Set([
+    worldwideRegion,
+    ...(validRequestedRegion ? [requestedRegion!] : []),
+    ...available,
+  ]));
 
   const controls = (
     <SelectionBar
@@ -80,7 +84,8 @@ function TonightSection() {
     >
       <RegionPicker
         value={region}
-        regions={available.slice(0, 6)}
+        regions={regionOptions}
+        worldwideRegion={worldwideRegion}
         hrefFor={(next) => selection.paramHref('region', next)}
       />
     </SelectionBar>

--- a/frontend/src/hooks/useAdminScope.tsx
+++ b/frontend/src/hooks/useAdminScope.tsx
@@ -21,7 +21,13 @@ const AdminScopeContext = createContext<AdminScopeContextValue | null>(null);
 
 function readStoredScope(): AdminScope {
   if (typeof window === 'undefined') return 'global';
-  return window.localStorage.getItem(SCOPE_STORAGE_KEY) === 'tracked' ? 'tracked' : 'global';
+  try {
+    return window.localStorage.getItem(SCOPE_STORAGE_KEY) === 'tracked' ? 'tracked' : 'global';
+  } catch {
+    // Storage can be denied even when `window.localStorage` exists. Scope is a
+    // convenience, so a browser privacy setting must not take down the app.
+    return 'global';
+  }
 }
 
 export function AdminScopeProvider({ children }: { children: React.ReactNode }) {

--- a/frontend/src/hooks/useTerminalSelection.ts
+++ b/frontend/src/hooks/useTerminalSelection.ts
@@ -44,6 +44,7 @@ export function useTerminalSelection(options: TerminalSelectionOptions = {}) {
   );
 
   const selection = useUrlProfileSelection(available, {
+    isReady: profilesQuery.isFetched,
     minSelection,
     maxSelection: options.maxSelection,
     defaultCount: options.defaultCount ?? Math.min(available.length, 6),

--- a/frontend/src/hooks/useUrlProfileSelection.ts
+++ b/frontend/src/hooks/useUrlProfileSelection.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 interface UrlProfileSelectionOptions {
+  isReady: boolean;
   minSelection: number;
   maxSelection?: number;
   defaultCount: number;
@@ -45,12 +46,32 @@ export function useUrlProfileSelection(
     return availableProfiles.slice(0, options.defaultCount);
   }, [availableProfiles, options.defaultCount, options.maxSelection, options.minSelection, urlProfilesKey]);
 
+  // Query-key changes (most importantly the admin scope lens) render before
+  // this hook's synchronization effect runs. Reconcile during render as well,
+  // so a child query can never receive names from the previous scope in that
+  // intervening commit. While the new profile catalog is loading, an empty
+  // selection is safer than querying the old scope.
+  const reconciledAppliedProfiles = useMemo(() => {
+    if (!options.isReady) return [];
+    const available = new Set(availableProfiles);
+    const valid = appliedProfiles.filter((profile) => available.has(profile));
+    const bounded = options.maxSelection ? valid.slice(0, options.maxSelection) : valid;
+    return bounded.length >= options.minSelection ? bounded : normalizedProfiles;
+  }, [
+    appliedProfiles,
+    availableProfiles,
+    normalizedProfiles,
+    options.isReady,
+    options.maxSelection,
+    options.minSelection,
+  ]);
+
   useEffect(() => {
-    if (availableProfiles.length < options.minSelection) return;
+    if (!options.isReady) return;
     setDraftProfiles((current) => sameProfiles(current, normalizedProfiles) ? current : normalizedProfiles);
     setAppliedProfiles((current) => sameProfiles(current, normalizedProfiles) ? current : normalizedProfiles);
     setIsInitialized(true);
-  }, [availableProfiles.length, normalizedProfiles, options.minSelection]);
+  }, [normalizedProfiles, options.isReady]);
 
   const replaceParams = useCallback((
     profiles: string[],
@@ -79,7 +100,7 @@ export function useUrlProfileSelection(
   }, [availableProfiles, options.maxSelection, options.minSelection, replaceParams]);
 
   return {
-    appliedProfiles,
+    appliedProfiles: reconciledAppliedProfiles,
     applyProfiles,
     draftProfiles,
     isInitialized,

--- a/frontend/src/views/PublicDashboard.tsx
+++ b/frontend/src/views/PublicDashboard.tsx
@@ -257,7 +257,10 @@ function PublicHeader({ isSignedIn }: { isSignedIn: boolean | undefined }) {
         <span className="grid h-[22px] w-[22px] place-items-center rounded-[3px] bg-term-accent text-[11px] font-extrabold text-term-onaccent">
           S
         </span>
-        <span className="font-bold tracking-crumb text-term-accent">SPYBOXD</span>
+        {/* Phone-width controls need this space more than a repeated wordmark
+            does. The S remains the visible home affordance, and the link's
+            accessible name still carries the full product name. */}
+        <span className="hidden font-bold tracking-crumb text-term-accent sm:inline">SPYBOXD</span>
         <span className="hidden text-term-dim2 sm:inline">›</span>
         <span className="hidden text-term-ink3 sm:inline">PUBLIC TOTALS</span>
       </Link>
@@ -284,15 +287,19 @@ function PublicHeader({ isSignedIn }: { isSignedIn: boolean | undefined }) {
           <>
             <Link
               href="/sign-up"
+              aria-label="Create account"
               className="rounded-[3px] border border-term-accent bg-term-accent px-2 py-[3px] font-bold text-term-onaccent no-underline hover:no-underline"
             >
-              Create account
+              <span className="sm:hidden">Join</span>
+              <span className="hidden sm:inline">Create account</span>
             </Link>
             <Link
               href="/sign-in?redirect_url=%2Fdata%3Ftab%3Dprofiles"
+              aria-label="Sign in to monitor profiles"
               className="rounded-[3px] border border-term-rule px-2 py-[3px] text-term-ink3 no-underline hover:border-term-accent hover:text-term-accent hover:no-underline"
             >
-              Sign in to monitor profiles
+              <span className="sm:hidden">Sign in</span>
+              <span className="hidden sm:inline">Sign in to monitor profiles</span>
             </Link>
           </>
         )}

--- a/scripts/local_full_sync.py
+++ b/scripts/local_full_sync.py
@@ -81,7 +81,9 @@ def sync_profile(
     timeout_seconds: int = 180,
 ) -> dict:
     if not validate_username(username):
-        raise ValueError("Invalid username. Use only letters, numbers, underscores, and hyphens.")
+        raise ValueError(
+            "Invalid username. Use 2-15 letters, numbers, or underscores."
+        )
 
     if not upload_token and not bearer_token:
         raise ValueError("Provide either an upload token or a bearer token.")

--- a/scripts/resolve_like_targets.py
+++ b/scripts/resolve_like_targets.py
@@ -40,12 +40,19 @@ from database.models import MemberContentLike, Profile  # noqa: E402
 TARGET = re.compile(
     r"^https://letterboxd\.com/([A-Za-z0-9_]+)/(?:(film|list)/([a-z0-9][a-z0-9-]*))?"
 )
+# Official exports use an HTTPS boxd.it URL with one base62-like token. Check
+# that exact shape before making a request: imported archive data is still
+# untrusted even though this resolver is an operator-run maintenance command.
+SHORT_LINK = re.compile(r"^https://boxd\.it/[A-Za-z0-9]+$")
 # Paths that are Letterboxd's own, not a member's.
 RESERVED = {"films", "film", "lists", "list", "members", "settings", "search", "journal"}
 
 
 def resolve(url: str, fetch) -> tuple[str | None, str | None]:
     """Return (author, film slug). Either may be None; neither is guessed."""
+
+    if not SHORT_LINK.fullmatch(url):
+        return None, None
 
     response = fetch(url)
     location = response.headers.get("location") or response.headers.get("Location") or ""


### PR DESCRIPTION
## What changed

- close the authenticated numeric-profile tracking authorization bypass
- constrain the residential like resolver to exact official `boxd.it` URLs
- isolate same-named ZIP uploads and centralize the storage-safe username contract
- keep admin scope changes from querying profiles from the previous scope
- make private-mode storage failures non-fatal
- expose Worldwide and every supported Tonight availability country
- fix signed-in and anonymous mobile header overflow
- update vulnerable `js-yaml` and `brace-expansion` lock entries
- rate-limit database-backed health routes and preserve queued canary resets

## Why

The repository-wide audit found two security boundaries that could be bypassed, two ingestion correctness failures, three frontend truth/usability defects, vulnerable transitive development dependencies, and two operations reliability gaps. Each fix is paired with a focused regression.

## Validation

- backend: 762 passed, 9 PostgreSQL-gated skipped, 19 subtests passed
- deploy: 150 passed, 5 expected platform skips, 37 subtests passed
- frontend: ESLint and TypeScript passed; production build passed
- Playwright: 318 passed, 2 intentional desktop skips for mobile-only cases
- npm audit: 0 vulnerabilities
- pip-audit: 0 known vulnerabilities
- Compose validation, shell syntax, compileall, and diff checks passed
- rendered 390px production build check confirmed no horizontal overflow

No production data migration is required.
