### PR TITLE
Expose Tonight decision modes

### DIFF
--- a/frontend/e2e/tonight-decision-modes.spec.ts
+++ b/frontend/e2e/tonight-decision-modes.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+import { installApiMocks } from './fixtures/api';
+
+test.beforeEach(async ({ page }) => {
+  await installApiMocks(page);
+});
+
+test('Tonight pick decisions are accessible, URL-backed, and request the selected mode', async ({
+  page,
+}) => {
+  await page.goto('/tonight?tab=picks');
+
+  const decision = page.getByRole('group', { name: 'Pick decision' });
+  const watchlist = decision.getByRole('link', { name: 'WATCHLIST FIT', exact: true });
+  const unseen = decision.getByRole('link', { name: 'UNSEEN BY ALL', exact: true });
+  const blindSpot = decision.getByRole('link', { name: 'ONE PERSON LOVES', exact: true });
+
+  await expect(decision).toBeVisible();
+  await expect(watchlist).toHaveAttribute('aria-current', 'true');
+  await expect(unseen).toBeVisible();
+  await expect(blindSpot).toBeVisible();
+
+  const unseenRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/watch-together' && url.searchParams.get('mode') === 'unseen_pick';
+  });
+  await unseen.click();
+  await unseenRequest;
+  await expect(page).toHaveURL(/(?:\?|&)mode=unseen_pick(?:&|$)/);
+  await expect(unseen).toHaveAttribute('aria-current', 'true');
+  await expect(page.getByText('Only films nobody in the room has watched.', { exact: false })).toBeVisible();
+
+  const blindSpotRequest = page.waitForRequest((request) => {
+    const url = new URL(request.url());
+    return url.pathname === '/api/watch-together'
+      && url.searchParams.get('mode') === 'collective_blind_spots';
+  });
+  await blindSpot.click();
+  await blindSpotRequest;
+  await expect(page).toHaveURL(/(?:\?|&)mode=collective_blind_spots(?:&|$)/);
+  await expect(blindSpot).toHaveAttribute('aria-current', 'true');
+  await expect(page.getByText('One person in the room liked it', { exact: false })).toBeVisible();
+
+  const dimensions = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(dimensions.scrollWidth).toBeLessThanOrEqual(dimensions.clientWidth);
+
+  await page.reload();
+  await expect(decision).toBeVisible();
+  await expect(blindSpot).toHaveAttribute('aria-current', 'true');
+});

--- a/frontend/src/app/(terminal)/tonight/page.tsx
+++ b/frontend/src/app/(terminal)/tonight/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 
@@ -11,7 +12,69 @@ import { useTerminalSelection } from '../../../hooks/useTerminalSelection';
 import { insightsApi } from '../../../services/api';
 import AvailabilityTab from '../../../views/tonight/AvailabilityTab';
 import ListsTab from '../../../views/tonight/ListsTab';
-import PicksTab from '../../../views/tonight/PicksTab';
+import PicksTab, { type TonightPickMode } from '../../../views/tonight/PicksTab';
+
+const PICK_MODES: ReadonlyArray<{
+  value: TonightPickMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: 'watchlist_overlap',
+    label: 'WATCHLIST FIT',
+    description: 'Rank everything queued by somebody in the room.',
+  },
+  {
+    value: 'unseen_pick',
+    label: 'UNSEEN BY ALL',
+    description: 'Only show films nobody selected has watched.',
+  },
+  {
+    value: 'collective_blind_spots',
+    label: 'ONE PERSON LOVES',
+    description: 'Start from a film one person loved and everyone else has yet to see.',
+  },
+];
+
+const PICK_MODE_VALUES = new Set<TonightPickMode>(PICK_MODES.map((option) => option.value));
+
+function PickModePicker({
+  value,
+  hrefFor,
+}: {
+  value: TonightPickMode;
+  hrefFor: (mode: TonightPickMode) => string;
+}) {
+  return (
+    <div role="group" aria-label="Pick decision" className="flex flex-wrap items-center gap-2">
+      <span className="text-t9 tracking-tab text-term-muted2">DECISION</span>
+      <div className="flex flex-wrap items-center gap-1">
+        {PICK_MODES.map((option) => {
+          const active = option.value === value;
+          return (
+            <Link
+              key={option.value}
+              href={hrefFor(option.value)}
+              scroll={false}
+              aria-current={active ? 'true' : undefined}
+              title={option.description}
+              className="rounded-[3px] border px-2 py-[3px] text-t10 no-underline hover:no-underline"
+              style={{
+                borderColor: active ? 'var(--accent)' : 'var(--rule)',
+                background: active
+                  ? 'color-mix(in srgb, var(--accent) 14%, transparent)'
+                  : 'transparent',
+                color: active ? 'var(--accent)' : 'var(--muted)',
+              }}
+            >
+              {option.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 function RegionPicker({
   value,
@@ -74,6 +137,10 @@ function TonightSection() {
     ...(validRequestedRegion ? [requestedRegion!] : []),
     ...available,
   ]));
+  const requestedMode = searchParams.get('mode')?.trim() as TonightPickMode | undefined;
+  const mode = requestedMode && PICK_MODE_VALUES.has(requestedMode)
+    ? requestedMode
+    : 'watchlist_overlap';
 
   const controls = (
     <SelectionBar
@@ -82,6 +149,12 @@ function TonightSection() {
       hrefFor={selection.toggleHref}
       isLocked={selection.isLockedByMinimum}
     >
+      {tab.id === 'picks' ? (
+        <PickModePicker
+          value={mode}
+          hrefFor={(next) => selection.paramHref('mode', next)}
+        />
+      ) : null}
       <RegionPicker
         value={region}
         regions={regionOptions}
@@ -97,6 +170,7 @@ function TonightSection() {
         <PicksTab
           profiles={selection.selected}
           region={region}
+          mode={mode}
           pick={searchParams.get('pick')}
           pickHref={(title) => selection.paramHref('pick', title)}
         />

--- a/frontend/src/components/terminal/SelectionBar.tsx
+++ b/frontend/src/components/terminal/SelectionBar.tsx
@@ -77,7 +77,11 @@ export default function SelectionBar({
           );
         })}
       </div>
-      {children ? <div className="ml-auto flex items-center gap-3">{children}</div> : null}
+      {children ? (
+        <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-3">
+          {children}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/views/tonight/PicksTab.tsx
+++ b/frontend/src/views/tonight/PicksTab.tsx
@@ -9,16 +9,100 @@ import Posters from '../../components/terminal/bodies/Posters';
 import Rows, { cell } from '../../components/terminal/bodies/Rows';
 import { panelState } from '../../components/terminal/states';
 import { sectionHref } from '../../components/terminal/sections';
-import { insightsApi, tonightApi } from '../../services/api';
+import {
+  insightsApi,
+  tonightApi,
+  type WatchTogetherCandidate,
+  type WatchTogetherMode,
+} from '../../services/api';
+
+export type TonightPickMode = Exclude<WatchTogetherMode, 'list_mission'>;
+
+const MODE_COPY: Record<
+  TonightPickMode,
+  { blurb: string; empty: { title: string; body: string } }
+> = {
+  watchlist_overlap: {
+    blurb:
+      'Ranked by fit across whoever is in the room. Want is how many have it queued; seen is how many have already watched it and are being asked to rewatch.',
+    empty: {
+      title: 'Nothing on the selected watchlists yet',
+      body: 'This ranks films somebody in the room has queued, seen or not. Nobody in the selection has a watchlist entry we hold, so there is nothing to rank.',
+    },
+  },
+  unseen_pick: {
+    blurb:
+      'Only films nobody in the room has watched. Selected watchlists supply intent; ratings from other accessible profiles can supply evidence that the film is worth the risk.',
+    empty: {
+      title: 'No unseen group pick found',
+      body: 'Nothing backed by the selected watchlists or accessible rating evidence is still unseen by everybody in the room.',
+    },
+  },
+  collective_blind_spots: {
+    blurb:
+      'One person in the room liked it or rated it at least four stars, and everybody else selected has yet to see it. A personal favourite becomes a group recommendation.',
+    empty: {
+      title: 'No one-person favourite to pass around',
+      body: 'No film is liked or rated at least four stars by exactly one person in the room while remaining unseen by everybody else selected.',
+    },
+  },
+};
+
+function decisionStats(
+  mode: TonightPickMode,
+  candidates: WatchTogetherCandidate[],
+  profileCount: number,
+) {
+  if (mode === 'unseen_pick') {
+    return [
+      {
+        big: candidates.filter((candidate) => candidate.on_watchlist_by.length > 0).length.toLocaleString(),
+        unit: 'ON A SELECTED WATCHLIST',
+      },
+      {
+        big: candidates.filter((candidate) => candidate.watched_by.length === 0).length.toLocaleString(),
+        unit: 'UNSEEN BY THE ROOM',
+      },
+    ];
+  }
+  if (mode === 'collective_blind_spots') {
+    return [
+      {
+        big: candidates.filter((candidate) => candidate.blind_spot_source).length.toLocaleString(),
+        unit: 'BACKED BY ONE PERSON',
+      },
+      {
+        big: candidates
+          .filter((candidate) => candidate.unseen_by.length === profileCount - 1)
+          .length.toLocaleString(),
+        unit: 'NEW TO EVERYONE ELSE',
+      },
+    ];
+  }
+  return [
+    {
+      big: candidates
+        .filter((candidate) => candidate.on_watchlist_by.length === profileCount)
+        .length.toLocaleString(),
+      unit: "ON EVERYONE'S WATCHLIST",
+    },
+    {
+      big: candidates.filter((candidate) => candidate.watched_by.length === 0).length.toLocaleString(),
+      unit: 'NOBODY HAS SEEN',
+    },
+  ];
+}
 
 export default function PicksTab({
   profiles,
   region,
+  mode,
   pick,
   pickHref,
 }: {
   profiles: string[];
   region: string;
+  mode: TonightPickMode;
   /** Which shortlist row the explanation panel is unpacking. */
   pick: string | null;
   pickHref: (title: string) => string;
@@ -26,9 +110,9 @@ export default function PicksTab({
   const ready = profiles.length >= 2;
 
   const shortlistQuery = useQuery({
-    queryKey: ['watch-together', profiles, region],
+    queryKey: ['watch-together', profiles, region, mode],
     queryFn: () =>
-      insightsApi.getWatchTogether(profiles, { mode: 'watchlist_overlap', region }),
+      insightsApi.getWatchTogether(profiles, { mode, region }),
     enabled: ready,
     staleTime: 60 * 1000,
     refetchOnWindowFocus: false,
@@ -44,6 +128,7 @@ export default function PicksTab({
 
   const candidates = shortlistQuery.data?.recommendations ?? [];
   const summary = shortlistQuery.data?.summary;
+  const modeCopy = MODE_COPY[mode];
   // The explanation unpacks whichever row was chosen, defaulting to the top.
   // Heading it "why this ranked first" for a row the reader clicked was the
   // old panel's one dishonest sentence.
@@ -64,7 +149,7 @@ export default function PicksTab({
         title="TONIGHT'S SHORTLIST"
         src="watchlist_items × profile_films × ratings"
         wide
-        blurb="Ranked by fit across whoever is in the room. Want is how many have it queued; seen is how many have already watched it and are being asked to rewatch."
+        blurb={modeCopy.blurb}
         // Counted from the rows actually rendered rather than from the
         // server's summary. A header claiming more candidates than the table
         // below it holds is the one thing this panel must never do, and
@@ -77,18 +162,7 @@ export default function PicksTab({
                   unit: 'RANKED CANDIDATES',
                   tone: 'var(--accent)',
                 },
-                {
-                  big: candidates
-                    .filter((candidate) => candidate.on_watchlist_by.length === profiles.length)
-                    .length.toLocaleString(),
-                  unit: "ON EVERYONE'S WATCHLIST",
-                },
-                {
-                  big: candidates
-                    .filter((candidate) => candidate.watched_by.length === 0)
-                    .length.toLocaleString(),
-                  unit: 'NOBODY HAS SEEN',
-                },
+                ...decisionStats(mode, candidates, profiles.length),
                 {
                   // Subscription only, matching what Tonight › Leaving soon
                   // counts. The payload carries rent and buy offers too, and
@@ -127,14 +201,8 @@ export default function PicksTab({
           onRetry: () => shortlistQuery.refetch(),
           empty: ready
             ? {
-                title: 'Nothing on the selected watchlists yet',
-                // This mode ranks whatever is queued -- it never filters to
-                // films nobody has seen, and the region only decides where a
-                // film can be watched, not whether it is listed. Saying
-                // otherwise sent people to change a control that could not
-                // help.
-                body: 'This ranks films somebody in the room has queued, seen or not. Nobody in the selection has a watchlist entry we hold, so there is nothing to rank.',
-                cta: { label: 'CHECK WATCHLIST COVERAGE', href: sectionHref('data', 'missing') },
+                ...modeCopy.empty,
+                cta: { label: 'CHECK INPUT COVERAGE', href: sectionHref('data', 'missing') },
               }
             : needsTwo,
         }) ?? (


### PR DESCRIPTION
## Summary

- add a URL-backed, accessible decision selector to Tonight picks
- expose the existing Watchlist fit, Unseen by all, and One person loves modes
- adapt shortlist copy and stats per mode while keeping controls responsive on mobile

## Why

The backend and frontend API contract already supported these decision modes, but the redesigned Picks tab hardcoded watchlist_overlap, leaving the other decision paths inaccessible.

## Validation

- npm ci with Node 24.18.1 (0 audit vulnerabilities)
- npm run lint -- --max-warnings=0
- npm run typecheck
- npm run build
- CI=true PLAYWRIGHT_REUSE_BUILD=1 npm run test:e2e -- e2e/tonight-decision-modes.spec.ts (2 passed: desktop and mobile)