### PR TITLE
Show opinion coverage on profile snapshots

### DIFF
--- a/frontend/e2e/fixtures/api.ts
+++ b/frontend/e2e/fixtures/api.ts
@@ -1164,6 +1164,20 @@ async function handleApiRoute(route: Route, state: ApiFixtureState, isAdmin: boo
   }
   if (path === '/profiles' && method === 'GET') return json(route, { profiles: state.profiles });
   if (path === '/profiles/tracked' && method === 'GET') return json(route, { profiles: state.profiles });
+  const profileSnapshotMatch = path.match(/^\/public\/profile\/([^/]+)$/);
+  if (profileSnapshotMatch && method === 'GET') {
+    const username = decodeURIComponent(profileSnapshotMatch[1]);
+    const profile = state.profiles.find(
+      (candidate) => candidate.username.toLocaleLowerCase() === username.toLocaleLowerCase(),
+    );
+    if (!profile) return route.fulfill({ status: 404, body: '' });
+    return json(route, {
+      ...profile,
+      bio: 'Fixture profile bio.',
+      location: 'Berlin',
+      website: null,
+    });
+  }
   const analysisMatch = path.match(/^\/profiles\/([^/]+)\/analysis$/);
   if (analysisMatch && method === 'GET') {
     return json(route, {

--- a/frontend/e2e/profile-snapshot.spec.ts
+++ b/frontend/e2e/profile-snapshot.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('a profile snapshot separates watched films from expressed opinions', async ({ page }) => {
+  await page.goto('/u/alpha');
+
+  const snapshot = page.locator('section', { hasText: '@alpha' });
+  await expect(snapshot.getByText('1,200', { exact: true })).toBeVisible();
+  await expect(snapshot.getByText('Opinion coverage', { exact: true })).toBeVisible();
+  await expect(snapshot.getByText('900 rated · 180 liked', { exact: true })).toBeVisible();
+});

--- a/frontend/src/app/u/[username]/page.tsx
+++ b/frontend/src/app/u/[username]/page.tsx
@@ -71,6 +71,10 @@ export default function ProfileSnapshotPage() {
                     [profile.location, profile.bio].filter(Boolean).join(' — ') ||
                     'No public bio on the profile.',
                 },
+                {
+                  label: 'Opinion coverage',
+                  text: `${profile.rated_films.toLocaleString()} rated · ${profile.liked_films.toLocaleString()} liked`,
+                },
               ]}
             />
           ) : null)}


### PR DESCRIPTION
## What changed

- Show rated and liked film counts on signed-in profile snapshots.
- Extend the existing profile API fixture with the stored snapshot shape.
- Add a focused desktop-Chromium regression for the new coverage note.

## Why

The profile endpoint already exposes watched, rated, and liked totals, but the page only surfaced the watched total. Showing opinion coverage makes the existing snapshot more useful without changing backend or authentication contracts.

## Checks

- npm run typecheck
- npm run lint -- src/app/u/[username]/page.tsx e2e/profile-snapshot.spec.ts e2e/fixtures/api.ts
- npm run test:e2e -- e2e/profile-snapshot.spec.ts --project=desktop-chromium
- git diff --check